### PR TITLE
Fix/clear trash on tras uses case

### DIFF
--- a/src/externals/bridge/bridge.service.ts
+++ b/src/externals/bridge/bridge.service.ts
@@ -17,7 +17,7 @@ export class BridgeService {
   ) {}
 
   private authorizationHeaders(user: string, password: string | number) {
-    const hashedPassword = this.cryptoService.hashSha256(String(password));
+    const hashedPassword = this.cryptoService.hashSha256(password.toString());
     const credential = Buffer.from(`${user}:${hashedPassword}`).toString(
       'base64',
     );
@@ -35,15 +35,12 @@ export class BridgeService {
     const params = {
       headers: {
         'Content-Type': 'application/json',
-        ...this.authorizationHeaders(user.bridgeUser, user.id),
+        ...this.authorizationHeaders(user.bridgeUser, user.userId),
       },
     };
 
     Logger.log(
-      '[INXT removeFile]: User: %s, Bucket: %s, File: %s',
-      user.bridgeUser,
-      bucket,
-      bucketEntry,
+      `[INXT removeFile]: User: ${user.bridgeUser}, Bucket: ${bucket}, File: ${bucketEntry}`,
     );
 
     await this.httpClient.delete(

--- a/src/modules/file/file.module.ts
+++ b/src/modules/file/file.module.ts
@@ -4,11 +4,13 @@ import { SequelizeFileRepository } from './file.repository';
 import { FileUseCases } from './file.usecase';
 import { FileModel } from './file.repository';
 import { ShareModel } from '../share/share.repository';
+import { ShareModule } from '../share/share.module';
+import { FolderModule } from '../folder/folder.module';
 
 @Module({
   imports: [
-    SequelizeModule.forFeature([FileModel]),
-    forwardRef(() => ShareModel),
+    SequelizeModule.forFeature([FileModel, ShareModel]),
+    forwardRef(() => ShareModule),
   ],
   controllers: [],
   providers: [SequelizeFileRepository, FileUseCases],

--- a/src/modules/file/file.module.ts
+++ b/src/modules/file/file.module.ts
@@ -5,12 +5,13 @@ import { FileUseCases } from './file.usecase';
 import { FileModel } from './file.repository';
 import { ShareModel } from '../share/share.repository';
 import { ShareModule } from '../share/share.module';
-import { FolderModule } from '../folder/folder.module';
+import { BridgeModule } from '../../externals/bridge/bridge.module';
 
 @Module({
   imports: [
     SequelizeModule.forFeature([FileModel, ShareModel]),
     forwardRef(() => ShareModule),
+    BridgeModule,
   ],
   controllers: [],
   providers: [SequelizeFileRepository, FileUseCases],

--- a/src/modules/file/file.module.ts
+++ b/src/modules/file/file.module.ts
@@ -1,11 +1,15 @@
-import { Module } from '@nestjs/common';
+import { Module, forwardRef } from '@nestjs/common';
 import { SequelizeModule } from '@nestjs/sequelize';
 import { SequelizeFileRepository } from './file.repository';
 import { FileUseCases } from './file.usecase';
 import { FileModel } from './file.repository';
+import { ShareModel } from '../share/share.repository';
 
 @Module({
-  imports: [SequelizeModule.forFeature([FileModel])],
+  imports: [
+    SequelizeModule.forFeature([FileModel]),
+    forwardRef(() => ShareModel),
+  ],
   controllers: [],
   providers: [SequelizeFileRepository, FileUseCases],
   exports: [FileUseCases],

--- a/src/modules/file/file.usecase.spec.ts
+++ b/src/modules/file/file.usecase.spec.ts
@@ -227,27 +227,6 @@ describe('FileUseCases', () => {
       expect(shareUseCases.deleteFileShare).toHaveBeenCalledTimes(1);
     });
 
-    it('should be able to delete a trashed file when file share does not exist', async () => {
-      const fileId = '6f10f732-59b1-525c-a2d0-ff538f687903';
-      const file = {
-        id: 1,
-        fileId,
-        deleted: true,
-      } as File;
-
-      jest
-        .spyOn(fileRepository, 'deleteByFileId')
-        .mockImplementationOnce(() => Promise.resolve());
-
-      jest
-        .spyOn(shareUseCases, 'deleteFileShare')
-        .mockImplementationOnce(() => Promise.reject());
-
-      await service.deleteFilePermanently(file, userMock);
-
-      expect(fileRepository.deleteByFileId).toHaveBeenCalledWith(fileId);
-    });
-
     it('should fail when the folder trying to delete has not been trashed', async () => {
       const fileId = 2618494108;
       const file = File.build({

--- a/src/modules/file/file.usecase.spec.ts
+++ b/src/modules/file/file.usecase.spec.ts
@@ -181,8 +181,9 @@ describe('FileUseCases', () => {
   });
 
   describe('delete file use case', () => {
+    const incrementalUserId = 15494;
     const userMock = User.build({
-      id: 2,
+      id: incrementalUserId,
       userId: 'userId',
       name: 'User Owner',
       lastname: 'Lastname',
@@ -216,7 +217,7 @@ describe('FileUseCases', () => {
         id: 1,
         fileId,
         deleted: true,
-        user: userMock,
+        userId: incrementalUserId,
       } as File;
 
       jest
@@ -250,11 +251,10 @@ describe('FileUseCases', () => {
         encryptVersion: '',
         deleted: false,
         deletedAt: new Date(),
-        userId: 1,
+        userId: incrementalUserId,
         modificationTime: new Date(),
         createdAt: new Date(),
         updatedAt: new Date(),
-        user: userMock,
       });
 
       jest.spyOn(fileRepository, 'deleteByFileId');
@@ -269,9 +269,7 @@ describe('FileUseCases', () => {
 
     it('should fail when the folder trying to delete is not owned by the user', async () => {
       const file = {
-        user: {
-          id: userMock.id + 1,
-        },
+        userId: incrementalUserId + 1,
         deleted: true,
       } as File;
 
@@ -300,11 +298,10 @@ describe('FileUseCases', () => {
         encryptVersion: '',
         deleted: true,
         deletedAt: new Date(),
-        userId: 1,
+        userId: incrementalUserId,
         modificationTime: new Date(),
         createdAt: new Date(),
         updatedAt: new Date(),
-        user: userMock,
       });
 
       const errorReason = new Error('reason');
@@ -338,7 +335,7 @@ describe('FileUseCases', () => {
         encryptVersion: '',
         deleted: true,
         deletedAt: new Date(),
-        userId: 1,
+        userId: incrementalUserId,
         modificationTime: new Date(),
         createdAt: new Date(),
         updatedAt: new Date(),

--- a/src/modules/file/file.usecase.spec.ts
+++ b/src/modules/file/file.usecase.spec.ts
@@ -14,6 +14,7 @@ import { FolderUseCases } from '../folder/folder.usecase';
 import { SequelizeShareRepository, ShareModel } from '../share/share.repository';
 import { FolderModel, SequelizeFolderRepository } from '../folder/folder.repository';
 import { FileModule } from './file.module';
+import { SequelizeUserRepository, UserModel } from '../user/user.repository';
 
 const fileId = '6295c99a241bb000083f1c6a';
 const userId = 1;
@@ -35,6 +36,17 @@ describe('FileUseCases', () => {
         SequelizeShareRepository,
         {
           provide: getModelToken(ShareModel),
+          useValue: jest.fn(),
+        },
+        FolderUseCases,
+        SequelizeFolderRepository,
+        {
+          provide: getModelToken(FolderModel),
+          useValue: jest.fn(),
+        },
+        SequelizeUserRepository,
+        {
+          provide: getModelToken(UserModel),
           useValue: jest.fn(),
         },
       ],

--- a/src/modules/file/file.usecase.spec.ts
+++ b/src/modules/file/file.usecase.spec.ts
@@ -2,6 +2,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { FileUseCases } from './file.usecase';
 import { SequelizeFileRepository, FileRepository } from './file.repository';
 import {
+  ForbiddenException,
   NotFoundException,
   UnprocessableEntityException,
 } from '@nestjs/common';
@@ -20,7 +21,8 @@ import {
   SequelizeFolderRepository,
 } from '../folder/folder.repository';
 import { SequelizeUserRepository, UserModel } from '../user/user.repository';
-
+import { BridgeModule } from '../../externals/bridge/bridge.module';
+import { BridgeService } from '../../externals/bridge/bridge.service';
 const fileId = '6295c99a241bb000083f1c6a';
 const userId = 1;
 const folderId = 4;
@@ -28,9 +30,11 @@ describe('FileUseCases', () => {
   let service: FileUseCases;
   let fileRepository: FileRepository;
   let shareUseCases: ShareUseCases;
+  let bridgeService: BridgeService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
+      imports: [BridgeModule],
       providers: [
         FileUseCases,
         SequelizeFileRepository,
@@ -61,6 +65,7 @@ describe('FileUseCases', () => {
     service = module.get<FileUseCases>(FileUseCases);
     fileRepository = module.get<FileRepository>(SequelizeFileRepository);
     shareUseCases = module.get<ShareUseCases>(ShareUseCases);
+    bridgeService = module.get<BridgeService>(BridgeService);
   });
 
   afterEach(() => {
@@ -211,6 +216,7 @@ describe('FileUseCases', () => {
         id: 1,
         fileId,
         deleted: true,
+        user: userMock,
       } as File;
 
       jest
@@ -219,6 +225,10 @@ describe('FileUseCases', () => {
 
       jest
         .spyOn(shareUseCases, 'deleteFileShare')
+        .mockImplementationOnce(() => Promise.resolve());
+
+      jest
+        .spyOn(bridgeService, 'deleteFile')
         .mockImplementationOnce(() => Promise.resolve());
 
       await service.deleteFilePermanently(file, userMock);
@@ -244,18 +254,114 @@ describe('FileUseCases', () => {
         modificationTime: new Date(),
         createdAt: new Date(),
         updatedAt: new Date(),
+        user: userMock,
       });
 
-      jest
-        .spyOn(fileRepository, 'deleteByFileId')
-        .mockImplementationOnce(() => Promise.resolve());
+      jest.spyOn(fileRepository, 'deleteByFileId');
 
       expect(service.deleteFilePermanently(file, userMock)).rejects.toThrow(
         new UnprocessableEntityException(
           `file with id ${fileId} cannot be permanently deleted`,
         ),
       );
-      expect(fileRepository.deleteByFileId).toHaveBeenCalledTimes(0);
+      expect(fileRepository.deleteByFileId).not.toHaveBeenCalled();
+    });
+
+    it('should fail when the folder trying to delete is not owned by the user', async () => {
+      const file = {
+        user: {
+          id: userMock.id + 1,
+        },
+        deleted: true,
+      } as File;
+
+      jest.spyOn(shareUseCases, 'deleteFileShare');
+      jest.spyOn(bridgeService, 'deleteFile');
+      jest.spyOn(fileRepository, 'deleteByFileId');
+
+      expect(service.deleteFilePermanently(file, userMock)).rejects.toThrow(
+        new ForbiddenException(`You are not owner of this share`),
+      );
+      expect(shareUseCases.deleteFileShare).not.toHaveBeenCalled();
+      expect(bridgeService.deleteFile).not.toHaveBeenCalled();
+      expect(fileRepository.deleteByFileId).not.toHaveBeenCalled();
+    });
+
+    it('should not delete a file from storage if delete shares fails', async () => {
+      const fileId = 2618494108;
+      const file = File.build({
+        id: fileId,
+        fileId: '6f10f732-59b1-525c-a2d0-ff538f687903',
+        name: '',
+        type: '',
+        size: null,
+        bucket: '',
+        folderId: 4,
+        encryptVersion: '',
+        deleted: true,
+        deletedAt: new Date(),
+        userId: 1,
+        modificationTime: new Date(),
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        user: userMock,
+      });
+
+      const errorReason = new Error('reason');
+
+      jest
+        .spyOn(shareUseCases, 'deleteFileShare')
+        .mockImplementationOnce(() => Promise.reject(errorReason));
+      jest
+        .spyOn(fileRepository, 'deleteByFileId')
+        .mockImplementationOnce(() => Promise.resolve());
+      jest.spyOn(bridgeService, 'deleteFile');
+
+      await service.deleteFilePermanently(file, userMock).catch((err) => {
+        expect(err).toBe(errorReason);
+      });
+
+      expect(bridgeService.deleteFile).not.toHaveBeenCalled();
+      expect(fileRepository.deleteByFileId).not.toHaveBeenCalled();
+    });
+
+    it('should not delete a file from databse if could not be deleted from storage', async () => {
+      const fileId = 2618494108;
+      const file = File.build({
+        id: fileId,
+        fileId: '6f10f732-59b1-525c-a2d0-ff538f687903',
+        name: '',
+        type: '',
+        size: null,
+        bucket: '',
+        folderId: 4,
+        encryptVersion: '',
+        deleted: true,
+        deletedAt: new Date(),
+        userId: 1,
+        modificationTime: new Date(),
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        user: userMock,
+      });
+
+      const errorReason = new Error('reason');
+
+      jest
+        .spyOn(fileRepository, 'deleteByFileId')
+        .mockImplementationOnce(() => Promise.resolve());
+      jest
+        .spyOn(shareUseCases, 'deleteFileShare')
+        .mockImplementationOnce(() => Promise.resolve());
+      jest
+        .spyOn(bridgeService, 'deleteFile')
+        .mockImplementationOnce(() => Promise.reject(errorReason));
+
+      await service.deleteFilePermanently(file, userMock).catch((err) => {
+        expect(err).toBe(errorReason);
+      });
+
+      expect(fileRepository.deleteByFileId).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/modules/file/file.usecase.ts
+++ b/src/modules/file/file.usecase.ts
@@ -1,6 +1,11 @@
 import { Environment } from '@internxt/inxt-js';
 import { aes } from '@internxt/lib';
-import { Injectable, UnprocessableEntityException } from '@nestjs/common';
+import {
+  forwardRef,
+  Inject,
+  Injectable,
+  UnprocessableEntityException,
+} from '@nestjs/common';
 import { FolderAttributes } from '../folder/folder.domain';
 import { Share } from '../share/share.domain';
 import { ShareUseCases } from '../share/share.usecase';
@@ -11,6 +16,7 @@ import { SequelizeFileRepository } from './file.repository';
 export class FileUseCases {
   constructor(
     private fileRepository: SequelizeFileRepository,
+    @Inject(forwardRef(() => ShareUseCases))
     private shareUseCases: ShareUseCases,
   ) {}
 

--- a/src/modules/file/file.usecase.ts
+++ b/src/modules/file/file.usecase.ts
@@ -90,7 +90,7 @@ export class FileUseCases {
   }
 
   async deleteFilePermanently(file: File, user: User): Promise<void> {
-    if (file.user.id !== user.id) {
+    if (file.userId !== user.id) {
       Logger.error(
         `User with id: ${user.id} tryed to delete a file that does not own.`,
       );

--- a/src/modules/file/file.usecase.ts
+++ b/src/modules/file/file.usecase.ts
@@ -92,7 +92,7 @@ export class FileUseCases {
       );
     }
 
-    await this.shareUseCases.deleteShareById(file.id, user);
+    await this.shareUseCases.deleteFileShare(file.id, user);
     // TODO: delete file from bridge
     await this.fileRepository.deleteByFileId(file.fileId);
   }

--- a/src/modules/folder/folder.module.ts
+++ b/src/modules/folder/folder.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { Module, forwardRef } from '@nestjs/common';
 import { SequelizeModule } from '@nestjs/sequelize';
 import { SequelizeFolderRepository } from './folder.repository';
 import { FolderUseCases } from './folder.usecase';
@@ -6,7 +6,10 @@ import { FolderModel } from './folder.repository';
 import { FileModule } from '../file/file.module';
 
 @Module({
-  imports: [SequelizeModule.forFeature([FolderModel]), FileModule],
+  imports: [
+    SequelizeModule.forFeature([FolderModel]),
+    forwardRef(() => FileModule),
+  ],
   controllers: [],
   providers: [SequelizeFolderRepository, FolderUseCases],
   exports: [FolderUseCases],

--- a/src/modules/folder/folder.repository.ts
+++ b/src/modules/folder/folder.repository.ts
@@ -86,6 +86,7 @@ export interface FolderRepository {
     update: Partial<Folder>,
   ): Promise<void>;
   deleteById(folderId: FolderAttributes['id']): Promise<void>;
+  clearOrphansFolders(userId: FolderAttributes['userId']): Promise<number>;
 }
 @Injectable()
 export class SequelizeFolderRepository implements FolderRepository {
@@ -173,6 +174,19 @@ export class SequelizeFolderRepository implements FolderRepository {
         id: { [Op.eq]: folderId },
       },
     });
+  }
+
+  async clearOrphansFolders(
+    userId: FolderAttributes['userId'],
+  ): Promise<number> {
+    const clear = await this.folderModel.sequelize.query(
+      'CALL clear_orphan_folders_by_user (:userId, :output)',
+      {
+        replacements: { userId, output: null },
+      },
+    );
+
+    return (clear[0] as any).total_left;
   }
 
   private toDomain(model: FolderModel): Folder {

--- a/src/modules/folder/folder.usecase.spec.ts
+++ b/src/modules/folder/folder.usecase.spec.ts
@@ -19,6 +19,7 @@ import {
 } from '../share/share.repository';
 import { ShareUseCases } from '../share/share.usecase';
 import { SequelizeUserRepository, UserModel } from '../user/user.repository';
+import { BridgeModule } from '../../externals/bridge/bridge.module';
 
 const folderId = 4;
 const userId = 1;
@@ -27,6 +28,7 @@ describe('FolderUseCases', () => {
   let folderRepository: FolderRepository;
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
+      imports: [BridgeModule],
       providers: [
         FolderUseCases,
         FileUseCases,

--- a/src/modules/folder/folder.usecase.ts
+++ b/src/modules/folder/folder.usecase.ts
@@ -112,7 +112,7 @@ export class FolderUseCases {
     );
 
     if (remainingFolders > 0) {
-      this.deleteOrphansFolders(userId);
+      await this.deleteOrphansFolders(userId);
     }
   }
 }

--- a/src/modules/folder/folder.usecase.ts
+++ b/src/modules/folder/folder.usecase.ts
@@ -4,6 +4,7 @@ import {
   UnprocessableEntityException,
 } from '@nestjs/common';
 import { FileUseCases } from '../file/file.usecase';
+import { UserAttributes } from '../user/user.domain';
 import { Folder, FolderAttributes } from './folder.domain';
 import { SequelizeFolderRepository } from './folder.repository';
 
@@ -100,5 +101,15 @@ export class FolderUseCases {
     }
 
     await this.folderRepository.deleteById(folder.id);
+  }
+
+  async deleteOrphansFolders(userId: UserAttributes['id']): Promise<void> {
+    const remainingFolders = await this.folderRepository.clearOrphansFolders(
+      userId,
+    );
+
+    if (remainingFolders > 0) {
+      this.deleteOrphansFolders(userId);
+    }
   }
 }

--- a/src/modules/folder/folder.usecase.ts
+++ b/src/modules/folder/folder.usecase.ts
@@ -1,4 +1,6 @@
 import {
+  forwardRef,
+  Inject,
   Injectable,
   NotFoundException,
   UnprocessableEntityException,

--- a/src/modules/folder/folder.usecase.ts
+++ b/src/modules/folder/folder.usecase.ts
@@ -14,6 +14,7 @@ import { SequelizeFolderRepository } from './folder.repository';
 export class FolderUseCases {
   constructor(
     private folderRepository: SequelizeFolderRepository,
+    @Inject(forwardRef(() => FileUseCases))
     private fileUseCases: FileUseCases,
   ) {}
 

--- a/src/modules/share/share.module.ts
+++ b/src/modules/share/share.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { Module, forwardRef } from '@nestjs/common';
 import { SequelizeModule } from '@nestjs/sequelize';
 import { NotificationModule } from '../../externals/notifications/notifications.module';
 import { FileModule } from '../file/file.module';
@@ -14,7 +14,7 @@ import { ShareUseCases } from './share.usecase';
 @Module({
   imports: [
     SequelizeModule.forFeature([ShareModel, FileModel, FolderModel, UserModel]),
-    FileModule,
+    forwardRef(() => FileModule),
     FolderModule,
     UserModule,
     NotificationModule,

--- a/src/modules/share/share.module.ts
+++ b/src/modules/share/share.module.ts
@@ -15,11 +15,12 @@ import { ShareUseCases } from './share.usecase';
   imports: [
     SequelizeModule.forFeature([ShareModel, FileModel, FolderModel, UserModel]),
     forwardRef(() => FileModule),
-    FolderModule,
+    forwardRef(() => FolderModule),
     UserModule,
     NotificationModule,
   ],
   controllers: [ShareController],
   providers: [SequelizeShareRepository, ShareUseCases],
+  exports: [ShareUseCases],
 })
 export class ShareModule {}

--- a/src/modules/share/share.usecase.spec.ts
+++ b/src/modules/share/share.usecase.spec.ts
@@ -2,6 +2,7 @@ import { ForbiddenException } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { getModelToken } from '@nestjs/sequelize';
 import { Test, TestingModule } from '@nestjs/testing';
+import { BridgeModule } from '../../externals/bridge/bridge.module';
 import { File } from '../file/file.domain';
 import { FileModel, SequelizeFileRepository } from '../file/file.repository';
 import { FileUseCases } from '../file/file.usecase';
@@ -146,6 +147,7 @@ describe('Share Use Cases', () => {
   });
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
+      imports: [BridgeModule],
       providers: [
         ShareUseCases,
         FolderUseCases,

--- a/src/modules/share/share.usecase.spec.ts
+++ b/src/modules/share/share.usecase.spec.ts
@@ -1,3 +1,4 @@
+import { ForbiddenException } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { getModelToken } from '@nestjs/sequelize';
 import { Test, TestingModule } from '@nestjs/testing';
@@ -477,6 +478,47 @@ describe('Share Use Cases', () => {
         },
         created: true,
       });
+    });
+  });
+
+  describe('delete share by fileId', () => {
+    it('should delete the share if its from the user', async () => {
+      jest.spyOn(shareRepository, 'delete').mockResolvedValueOnce();
+      jest
+        .spyOn(shareRepository, 'findByFileIdAndUser')
+        .mockResolvedValueOnce({ user: { id: userMock.id } } as Share);
+
+      await service.deleteFileShare(885045478, userMock);
+
+      expect(shareRepository.findByFileIdAndUser).toBeCalled();
+      expect(shareRepository.delete).toBeCalled();
+    });
+
+    it('should not fail if there is no share its not from the user', async () => {
+      jest.spyOn(shareRepository, 'delete');
+      jest
+        .spyOn(shareRepository, 'findByFileIdAndUser')
+        .mockResolvedValueOnce({ user: { id: userMock.id + 1 } } as Share);
+
+      await service.deleteFileShare(885045478, userMock).catch((error) => {
+        expect(error).toBeInstanceOf(ForbiddenException);
+        expect(error.message).toBe(`You are not owner of this share`);
+      });
+
+      expect(shareRepository.findByFileIdAndUser).toBeCalled();
+      expect(shareRepository.delete).toBeCalledTimes(0);
+    });
+
+    it('should not fail if there is no share for the file', async () => {
+      jest.spyOn(shareRepository, 'delete');
+      jest
+        .spyOn(shareRepository, 'findByFileIdAndUser')
+        .mockResolvedValueOnce(null);
+
+      await service.deleteFileShare(885045478, userMock);
+
+      expect(shareRepository.findByFileIdAndUser).toBeCalled();
+      expect(shareRepository.delete).toBeCalledTimes(0);
     });
   });
 });

--- a/src/modules/share/share.usecase.ts
+++ b/src/modules/share/share.usecase.ts
@@ -190,6 +190,10 @@ export class ShareUseCases {
       user.id,
     );
 
+    if (!share) {
+      return;
+    }
+
     if (share.user.id !== user.id) {
       throw new ForbiddenException(`You are not owner of this share`);
     }

--- a/src/modules/share/share.usecase.ts
+++ b/src/modules/share/share.usecase.ts
@@ -4,7 +4,6 @@ import {
   Inject,
   Injectable,
   NotFoundException,
-  UnauthorizedException,
 } from '@nestjs/common';
 import { FileUseCases } from '../file/file.usecase';
 import { User } from '../user/user.domain';

--- a/src/modules/share/share.usecase.ts
+++ b/src/modules/share/share.usecase.ts
@@ -1,5 +1,7 @@
 import {
   ForbiddenException,
+  forwardRef,
+  Inject,
   Injectable,
   NotFoundException,
   UnauthorizedException,
@@ -17,7 +19,9 @@ import { UpdateShareDto } from './dto/update-share.dto';
 export class ShareUseCases {
   constructor(
     private shareRepository: SequelizeShareRepository,
+    @Inject(forwardRef(() => FileUseCases))
     private fileUseCases: FileUseCases,
+    @Inject(forwardRef(() => FolderUseCases))
     private folderUseCases: FolderUseCases,
   ) {}
 

--- a/src/modules/share/share.usecase.ts
+++ b/src/modules/share/share.usecase.ts
@@ -180,4 +180,17 @@ export class ShareUseCases {
 
     return { item: shareCreated, created: true };
   }
+
+  async deleteFileShare(fileId: number, user: User): Promise<void> {
+    const share = await this.shareRepository.findByFileIdAndUser(
+      fileId,
+      user.id,
+    );
+
+    if (share.user.id !== user.id) {
+      throw new ForbiddenException(`You are not owner of this share`);
+    }
+
+    return this.shareRepository.delete(share);
+  }
 }

--- a/src/modules/trash/trash.controller.ts
+++ b/src/modules/trash/trash.controller.ts
@@ -97,13 +97,11 @@ export class TrashController {
   }
 
   @Delete('/all')
-  @HttpCode(204)
+  @HttpCode(202)
   @ApiOperation({
     summary: "Deletes all items from user's trash",
   })
-  async clearTrash(@UserDecorator() user: User) {
-    await this.trashUseCases.clearTrash(user);
-
-    return;
+  clearTrash(@UserDecorator() user: User) {
+    this.trashUseCases.clearTrash(user);
   }
 }

--- a/src/modules/trash/trash.controller.ts
+++ b/src/modules/trash/trash.controller.ts
@@ -22,8 +22,7 @@ import { UserUseCases } from '../user/user.usecase';
 import { ItemsToTrashEvent } from '../../externals/notifications/events/items-to-trash.event';
 import { NotificationService } from '../../externals/notifications/notification.service';
 import { User } from '../user/user.domain';
-import { Folder } from '../folder/folder.domain';
-import { File } from '../file/file.domain';
+import { TrashUseCases } from './trash.usecase';
 @ApiTags('Trash')
 @Controller('storage/trash')
 export class TrashController {
@@ -32,6 +31,7 @@ export class TrashController {
     private folderUseCases: FolderUseCases,
     private userUseCases: UserUseCases,
     private notificationService: NotificationService,
+    private trashUseCases: TrashUseCases,
   ) {}
 
   @Get('/')
@@ -102,21 +102,7 @@ export class TrashController {
     summary: "Deletes all items from user's trash",
   })
   async clearTrash(@UserDecorator() user: User) {
-    const { rootFolderId: folderId, id: userId } = user;
-    const deleted = true;
-
-    await Promise.all([
-      await this.fileUseCases
-        .getByFolderAndUser(folderId, userId, deleted)
-        .then((files: Array<File>) =>
-          files.map(this.fileUseCases.deleteFilePermanently),
-        ),
-      await this.folderUseCases
-        .getChildrenFoldersToUser(folderId, userId, deleted)
-        .then((folders: Array<Folder>) =>
-          folders.map(this.folderUseCases.deleteFolderPermanently),
-        ),
-    ]);
+    await this.trashUseCases.clearTrash(user);
 
     return;
   }

--- a/src/modules/trash/trash.module.ts
+++ b/src/modules/trash/trash.module.ts
@@ -4,10 +4,11 @@ import { FolderModule } from '../folder/folder.module';
 import { NotificationModule } from '../../externals/notifications/notifications.module';
 import { UserModule } from '../user/user.module';
 import { TrashController } from './trash.controller';
+import { TrashUseCases } from './trash.usecase';
 
 @Module({
   imports: [FileModule, FolderModule, NotificationModule, UserModule],
   controllers: [TrashController],
-  providers: [Logger],
+  providers: [Logger, TrashUseCases],
 })
 export class TrashModule {}

--- a/src/modules/trash/trash.module.ts
+++ b/src/modules/trash/trash.module.ts
@@ -1,13 +1,25 @@
-import { Logger, Module } from '@nestjs/common';
+import { Logger, Module, forwardRef } from '@nestjs/common';
+import { SequelizeModule } from '@nestjs/sequelize';
 import { FileModule } from '../file/file.module';
 import { FolderModule } from '../folder/folder.module';
 import { NotificationModule } from '../../externals/notifications/notifications.module';
 import { UserModule } from '../user/user.module';
 import { TrashController } from './trash.controller';
 import { TrashUseCases } from './trash.usecase';
+import { ShareModule } from '../share/share.module';
+import { FileModel } from '../file/file.repository';
+import { ShareModel } from '../share/share.repository';
 
 @Module({
-  imports: [FileModule, FolderModule, NotificationModule, UserModule],
+  imports: [
+    SequelizeModule.forFeature([FileModel, ShareModel]),
+    forwardRef(() => FileModule),
+    forwardRef(() => ShareModule),
+    FolderModule,
+    NotificationModule,
+    UserModule,
+    ShareModule,
+  ],
   controllers: [TrashController],
   providers: [Logger, TrashUseCases],
 })

--- a/src/modules/trash/trash.usecase.spec.ts
+++ b/src/modules/trash/trash.usecase.spec.ts
@@ -1,0 +1,256 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { Sequelize } from 'sequelize-typescript';
+import { TrashUseCases } from './trash.usecase';
+import { FileModel, SequelizeFileRepository } from '../file/file.repository';
+import { File } from '../file/file.domain';
+import {
+  FolderModel,
+  SequelizeFolderRepository,
+} from '../folder/folder.repository';
+import { getModelToken } from '@nestjs/sequelize';
+import { User } from '../user/user.domain';
+import { UserModel } from '../user/user.repository';
+import { Folder } from '../folder/folder.domain';
+import { FileUseCases } from '../file/file.usecase';
+import { FolderUseCases } from '../folder/folder.usecase';
+import { ShareUseCases } from '../share/share.usecase';
+import { SequelizeShareRepository } from '../share/share.repository';
+import { FileModule } from '../file/file.module';
+import { FolderModule } from '../folder/folder.module';
+import { UserModule } from '../user/user.module';
+
+describe('Trash Use Cases', () => {
+  let service: TrashUseCases,
+    fileUseCases: FileUseCases,
+    folderUseCases: FolderUseCases;
+  const userMock = User.build({
+    id: 2,
+    userId: 'userId',
+    name: 'User Owner',
+    lastname: 'Lastname',
+    email: 'fake@internxt.com',
+    username: 'fake',
+    bridgeUser: null,
+    rootFolderId: 1,
+    errorLoginCount: 0,
+    isEmailActivitySended: 1,
+    referralCode: null,
+    referrer: null,
+    syncDate: new Date(),
+    uuid: 'uuid',
+    lastResend: new Date(),
+    credit: null,
+    welcomePack: true,
+    registerCompleted: true,
+    backupsBucket: 'bucket',
+    sharedWorkspace: true,
+    avatar: 'avatar',
+    password: '',
+    mnemonic: '',
+    hKey: undefined,
+    secret_2FA: '',
+    tempKey: '',
+  });
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      imports: [FileModule, FolderModule, UserModule],
+      providers: [
+        TrashUseCases,
+        FileUseCases,
+        FolderUseCases,
+        SequelizeFileRepository,
+        SequelizeFolderRepository,
+        ShareUseCases,
+        SequelizeShareRepository,
+        {
+          provide: Sequelize,
+          useValue: jest.fn(),
+        },
+        {
+          provide: getModelToken(FileModel),
+          useValue: jest.fn(),
+        },
+        {
+          provide: getModelToken(FolderModel),
+          useValue: jest.fn(),
+        },
+        {
+          provide: getModelToken(UserModel),
+          useValue: jest.fn(),
+        },
+      ],
+    }).compile();
+
+    service = module.get<TrashUseCases>(TrashUseCases);
+    fileUseCases = module.get<FileUseCases>(FileUseCases);
+    folderUseCases = module.get<FolderUseCases>(FolderUseCases);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('clear trash', () => {
+    it('should delete orphaned folders', async () => {
+      const folder = Folder.build({
+        id: 2725517497,
+        parentId: 3388762609,
+        name: 'name',
+        bucket: 'bucket',
+        userId: 1,
+        encryptVersion: '2',
+        deleted: true,
+        deletedAt: new Date(),
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        user: null,
+        parent: null,
+      });
+      jest
+        .spyOn(fileUseCases, 'getByFolderAndUser')
+        .mockImplementationOnce(() => Promise.resolve([]));
+      jest
+        .spyOn(folderUseCases, 'getChildrenFoldersToUser')
+        .mockResolvedValueOnce([folder]);
+      jest
+        .spyOn(folderUseCases, 'deleteFolderPermanently')
+        .mockImplementationOnce(() => Promise.resolve());
+      jest
+        .spyOn(folderUseCases, 'deleteOrphansFolders')
+        .mockImplementationOnce(() => Promise.resolve());
+
+      await service.clearTrash(userMock);
+
+      expect(folderUseCases.deleteOrphansFolders).toHaveBeenCalledTimes(1);
+    });
+
+    it('should delete all files and folder found', async () => {
+      const folder = Folder.build({
+        id: 2725517497,
+        parentId: 3388762609,
+        name: 'name',
+        bucket: 'bucket',
+        userId: 1,
+        encryptVersion: '2',
+        deleted: true,
+        deletedAt: new Date(),
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        user: null,
+        parent: null,
+      });
+
+      const file = File.build({
+        id: 1,
+        fileId: 'd666933f-0b1a-52c6-92d2-7ac1fc6d27fa',
+        name: '',
+        type: '',
+        size: null,
+        bucket: '',
+        folderId: 4,
+        encryptVersion: '',
+        deleted: true,
+        deletedAt: new Date(),
+        userId: 1,
+        modificationTime: new Date(),
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+
+      jest
+        .spyOn(fileUseCases, 'getByFolderAndUser')
+        .mockResolvedValueOnce([file, file, file]);
+      jest
+        .spyOn(fileUseCases, 'deleteFilePermanently')
+        .mockImplementation(() => Promise.resolve());
+      jest
+        .spyOn(folderUseCases, 'getChildrenFoldersToUser')
+        .mockResolvedValueOnce([folder, folder]);
+      jest
+        .spyOn(folderUseCases, 'deleteFolderPermanently')
+        .mockImplementation(() => Promise.resolve());
+      jest
+        .spyOn(folderUseCases, 'deleteOrphansFolders')
+        .mockImplementationOnce(() => Promise.resolve());
+
+      await service.clearTrash(userMock);
+
+      expect(fileUseCases.getByFolderAndUser).toHaveBeenCalledTimes(1);
+      expect(fileUseCases.deleteFilePermanently).toHaveBeenCalledTimes(3);
+      expect(folderUseCases.getChildrenFoldersToUser).toHaveBeenCalledTimes(1);
+      expect(folderUseCases.deleteFolderPermanently).toHaveBeenCalledTimes(2);
+      expect(folderUseCases.deleteOrphansFolders).toHaveBeenCalledTimes(1);
+    });
+
+    it('should continue deleting if a item cannot be deleted', async () => {
+      const folder = Folder.build({
+        id: 2725517497,
+        parentId: 3388762609,
+        name: 'name',
+        bucket: 'bucket',
+        userId: 1,
+        encryptVersion: '2',
+        deleted: true,
+        deletedAt: new Date(),
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        user: null,
+        parent: null,
+      });
+      const file = File.build({
+        id: 1,
+        fileId: 'd666933f-0b1a-52c6-92d2-7ac1fc6d27fa',
+        name: '',
+        type: '',
+        size: null,
+        bucket: '',
+        folderId: 4,
+        encryptVersion: '',
+        deleted: true,
+        deletedAt: new Date(),
+        userId: 1,
+        modificationTime: new Date(),
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+
+      jest
+        .spyOn(fileUseCases, 'getByFolderAndUser')
+        .mockResolvedValueOnce([
+          file,
+          File.build({ ...file, deleted: false }),
+          file,
+        ]);
+      jest
+        .spyOn(fileUseCases, 'deleteFilePermanently')
+        .mockImplementation(() => Promise.resolve());
+      jest
+        .spyOn(folderUseCases, 'getChildrenFoldersToUser')
+        .mockResolvedValueOnce([
+          Folder.build({
+            ...folder,
+            deleted: false,
+          }),
+          folder,
+          Folder.build({ ...folder, parentId: null }),
+        ]);
+      jest
+        .spyOn(folderUseCases, 'deleteFolderPermanently')
+        .mockImplementation(() => Promise.resolve());
+      jest
+        .spyOn(folderUseCases, 'deleteOrphansFolders')
+        .mockImplementation(() => Promise.resolve());
+
+      // jest.spyOn(service, 'deleteFilePermanently');
+
+      await service.clearTrash(userMock);
+
+      expect(fileUseCases.getByFolderAndUser).toHaveBeenCalledTimes(1);
+      expect(fileUseCases.deleteFilePermanently).toHaveBeenCalledTimes(2);
+      expect(folderUseCases.getChildrenFoldersToUser).toHaveBeenCalledTimes(1);
+      expect(folderUseCases.deleteFolderPermanently).toHaveBeenCalledTimes(1);
+      expect(folderUseCases.deleteOrphansFolders).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/src/modules/trash/trash.usecase.spec.ts
+++ b/src/modules/trash/trash.usecase.spec.ts
@@ -165,6 +165,7 @@ describe('Trash Use Cases', () => {
     });
 
     it('should continue deleting if a item cannot be deleted', async () => {
+      const errorToBeThrown = new Error('an error');
       const foldersToDelete: Array<Folder> = Array(3).fill({} as Folder);
       const filesToDelete: Array<File> = Array(6).fill({} as File);
 
@@ -173,7 +174,7 @@ describe('Trash Use Cases', () => {
         .mockResolvedValueOnce(filesToDelete);
       jest
         .spyOn(fileUseCases, 'deleteFilePermanently')
-        .mockImplementationOnce(() => Promise.reject())
+        .mockImplementationOnce(() => Promise.reject(errorToBeThrown))
         .mockImplementation(() => Promise.resolve());
       jest
         .spyOn(folderUseCases, 'getChildrenFoldersToUser')
@@ -181,7 +182,7 @@ describe('Trash Use Cases', () => {
       jest
         .spyOn(folderUseCases, 'deleteFolderPermanently')
         .mockImplementation(() => Promise.resolve())
-        .mockImplementationOnce(() => Promise.reject());
+        .mockImplementationOnce(() => Promise.reject(errorToBeThrown));
       jest
         .spyOn(folderUseCases, 'deleteOrphansFolders')
         .mockImplementation(() => Promise.resolve());

--- a/src/modules/trash/trash.usecase.spec.ts
+++ b/src/modules/trash/trash.usecase.spec.ts
@@ -17,6 +17,7 @@ import {
   SequelizeShareRepository,
   ShareModel,
 } from '../share/share.repository';
+import { BridgeModule } from '../../externals/bridge/bridge.module';
 
 describe('Trash Use Cases', () => {
   let service: TrashUseCases,
@@ -53,6 +54,7 @@ describe('Trash Use Cases', () => {
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
+      imports: [BridgeModule],
       providers: [
         TrashUseCases,
         FileUseCases,

--- a/src/modules/trash/trash.usecase.ts
+++ b/src/modules/trash/trash.usecase.ts
@@ -12,28 +12,27 @@ export class TrashUseCases {
     private folderUseCases: FolderUseCases,
   ) {}
 
-  private async deleteFiles(files: Array<File>, user: User) {
-    await Promise.all(
-      files.map((file: File) =>
-        this.fileUseCases
-          .deleteFilePermanently(file, user)
-          .catch((err) => Logger.error(err.message)),
-      ),
-    );
+  private async deleteFiles(files: Array<File>, user: User): Promise<void> {
+    for (const file of files) {
+      await this.fileUseCases
+        .deleteFilePermanently(file, user)
+        .catch((err) => Logger.error(err.message));
+    }
   }
 
-  private async deleteFolders(folders: Array<Folder>, user: User) {
+  private async deleteFolders(
+    folders: Array<Folder>,
+    user: User,
+  ): Promise<void> {
     if (folders.length === 0) {
       return;
     }
 
-    const folderDeletion = folders.map((folder: Folder) =>
-      this.folderUseCases
+    for (const folder of folders) {
+      await this.folderUseCases
         .deleteFolderPermanently(folder)
-        .catch((err) => Logger.error(err.message)),
-    );
-
-    await Promise.allSettled(folderDeletion);
+        .catch((err) => Logger.error(err.message));
+    }
 
     await this.folderUseCases.deleteOrphansFolders(user.id);
   }

--- a/src/modules/trash/trash.usecase.ts
+++ b/src/modules/trash/trash.usecase.ts
@@ -23,13 +23,17 @@ export class TrashUseCases {
   }
 
   private async deleteFolders(folders: Array<Folder>, user: User) {
+    if (folders.length === 0) {
+      return;
+    }
+
     const folderDeletion = folders.map((folder: Folder) =>
       this.folderUseCases
         .deleteFolderPermanently(folder)
         .catch((err) => Logger.error(err.message)),
     );
 
-    await Promise.all(folderDeletion);
+    await Promise.allSettled(folderDeletion);
 
     await this.folderUseCases.deleteOrphansFolders(user.id);
   }

--- a/src/modules/trash/trash.usecase.ts
+++ b/src/modules/trash/trash.usecase.ts
@@ -1,0 +1,51 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Folder } from '../folder/folder.domain';
+import { User } from '../user/user.domain';
+import { File } from '../file/file.domain';
+import { FolderUseCases } from '../folder/folder.usecase';
+import { FileUseCases } from '../file/file.usecase';
+
+@Injectable()
+export class TrashUseCases {
+  constructor(
+    private fileUseCases: FileUseCases,
+    private folderUseCases: FolderUseCases,
+  ) {}
+
+  private async deleteFiles(files: Array<File>, user: User) {
+    await Promise.all(
+      files.map((file: File) =>
+        this.fileUseCases
+          .deleteFilePermanently(file, user)
+          .catch((err) => Logger.error(err.message)),
+      ),
+    );
+  }
+
+  private async deleteFolders(folders: Array<Folder>, user: User) {
+    const folderDeletion = folders.map((folder: Folder) =>
+      this.folderUseCases
+        .deleteFolderPermanently(folder)
+        .catch((err) => Logger.error(err.message)),
+    );
+
+    await Promise.all(folderDeletion);
+
+    await this.folderUseCases.deleteOrphansFolders(user.id);
+  }
+
+  public async clearTrash(user: User) {
+    const { rootFolderId: folderId, id: userId } = user;
+    const deleted = true;
+
+    const filesDeletion = this.fileUseCases
+      .getByFolderAndUser(folderId, user.id, deleted)
+      .then((files: Array<File>) => this.deleteFiles(files, user));
+
+    const foldersDeletion = this.folderUseCases
+      .getChildrenFoldersToUser(folderId, userId, deleted)
+      .then((folders: Array<Folder>) => this.deleteFolders(folders, user));
+
+    await Promise.allSettled([filesDeletion, foldersDeletion]);
+  }
+}


### PR DESCRIPTION
#### Trash Module
- Moved the `clearTrash` logic to trash use cases.
- `clear trash` no longer waits for the operation to finish
#### Added the following use cases needed to delete files and folders:
- Added remove orphans folders use case
- Added remove file shares use case

