### PR TITLE
[_] fix: parameter for findByFileIdAndUser

### DIFF
--- a/src/modules/share/share.repository.ts
+++ b/src/modules/share/share.repository.ts
@@ -96,7 +96,7 @@ export interface ShareRepository {
   delete(share: Share): Promise<void>;
   create(share: Share): Promise<void>;
   findByFileIdAndUser(
-    fileId: FileAttributes['id'],
+    fileId: FileAttributes['fileId'],
     userId: UserAttributes['id'],
   ): Promise<Share | null>;
   findByFolderIdAndUser(
@@ -126,7 +126,7 @@ export class SequelizeShareRepository implements ShareRepository {
   }
 
   async findByFileIdAndUser(
-    fileId: FileAttributes['id'],
+    fileId: FileAttributes['fileId'],
     userId: UserAttributes['id'],
   ): Promise<Share | null> {
     const share = await this.shareModel.findOne({

--- a/src/modules/share/share.usecase.ts
+++ b/src/modules/share/share.usecase.ts
@@ -115,7 +115,7 @@ export class ShareUseCases {
       throw new NotFoundException(`file with id ${fileId} not found`);
     }
     const share = await this.shareRepository.findByFileIdAndUser(
-      file.id,
+      file.fileId,
       user.id,
     );
     if (share) {


### PR DESCRIPTION
The method `findByFileIdAndUser` will fail to find shares. All the method is needed to understand the issue, so I copied it here:
``` ts
async findByFileIdAndUser(
    fileId: FileAttributes['id'],
    userId: UserAttributes['id'],
  ): Promise<Share | null> {
    const share = await this.shareModel.findOne({
      where: { fileId, userId },
      include: [this.fileModel, this.userModel],
    });
    return share ? this.toDomain(share) : null;
  }
```
On the where object we are passing the value of the file id as the fileId, they are not only of different type, they are different properties of File.

Note: was not sure if this was the correct fix, but I thought it was the easyest way to illustrate it