### PR TITLE
[WT-65] feature: protect share and send-links with password

### DIFF
--- a/migrations/20220919083117-add-password-to-shared-links.js
+++ b/migrations/20220919083117-add-password-to-shared-links.js
@@ -1,0 +1,21 @@
+'use strict';
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.addColumn('shares', 'hashed_password', {
+      type: Sequelize.TEXT,
+      allowNull: true,
+    });
+
+    await queryInterface.addColumn('send_links', 'hashed_password', {
+      type: Sequelize.TEXT,
+      allowNull: true,
+    });
+  },
+
+  async down(queryInterface) {
+    await queryInterface.removeColumn('shares', 'hashed_password');
+
+    await queryInterface.removeColumn('send_links', 'hashed_password');
+  },
+};

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "@jbiskur/nestjs-test-utilities": "^3.4.1",
     "@nestjs/schematics": "^8.0.0",
     "@nestjs/testing": "^8.0.0",
+    "@types/crypto-js": "^4.1.1",
     "@types/express": "^4.17.13",
     "@types/hapi__joi": "^17.1.8",
     "@types/jest": "27.5.0",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -15,6 +15,7 @@ import { ShareModule } from './modules/share/share.module';
 import { SendModule } from './modules/send/send.module';
 import { BridgeModule } from './externals/bridge/bridge.module';
 import { DeviceModule } from './modules/device/device.module';
+import { CryptoModule } from './externals/crypto/crypto.module';
 
 @Module({
   imports: [
@@ -86,6 +87,7 @@ import { DeviceModule } from './modules/device/device.module';
     SendModule,
     BridgeModule,
     DeviceModule,
+    CryptoModule,
   ],
   controllers: [],
   providers: [],

--- a/src/externals/bridge/bridge.module.ts
+++ b/src/externals/bridge/bridge.module.ts
@@ -1,19 +1,13 @@
 import { Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
-import { CryptoService } from '../crypto/crypto';
+import { CryptoModule } from '../crypto/crypto.module';
 import { HttpClientModule } from '../http/http.module';
 import { BridgeService } from './bridge.service';
 
 @Module({
-  imports: [ConfigModule, HttpClientModule],
+  imports: [ConfigModule, HttpClientModule, CryptoModule],
   controllers: [],
-  providers: [
-    BridgeService,
-    {
-      provide: CryptoService,
-      useValue: CryptoService.getInstance(),
-    },
-  ],
+  providers: [BridgeService],
   exports: [BridgeService],
 })
 export class BridgeModule {}

--- a/src/externals/bridge/bridge.service.spec.ts
+++ b/src/externals/bridge/bridge.service.spec.ts
@@ -1,11 +1,12 @@
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { Test, TestingModule } from '@nestjs/testing';
 import { User } from '../../modules/user/user.domain';
-import { CryptoService } from '../crypto/crypto';
+import { CryptoService } from '../crypto/crypto.service';
 import { HttpClientModule } from '../http/http.module';
 import { HttpClient } from '../http/http.service';
 import { BridgeService } from './bridge.service';
 import { AxiosResponse } from 'axios';
+import { CryptoModule } from '../crypto/crypto.module';
 
 describe('Bridge Service', () => {
   let service: BridgeService;
@@ -44,14 +45,8 @@ describe('Bridge Service', () => {
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      imports: [ConfigModule, HttpClientModule],
-      providers: [
-        BridgeService,
-        {
-          provide: CryptoService,
-          useValue: new CryptoService(),
-        },
-      ],
+      imports: [ConfigModule, HttpClientModule, CryptoModule],
+      providers: [BridgeService],
     }).compile();
 
     service = module.get<BridgeService>(BridgeService);

--- a/src/externals/bridge/bridge.service.ts
+++ b/src/externals/bridge/bridge.service.ts
@@ -1,10 +1,9 @@
 import { Logger } from '@nestjs/common';
 import { Inject, Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
-import { rejectedSyncPromise } from '@sentry/utils';
 import { FileAttributes } from 'src/modules/file/file.domain';
 import { User } from 'src/modules/user/user.domain';
-import { CryptoService } from '../crypto/crypto';
+import { CryptoService } from '../crypto/crypto.service';
 import { HttpClient } from '../http/http.service';
 
 @Injectable()

--- a/src/externals/crypto/aes.ts
+++ b/src/externals/crypto/aes.ts
@@ -21,13 +21,26 @@
 import crypto from 'crypto';
 
 export class AesService {
-  private magicIv;
-  private magicSalt;
-  private cryptoKey;
-  constructor() {
-    this.magicIv = process.env.MAGIC_IV;
-    this.magicSalt = process.env.MAGIC_SALT;
-    this.cryptoKey = process.env.CRYPTO_SECRET2;
+  constructor(
+    private readonly magicIv: string,
+    private readonly magicSalt: string,
+    private readonly cryptoKey: string,
+  ) {
+    this.validate();
+  }
+
+  private validate(): void {
+    if (!this.magicIv) {
+      throw new Error('AES SERVICE: Missing magic IV');
+    }
+
+    if (!this.magicSalt) {
+      throw new Error('AES SERVICE: Missing magic salt');
+    }
+
+    if (!this.cryptoKey) {
+      throw new Error('AES SERVICE: Missing crytpo key');
+    }
   }
 
   encrypt(text, originalSalt, randomIv = false) {

--- a/src/externals/crypto/crypto.module.ts
+++ b/src/externals/crypto/crypto.module.ts
@@ -1,0 +1,25 @@
+import { Module } from '@nestjs/common';
+import { ConfigModule, ConfigService } from '@nestjs/config';
+import configuration from '../../config/configuration';
+import { CryptoService } from './crypto.service';
+
+@Module({
+  imports: [
+    ConfigModule.forRoot({
+      envFilePath: [`.env.${process.env.NODE_ENV}`],
+      load: [configuration],
+      isGlobal: true,
+    }),
+  ],
+  providers: [
+    {
+      provide: CryptoService,
+      useFactory: (configService: ConfigService) => {
+        return new CryptoService(configService);
+      },
+      inject: [ConfigService],
+    },
+  ],
+  exports: [CryptoService],
+})
+export class CryptoModule {}

--- a/src/externals/crypto/crypto.service.ts
+++ b/src/externals/crypto/crypto.service.ts
@@ -20,6 +20,16 @@ export class CryptoService {
     this.cryptoSecret = process.env.CRYPTO_SECRET;
   }
 
+  public encryptText(text: string, salt?: string): string {
+    const randomIv = false;
+
+    return this.aesService.encrypt(
+      text,
+      salt || this.configService.get('secrets.magicSalt'),
+      randomIv,
+    );
+  }
+
   encryptName(name, salt) {
     if (salt) {
       return this.aesService.encrypt(name, salt, salt === undefined);
@@ -57,6 +67,13 @@ export class CryptoService {
   }
 
   /* DECRYPT */
+
+  public decryptText(text: string, salt?: string): string {
+    return this.decryptName(
+      text,
+      salt || this.configService.get('secrets.magicSalt'),
+    );
+  }
 
   decryptName(cipherText, salt) {
     if (salt) {

--- a/src/externals/crypto/crypto.service.ts
+++ b/src/externals/crypto/crypto.service.ts
@@ -1,19 +1,23 @@
-import { Logger } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import { AesService } from './aes';
 import CryptoJS from 'crypto-js';
 import crypto from 'crypto';
 
+@Injectable()
 export class CryptoService {
-  private static instance: CryptoService;
+  private configService: ConfigService;
   private aesService: AesService;
   private cryptoSecret: string;
-  constructor() {
-    this.aesService = new AesService();
-    this.cryptoSecret = process.env.CRYPTO_SECRET;
-  }
 
-  static getInstance(): CryptoService {
-    return CryptoService.instance || (this.instance = new CryptoService());
+  constructor(configService: ConfigService) {
+    this.configService = configService;
+    this.aesService = new AesService(
+      this.configService.get('secrets.magicIv'),
+      this.configService.get('secrets.magicSalt'),
+      this.configService.get('secrets.cryptoSecret2'),
+    );
+    this.cryptoSecret = process.env.CRYPTO_SECRET;
   }
 
   encryptName(name, salt) {

--- a/src/externals/crypto/crypto.spec.ts
+++ b/src/externals/crypto/crypto.spec.ts
@@ -1,19 +1,43 @@
-import { CryptoService } from './crypto';
+import { ConfigModule, ConfigService } from '@nestjs/config';
+import { Test, TestingModule } from '@nestjs/testing';
+import configuration from '../../../src/config/configuration';
+import { CryptoService } from './crypto.service';
 
 describe('Crypto', () => {
+  let cryptoService: CryptoService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      imports: [
+        ConfigModule.forRoot({
+          envFilePath: [`.env.${process.env.NODE_ENV}`],
+          load: [configuration],
+          isGlobal: true,
+        }),
+      ],
+      providers: [
+        {
+          provide: CryptoService,
+          useFactory: async (configService: ConfigService) => {
+            return new CryptoService(configService);
+          },
+          inject: [ConfigService],
+        },
+      ],
+    }).compile();
+
+    cryptoService = module.get<CryptoService>(CryptoService);
+  });
+
   describe('check crypto as singleton', () => {
-    it('create 2 instances and are the same', () => {
-      const firstInstance = CryptoService.getInstance();
-      const secondInstance = CryptoService.getInstance();
-      expect(firstInstance === secondInstance).toBe(true);
+    it('encrypt text without random IV does not throw an exception', () => {
+      cryptoService.encryptName('text to encrypt', 'salt');
     });
   });
 
   describe('hashSha256', () => {
-    const service: CryptoService = CryptoService.getInstance();
-
     it('should hash correctly', () => {
-      const result = service.hashSha256('Azboodo');
+      const result = cryptoService.hashSha256('Azboodo');
 
       expect(result).toBe(
         '0b9d660f04cb895b899243f88c92e82483d7d881fc6d3d16d229d0e88c33b7e6',
@@ -21,7 +45,7 @@ describe('Crypto', () => {
     });
 
     it('should hash correctly when empty', () => {
-      const result = service.hashSha256('');
+      const result = cryptoService.hashSha256('');
 
       expect(result).toBe(
         'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855',

--- a/src/externals/mailer/mailer.service.ts
+++ b/src/externals/mailer/mailer.service.ts
@@ -15,7 +15,7 @@ export class MailerService {
       to: email,
       from: {
         email: this.configService.get('mailer.from'),
-        name: this.configService.get('mailer.name')
+        name: this.configService.get('mailer.name'),
       },
       subject: '',
       text: 'send link',

--- a/src/modules/file/dto/file.dto.ts
+++ b/src/modules/file/dto/file.dto.ts
@@ -1,0 +1,19 @@
+import { FolderDto } from '../../folder/dto/folder.dto';
+
+export class FileDto {
+  id: number;
+  fileId: string;
+  name: string;
+  type: string;
+  size: bigint;
+  bucket: string;
+  folderId: number;
+  folder: FolderDto;
+  encryptVersion: string;
+  deleted: boolean;
+  deletedAt: Date;
+  userId: number;
+  modificationTime: Date;
+  createdAt: Date;
+  updatedAt: Date;
+}

--- a/src/modules/file/file.domain.ts
+++ b/src/modules/file/file.domain.ts
@@ -1,4 +1,3 @@
-import { CryptoService } from '../../externals/crypto/crypto';
 import { Folder } from '../folder/folder.domain';
 import { User } from '../user/user.domain';
 
@@ -37,7 +36,7 @@ export class File implements FileAttributes {
   modificationTime: Date;
   createdAt: Date;
   updatedAt: Date;
-  constructor({
+  private constructor({
     id,
     fileId,
     name,
@@ -59,7 +58,7 @@ export class File implements FileAttributes {
     this.fileId = fileId;
     this.folderId = folderId;
     this.setFolder(folder);
-    this.name = this.decryptName(name);
+    this.name = name;
     this.type = type;
     this.size = size;
     this.bucket = bucket;
@@ -75,10 +74,6 @@ export class File implements FileAttributes {
 
   static build(file: FileAttributes): File {
     return new File(file);
-  }
-  private decryptName(name: FileAttributes['name']) {
-    const cryptoService = CryptoService.getInstance();
-    return cryptoService.decryptName(name, this.folderId);
   }
 
   setFolder(folder) {

--- a/src/modules/file/file.domain.ts
+++ b/src/modules/file/file.domain.ts
@@ -1,5 +1,6 @@
 import { Folder } from '../folder/folder.domain';
 import { User } from '../user/user.domain';
+import { FileDto } from './dto/file.dto';
 
 export interface FileAttributes {
   id: number;
@@ -98,7 +99,7 @@ export class File implements FileAttributes {
     this.deletedAt = null;
   }
 
-  toJSON() {
+  toJSON(): FileDto {
     return {
       id: this.id,
       fileId: this.fileId,
@@ -112,7 +113,6 @@ export class File implements FileAttributes {
       deleted: this.deleted,
       deletedAt: this.deletedAt,
       userId: this.userId,
-      user: this.user,
       modificationTime: this.modificationTime,
       createdAt: this.createdAt,
       updatedAt: this.updatedAt,

--- a/src/modules/file/file.module.ts
+++ b/src/modules/file/file.module.ts
@@ -6,12 +6,14 @@ import { FileModel } from './file.repository';
 import { ShareModel } from '../share/share.repository';
 import { ShareModule } from '../share/share.module';
 import { BridgeModule } from '../../externals/bridge/bridge.module';
+import { CryptoModule } from '../../externals/crypto/crypto.module';
 
 @Module({
   imports: [
     SequelizeModule.forFeature([FileModel, ShareModel]),
     forwardRef(() => ShareModule),
     BridgeModule,
+    CryptoModule,
   ],
   controllers: [],
   providers: [SequelizeFileRepository, FileUseCases],

--- a/src/modules/file/file.usecase.spec.ts
+++ b/src/modules/file/file.usecase.spec.ts
@@ -398,10 +398,12 @@ describe('FileUseCases', () => {
         folderId,
       });
 
+      const { user: _, ...exepectedFiles } = fileAttributes;
+
       const result = service.decrypFileName(file);
 
       expect(result).toStrictEqual({
-        ...fileAttributes,
+        ...exepectedFiles,
         name: decyptedName,
         folderId,
       });

--- a/src/modules/folder/dto/folder.dto.ts
+++ b/src/modules/folder/dto/folder.dto.ts
@@ -1,0 +1,13 @@
+export class FolderDto {
+  id: number;
+  parent?: FolderDto;
+  name: string;
+  bucket: string;
+  userId: number;
+  encryptVersion: string;
+  size: number;
+  deleted: boolean;
+  deletedAt: Date;
+  createdAt: Date;
+  updatedAt: Date;
+}

--- a/src/modules/folder/folder.domain.ts
+++ b/src/modules/folder/folder.domain.ts
@@ -1,4 +1,5 @@
 import { User } from '../user/user.domain';
+import { FolderDto } from './dto/folder.dto';
 export interface FolderAttributes {
   id: number;
   parentId: number;
@@ -90,7 +91,7 @@ export class Folder implements FolderAttributes {
     this.user = user;
   }
 
-  toJSON() {
+  toJSON(): FolderDto {
     return {
       id: this.id,
       parent: this.parent,

--- a/src/modules/folder/folder.domain.ts
+++ b/src/modules/folder/folder.domain.ts
@@ -1,4 +1,3 @@
-import { CryptoService } from '../../externals/crypto/crypto';
 import { User } from '../user/user.domain';
 export interface FolderAttributes {
   id: number;
@@ -30,7 +29,7 @@ export class Folder implements FolderAttributes {
   createdAt: Date;
   updatedAt: Date;
   size: number;
-  constructor({
+  private constructor({
     id,
     parentId,
     parent,
@@ -47,7 +46,7 @@ export class Folder implements FolderAttributes {
     this.type = 'folder';
     this.id = id;
     this.parentId = parentId;
-    this.name = this.decryptName(name);
+    this.name = name;
     this.setParent(parent);
     this.bucket = bucket;
     this.userId = userId;
@@ -62,10 +61,6 @@ export class Folder implements FolderAttributes {
 
   static build(file: FolderAttributes): Folder {
     return new Folder(file);
-  }
-  private decryptName(nameEncrypted) {
-    const cryptoService = CryptoService.getInstance();
-    return cryptoService.decryptName(nameEncrypted, this.parentId);
   }
 
   isRootFolder(): boolean {

--- a/src/modules/folder/folder.module.ts
+++ b/src/modules/folder/folder.module.ts
@@ -4,11 +4,13 @@ import { FolderModel, SequelizeFolderRepository } from './folder.repository';
 import { FolderUseCases } from './folder.usecase';
 import { FileModule } from '../file/file.module';
 import { UserModel } from '../user/user.repository';
+import { CryptoModule } from '../../externals/crypto/crypto.module';
 
 @Module({
   imports: [
     SequelizeModule.forFeature([FolderModel, UserModel]),
     forwardRef(() => FileModule),
+    CryptoModule,
   ],
   controllers: [],
   providers: [SequelizeFolderRepository, FolderUseCases],

--- a/src/modules/folder/folder.usecase.spec.ts
+++ b/src/modules/folder/folder.usecase.spec.ts
@@ -181,7 +181,7 @@ describe('FolderUseCases', () => {
         {
           id: 4,
           parentId: 1,
-          name: null,
+          name: nameEncrypted,
           bucket: 'bucket',
           userId: 1,
           encryptVersion: '2',

--- a/src/modules/send/dto/create-send-link.dto.ts
+++ b/src/modules/send/dto/create-send-link.dto.ts
@@ -104,4 +104,11 @@ export class CreateSendLinkDto {
   @ValidateNested({ each: true })
   @ArrayMaxSize(100)
   items: SendLinkItemDto[];
+
+  @ApiProperty({
+    example: 'Super secret password',
+    description: 'Password to unlock the link',
+  })
+  @IsOptional()
+  encryptedPassword?: string;
 }

--- a/src/modules/send/send-link.domain.ts
+++ b/src/modules/send/send-link.domain.ts
@@ -14,6 +14,7 @@ export interface SendLinkAttributes {
   createdAt: Date;
   updatedAt: Date;
   expirationAt: Date;
+  hashedPassword: string | null;
 }
 
 export class SendLink implements SendLinkAttributes {
@@ -29,6 +30,8 @@ export class SendLink implements SendLinkAttributes {
   createdAt: Date;
   updatedAt: Date;
   expirationAt: Date;
+  hashedPassword: string | null;
+
   constructor({
     id,
     views,
@@ -42,6 +45,7 @@ export class SendLink implements SendLinkAttributes {
     createdAt,
     updatedAt,
     expirationAt,
+    hashedPassword,
   }) {
     this.id = id;
     this.setUser(user);
@@ -55,6 +59,7 @@ export class SendLink implements SendLinkAttributes {
     this.createdAt = createdAt;
     this.updatedAt = updatedAt;
     this.expirationAt = expirationAt;
+    this.hashedPassword = hashedPassword;
   }
 
   static build(send: SendLinkAttributes): SendLink {
@@ -88,6 +93,11 @@ export class SendLink implements SendLinkAttributes {
   addView() {
     this.views++;
   }
+
+  public isProtected(): boolean {
+    return this.hashedPassword !== null;
+  }
+
   toJSON() {
     return {
       id: this.id,
@@ -102,6 +112,7 @@ export class SendLink implements SendLinkAttributes {
       createdAt: this.createdAt,
       updatedAt: this.updatedAt,
       expirationAt: this.expirationAt,
+      protected: this.isProtected(),
     };
   }
 }

--- a/src/modules/send/send-link.repository.ts
+++ b/src/modules/send/send-link.repository.ts
@@ -67,6 +67,10 @@ export class SendLinkModel extends Model {
   @Column
   updatedAt: Date;
 
+  @AllowNull
+  @Column(DataType.TEXT)
+  hashedPassword: string;
+
   @HasMany(() => SendLinkItemModel)
   items: SendLinkItemModel[];
 }
@@ -162,7 +166,7 @@ export class SequelizeSendRepository implements SendRepository {
     await sendLinkModel.save();
   }
 
-  private toDomain(model): SendLink {
+  private toDomain(model: SendLinkModel): SendLink {
     if (
       model.title &&
       model.subject &&
@@ -185,6 +189,7 @@ export class SequelizeSendRepository implements SendRepository {
       title: model.title,
       subject: model.subject,
       expirationAt: model.expirationAt,
+      hashedPassword: model.hashedPassword,
     });
     const items = model.items.map((item) => this.toDomainItem(item));
     sendLink.setItems(items);
@@ -204,6 +209,7 @@ export class SequelizeSendRepository implements SendRepository {
     expirationAt,
     createdAt,
     updatedAt,
+    hashedPassword,
   }) {
     if (title && subject && createdAt > ENCRYPTION_DATE_RELEASE) {
       title = btoa(convertStringToBinary(title));
@@ -222,6 +228,7 @@ export class SequelizeSendRepository implements SendRepository {
       expirationAt,
       createdAt,
       updatedAt,
+      hashedPassword,
     };
   }
   private toDomainItem(model: SendLinkItemModel): SendLinkItem {

--- a/src/modules/send/send.module.ts
+++ b/src/modules/send/send.module.ts
@@ -1,5 +1,6 @@
 import { Module } from '@nestjs/common';
 import { SequelizeModule } from '@nestjs/sequelize';
+import { CryptoModule } from '../../externals/crypto/crypto.module';
 import { NotificationModule } from '../../externals/notifications/notifications.module';
 import { FileModule } from '../file/file.module';
 import { FileModel } from '../file/file.repository';
@@ -28,6 +29,7 @@ import { SendUseCases } from './send.usecase';
     FileModule,
     FolderModule,
     NotificationModule,
+    CryptoModule,
   ],
   controllers: [SendController],
   providers: [SequelizeSendRepository, SendUseCases],

--- a/src/modules/send/send.usecase.spec.ts
+++ b/src/modules/send/send.usecase.spec.ts
@@ -106,6 +106,7 @@ describe('Send Use Cases', () => {
         title: 'title',
         subject: 'subject',
         expirationAt,
+        hashedPassword: null,
       });
       jest.spyOn(sendRepository, 'findById').mockResolvedValue(sendLinkMock);
 
@@ -130,6 +131,7 @@ describe('Send Use Cases', () => {
         title: 'title',
         subject: 'subject',
         expirationAt,
+        hashedPassword: null,
       });
       jest.spyOn(sendRepository, 'findById').mockResolvedValue(sendLinkMock);
       jest.spyOn(sendRepository, 'update').mockResolvedValue(undefined);

--- a/src/modules/send/send.usecase.spec.ts
+++ b/src/modules/send/send.usecase.spec.ts
@@ -3,8 +3,11 @@ import { getModelToken } from '@nestjs/sequelize';
 import { Test, TestingModule } from '@nestjs/testing';
 import { Sequelize } from 'sequelize-typescript';
 import { NotificationService } from '../../externals/notifications/notification.service';
+import { FileModel } from '../file/file.repository';
+import { FolderModel } from '../folder/folder.repository';
 import { User } from '../user/user.domain';
-import { UserModel } from '../user/user.repository';
+import { UserModule } from '../user/user.module';
+import { SequelizeUserRepository, UserModel } from '../user/user.repository';
 import { SendLink } from './send-link.domain';
 import {
   SendLinkItemModel,
@@ -66,6 +69,14 @@ describe('Send Use Cases', () => {
         },
         {
           provide: getModelToken(UserModel),
+          useValue: jest.fn(),
+        },
+        {
+          provide: getModelToken(FileModel),
+          useValue: jest.fn(),
+        },
+        {
+          provide: getModelToken(FolderModel),
           useValue: jest.fn(),
         },
       ],

--- a/src/modules/send/send.usecase.spec.ts
+++ b/src/modules/send/send.usecase.spec.ts
@@ -1,13 +1,14 @@
+import { UnauthorizedException } from '@nestjs/common';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { getModelToken } from '@nestjs/sequelize';
 import { Test, TestingModule } from '@nestjs/testing';
 import { Sequelize } from 'sequelize-typescript';
+import { CryptoModule } from '../../externals/crypto/crypto.module';
 import { NotificationService } from '../../externals/notifications/notification.service';
 import { FileModel } from '../file/file.repository';
 import { FolderModel } from '../folder/folder.repository';
 import { User } from '../user/user.domain';
-import { UserModule } from '../user/user.module';
-import { SequelizeUserRepository, UserModel } from '../user/user.repository';
+import { UserModel } from '../user/user.repository';
 import { SendLink } from './send-link.domain';
 import {
   SendLinkItemModel,
@@ -18,7 +19,7 @@ import {
 import { SendUseCases } from './send.usecase';
 
 describe('Send Use Cases', () => {
-  let service, notificationService, sendRepository;
+  let service: SendUseCases, notificationService, sendRepository;
   const userMock = User.build({
     id: 2,
     userId: 'userId',
@@ -50,6 +51,7 @@ describe('Send Use Cases', () => {
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
+      imports: [CryptoModule],
       providers: [
         SendUseCases,
         NotificationService,
@@ -175,6 +177,8 @@ describe('Send Use Cases', () => {
       'sender@gmail.com',
       'title',
       'subject',
+      'plainCode',
+      null,
     );
     expect(sendRepository.createSendLinkWithItems).toHaveBeenCalledTimes(1);
     expect(notificationService.add).toHaveBeenCalledTimes(1);
@@ -202,6 +206,8 @@ describe('Send Use Cases', () => {
       'sender@gmail.com',
       'title',
       'subject',
+      'plainCode',
+      null,
     );
     expect(sendRepository.createSendLinkWithItems).toHaveBeenCalledTimes(1);
     expect(notificationService.add).toHaveBeenCalledTimes(1);
@@ -212,6 +218,98 @@ describe('Send Use Cases', () => {
       sender: 'sender@gmail.com',
       receivers: ['receiver@gmail.com'],
       items: [],
+    });
+  });
+
+  it('should create a sendLink protected by password', async () => {
+    jest.spyOn(notificationService, 'add').mockResolvedValue(true);
+    jest
+      .spyOn(sendRepository, 'createSendLinkWithItems')
+      .mockResolvedValue(undefined);
+    jest.spyOn(sendRepository, 'findById').mockResolvedValue(undefined);
+
+    const sendLink = await service.createSendLinks(
+      userMock,
+      [],
+      'code',
+      ['receiver@gmail.com'],
+      'sender@gmail.com',
+      'title',
+      'subject',
+      'plainCode',
+      'password',
+    );
+
+    expect(sendLink.isProtected()).toBe(true);
+  });
+
+  describe('Unlock Link', () => {
+    it('unlock unprotected send link', () => {
+      const unprotectedSendLink = SendLink.build({
+        id: '46716608-c5e4-5404-a2b9-2a38d737d87d',
+        views: 0,
+        user: userMock,
+        items: [],
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        sender: 'sender@gmail.com',
+        receivers: ['receiver@gmail.com'],
+        code: 'code',
+        title: 'title',
+        subject: 'subject',
+        expirationAt: new Date(),
+        hashedPassword: null,
+      });
+
+      service.unlockLink(unprotectedSendLink, '');
+    });
+
+    it('unlock protected send link without password throws unauthorized exception', () => {
+      const unprotectedSendLink = SendLink.build({
+        id: '46716608-c5e4-5404-a2b9-2a38d737d87d',
+        views: 0,
+        user: userMock,
+        items: [],
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        sender: 'sender@gmail.com',
+        receivers: ['receiver@gmail.com'],
+        code: 'code',
+        title: 'title',
+        subject: 'subject',
+        expirationAt: new Date(),
+        hashedPassword: 'password',
+      });
+
+      try {
+        service.unlockLink(unprotectedSendLink, null);
+      } catch (err: any) {
+        expect(err).toBeInstanceOf(UnauthorizedException);
+      }
+    });
+
+    it('unlock protected send link with invalid password throws unauthorized exception', () => {
+      const unprotectedSendLink = SendLink.build({
+        id: '46716608-c5e4-5404-a2b9-2a38d737d87d',
+        views: 0,
+        user: userMock,
+        items: [],
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        sender: 'sender@gmail.com',
+        receivers: ['receiver@gmail.com'],
+        code: 'code',
+        title: 'title',
+        subject: 'subject',
+        expirationAt: new Date(),
+        hashedPassword: 'password',
+      });
+
+      try {
+        service.unlockLink(unprotectedSendLink, 'password');
+      } catch (err: any) {
+        expect(err).toBeInstanceOf(UnauthorizedException);
+      }
     });
   });
 });

--- a/src/modules/send/send.usecase.ts
+++ b/src/modules/send/send.usecase.ts
@@ -61,6 +61,7 @@ export class SendUseCases {
       title,
       subject,
       expirationAt,
+      hashedPassword: null,
     });
     for (const item of items) {
       const sendLinkItem = SendLinkItem.build({

--- a/src/modules/share/dto/create-share.dto.ts
+++ b/src/modules/share/dto/create-share.dto.ts
@@ -1,5 +1,6 @@
 import { IsNotEmpty } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
+import { Optional } from '@nestjs/common';
 
 export class CreateShareDto {
   @ApiProperty({
@@ -33,6 +34,15 @@ export class CreateShareDto {
   })
   bucket: string;
 
+  @IsNotEmpty()
+  @Optional()
+  @ApiProperty({
+    example:
+      '53616c7465645f5fba6e8c807dace724e060ed51138e87c7789c145e6cdc3d45c5a0197efc1d7d326d48454e960747f1e48b8c2477c20b94ff64e66dfabb79553ec8b46cb66be52f98b8caff78d3893e059370a3dfcd7ff876b659f7578b6a3e',
+    description: 'Encryped password to protect the shared resoruce',
+  })
+  encryptedPassword: string | null;
+  
   @ApiProperty({
     example: 'code',
     description: 'Code Encrypted',

--- a/src/modules/share/dto/create-share.dto.ts
+++ b/src/modules/share/dto/create-share.dto.ts
@@ -1,6 +1,5 @@
-import { IsNotEmpty } from 'class-validator';
+import { IsNotEmpty, IsOptional } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
-import { Optional } from '@nestjs/common';
 
 export class CreateShareDto {
   @ApiProperty({
@@ -35,14 +34,14 @@ export class CreateShareDto {
   bucket: string;
 
   @IsNotEmpty()
-  @Optional()
+  @IsOptional()
   @ApiProperty({
     example:
       '53616c7465645f5fba6e8c807dace724e060ed51138e87c7789c145e6cdc3d45c5a0197efc1d7d326d48454e960747f1e48b8c2477c20b94ff64e66dfabb79553ec8b46cb66be52f98b8caff78d3893e059370a3dfcd7ff876b659f7578b6a3e',
     description: 'Encryped password to protect the shared resoruce',
   })
-  encryptedPassword: string | null;
-  
+  encryptedPassword?: string | null;
+
   @ApiProperty({
     example: 'code',
     description: 'Code Encrypted',

--- a/src/modules/share/dto/share.dto.ts
+++ b/src/modules/share/dto/share.dto.ts
@@ -1,0 +1,23 @@
+import { FolderDto } from '../../folder/dto/folder.dto';
+import { FileDto } from '../../file/dto/file.dto';
+
+export class ShareDto {
+  id: number;
+  token: string;
+  mnemonic: string;
+  bucket: string;
+  isFolder: boolean;
+  views: number;
+  timesValid: number;
+  active: boolean;
+  code: string;
+  createdAt: Date;
+  updatedAt: Date;
+  fileId: number;
+  fileSize: bigint;
+  folderId: number;
+  fileToken: string;
+  item: FileDto | FolderDto;
+  encryptionKey?: string;
+  protected: boolean;
+}

--- a/src/modules/share/share.controller.ts
+++ b/src/modules/share/share.controller.ts
@@ -12,6 +12,7 @@ import {
   Put,
   Query,
   Req,
+  Headers,
   Res,
 } from '@nestjs/common';
 import { ApiOkResponse, ApiOperation, ApiTags } from '@nestjs/swagger';
@@ -106,9 +107,11 @@ export class ShareController {
     @UserDecorator() user: User,
     @Param('token') token: string,
     @Req() req: Request,
+    @Headers('x-send-password') password: string | null,
   ) {
     user = await this.getUserWhenPublic(user);
-    const share = await this.shareUseCases.getShareByToken(token);
+
+    const share = await this.shareUseCases.getShareByToken(token, password);
     const incremented = await this.shareUseCases.incrementShareView(
       share,
       user,
@@ -248,10 +251,11 @@ export class ShareController {
   async getDownFiles(
     @UserDecorator() user: User,
     @Query() query: GetDownFilesDto,
+    @Headers('x-send-password') password: string | null,
   ) {
     const { token, folderId, code, page, perPage } = query;
     user = await this.getUserWhenPublic(user);
-    const share = await this.shareUseCases.getShareByToken(token);
+    const share = await this.shareUseCases.getShareByToken(token, password);
     share.decryptMnemonic(code);
     const network = await this.userUseCases.getNetworkByUserId(
       share.userId,

--- a/src/modules/share/share.controller.ts
+++ b/src/modules/share/share.controller.ts
@@ -30,6 +30,7 @@ import { ShareLinkViewEvent } from '../../externals/notifications/events/share-l
 import { ShareLinkCreatedEvent } from '../../externals/notifications/events/share-link-created.event';
 import { User } from '../user/user.domain';
 import { FileAttributes } from '../file/file.domain';
+import { ShareDto } from './dto/share.dto';
 
 @ApiTags('Share')
 @Controller('storage/share')
@@ -89,7 +90,7 @@ export class ShareController {
   async getShareByToken(
     @Param('token') token: string,
     @Query('code') code: string,
-  ) {
+  ): Promise<ShareDto> {
     const share = await this.shareUseCases.getShareByToken(token, code);
     return share.toJSON();
   }

--- a/src/modules/share/share.domain.ts
+++ b/src/modules/share/share.domain.ts
@@ -120,7 +120,7 @@ export class Share implements ShareAttributes {
       fileSize: this.fileSize,
       folderId: this.folderId,
       fileToken: this.fileToken,
-      item: this.item,
+      item: this.item.toJSON(),
       encryptionKey: this.encryptionKey,
       protected: this.isProtected(),
     };

--- a/src/modules/share/share.domain.ts
+++ b/src/modules/share/share.domain.ts
@@ -3,6 +3,7 @@ import { aes } from '@internxt/lib';
 import { File, FileAttributes } from '../file/file.domain';
 import { Folder, FolderAttributes } from '../folder/folder.domain';
 import { UserAttributes } from '../user/user.domain';
+import { ShareDto } from './dto/share.dto';
 
 export interface ShareAttributes {
   id: number;
@@ -102,7 +103,7 @@ export class Share implements ShareAttributes {
     return this.hashedPassword !== null;
   }
 
-  toJSON() {
+  toJSON(): ShareDto {
     return {
       id: this.id,
       token: this.token,

--- a/src/modules/share/share.domain.ts
+++ b/src/modules/share/share.domain.ts
@@ -18,6 +18,7 @@ export interface ShareAttributes {
   active: boolean;
   createdAt: Date;
   updatedAt: Date;
+  hashedPassword: string | null;
 }
 
 export class Share implements ShareAttributes {
@@ -35,6 +36,8 @@ export class Share implements ShareAttributes {
   active: boolean;
   createdAt: Date;
   updatedAt: Date;
+  hashedPassword: string | null;
+
   constructor({
     id,
     token,
@@ -50,6 +53,7 @@ export class Share implements ShareAttributes {
     active,
     createdAt,
     updatedAt,
+    hashedPassword,
   }) {
     this.id = id;
     this.token = token;
@@ -65,6 +69,7 @@ export class Share implements ShareAttributes {
     this.active = active;
     this.createdAt = createdAt;
     this.updatedAt = updatedAt;
+    this.hashedPassword = hashedPassword;
   }
 
   static build(share: ShareAttributes): Share {
@@ -109,6 +114,10 @@ export class Share implements ShareAttributes {
     return this.mnemonic;
   }
 
+  public isProtected(): boolean {
+    return this.hashedPassword !== null;
+  }
+
   toJSON() {
     return {
       id: this.id,
@@ -125,6 +134,7 @@ export class Share implements ShareAttributes {
       active: this.active,
       createdAt: this.createdAt,
       updatedAt: this.updatedAt,
+      protected: this.isProtected(),
     };
   }
 }

--- a/src/modules/share/share.module.ts
+++ b/src/modules/share/share.module.ts
@@ -1,5 +1,6 @@
 import { Module, forwardRef } from '@nestjs/common';
 import { SequelizeModule } from '@nestjs/sequelize';
+import { CryptoModule } from '../../externals/crypto/crypto.module';
 import { CryptoService } from '../../externals/crypto/crypto';
 import { NotificationModule } from '../../externals/notifications/notifications.module';
 import { FileModule } from '../file/file.module';
@@ -22,6 +23,7 @@ import { ShareUseCases } from './share.usecase';
     forwardRef(() => FolderModule),
     UserModule,
     NotificationModule,
+    CryptoModule,
   ],
   controllers: [ShareController],
   providers: [

--- a/src/modules/share/share.module.ts
+++ b/src/modules/share/share.module.ts
@@ -1,7 +1,7 @@
 import { Module, forwardRef } from '@nestjs/common';
 import { SequelizeModule } from '@nestjs/sequelize';
 import { CryptoModule } from '../../externals/crypto/crypto.module';
-import { CryptoService } from '../../externals/crypto/crypto';
+// import { CryptoService } from '../../externals/crypto/crypto.service';
 import { NotificationModule } from '../../externals/notifications/notifications.module';
 import { FileModule } from '../file/file.module';
 import { FileModel, SequelizeFileRepository } from '../file/file.repository';
@@ -32,10 +32,6 @@ import { ShareUseCases } from './share.usecase';
     SequelizeFolderRepository,
     SequelizeUserRepository,
     ShareUseCases,
-    {
-      provide: CryptoService,
-      useValue: CryptoService.getInstance(),
-    },
   ],
   exports: [ShareUseCases],
 })

--- a/src/modules/share/share.module.ts
+++ b/src/modules/share/share.module.ts
@@ -1,6 +1,6 @@
 import { Module, forwardRef } from '@nestjs/common';
 import { SequelizeModule } from '@nestjs/sequelize';
-import { CryptoService } from 'src/externals/crypto/crypto';
+import { CryptoService } from '../../externals/crypto/crypto';
 import { NotificationModule } from '../../externals/notifications/notifications.module';
 import { FileModule } from '../file/file.module';
 import { FileModel, SequelizeFileRepository } from '../file/file.repository';

--- a/src/modules/share/share.repository.ts
+++ b/src/modules/share/share.repository.ts
@@ -82,6 +82,10 @@ export class ShareModel extends Model {
   @Default(true)
   @Column
   active: boolean;
+
+  @AllowNull
+  @Column(DataType.TEXT)
+  hashedPassword: string;
 }
 
 export interface ShareRepository {
@@ -232,6 +236,7 @@ export class SequelizeShareRepository implements ShareRepository {
       user: model.user ? User.build(model.user) : null,
       createdAt: model.createdAt,
       updatedAt: model.updatedAt,
+      hashedPassword: model.hashedPassword,
     });
   }
 
@@ -250,6 +255,7 @@ export class SequelizeShareRepository implements ShareRepository {
     active,
     createdAt,
     updatedAt,
+    hashedPassword,
   }) {
     return {
       id,
@@ -267,6 +273,7 @@ export class SequelizeShareRepository implements ShareRepository {
       active,
       createdAt,
       updatedAt,
+      hashedPassword,
     };
   }
 }

--- a/src/modules/share/share.usecase.spec.ts
+++ b/src/modules/share/share.usecase.spec.ts
@@ -1,4 +1,8 @@
-import { ForbiddenException, UnauthorizedException, NotFoundException } from '@nestjs/common';
+import {
+  ForbiddenException,
+  UnauthorizedException,
+  NotFoundException,
+} from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { getModelToken } from '@nestjs/sequelize';
 import { Test, TestingModule } from '@nestjs/testing';

--- a/src/modules/share/share.usecase.spec.ts
+++ b/src/modules/share/share.usecase.spec.ts
@@ -1,15 +1,20 @@
-import { ForbiddenException } from '@nestjs/common';
+import { ForbiddenException, NotFoundException } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { getModelToken } from '@nestjs/sequelize';
 import { Test, TestingModule } from '@nestjs/testing';
 import { CryptoModule } from '../../externals/crypto/crypto.module';
 import { BridgeModule } from '../../externals/bridge/bridge.module';
 import { File } from '../file/file.domain';
-import { FileModel, SequelizeFileRepository } from '../file/file.repository';
+import {
+  FileModel,
+  FileRepository,
+  SequelizeFileRepository,
+} from '../file/file.repository';
 import { FileUseCases } from '../file/file.usecase';
 import { Folder } from '../folder/folder.domain';
 import {
   FolderModel,
+  FolderRepository,
   SequelizeFolderRepository,
 } from '../folder/folder.repository';
 import { FolderUseCases } from '../folder/folder.usecase';
@@ -26,9 +31,10 @@ import { ShareUseCases } from './share.usecase';
 
 describe('Share Use Cases', () => {
   let service: ShareUseCases;
-  let fileService: FileUseCases;
-  let folderService: FolderUseCases;
   let shareRepository: ShareRepository;
+  let fileRepository: FileRepository;
+  let folderRepository: FolderRepository;
+
   const token = 'token';
   const userOwnerMock = User.build({
     id: 1,
@@ -118,11 +124,7 @@ describe('Share Use Cases', () => {
     id: 1,
     token: 'token',
     mnemonic: 'test',
-    user: userOwnerMock,
-    item: mockFolder,
-    encryptionKey: 'test',
     bucket: 'test',
-    itemToken: 'token',
     isFolder: true,
     views: 0,
     timesValid: 10,
@@ -130,16 +132,18 @@ describe('Share Use Cases', () => {
     createdAt: new Date(),
     updatedAt: new Date(),
     hashedPassword: null,
+    userId: 2083971069,
+    fileId: null,
+    fileSize: null,
+    folderId: 3209615469,
+    code: 'daz2uC8A0AMKoZjIvyfELDaTJz8p2f',
+    fileToken: '17phH5NgBtAbx4ARxp1PpNGTqgSz1G',
   });
   const shareFile = Share.build({
     id: 1,
     token: 'token',
     mnemonic: 'test',
-    user: userOwnerMock,
-    item: mockFile,
-    encryptionKey: 'test',
     bucket: 'test',
-    itemToken: 'token',
     isFolder: false,
     views: 0,
     timesValid: 10,
@@ -147,6 +151,12 @@ describe('Share Use Cases', () => {
     createdAt: new Date(),
     updatedAt: new Date(),
     hashedPassword: null,
+    userId: 2083971069,
+    fileId: 944407977,
+    fileSize: BigInt(2840781934),
+    folderId: null,
+    code: 'qJhD70HqNsaeIZs39MJCvy4HfNbC5v',
+    fileToken: '4FX6oaWFx2SCgIO5ZeGOlXY69J0rNJ',
   });
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -181,9 +191,9 @@ describe('Share Use Cases', () => {
     }).compile();
 
     service = module.get<ShareUseCases>(ShareUseCases);
-    fileService = module.get<FileUseCases>(FileUseCases);
-    folderService = module.get<FolderUseCases>(FolderUseCases);
     shareRepository = module.get<ShareRepository>(SequelizeShareRepository);
+    fileRepository = module.get<FileRepository>(SequelizeFileRepository);
+    folderRepository = module.get<FolderRepository>(SequelizeFolderRepository);
   });
 
   it('should be defined', () => {
@@ -211,7 +221,7 @@ describe('Share Use Cases', () => {
           {
             id: 1,
             token: 'token',
-            item: mockFolder,
+            // item: mockFolder,
             isFolder: true,
             views: 0,
             timesValid: 10,
@@ -224,10 +234,14 @@ describe('Share Use Cases', () => {
 
   describe('get share by token', () => {
     it('as owner share should return share', async () => {
+      const code = 'code';
       shareFolder.views = 0;
       shareFolder.active = true;
       jest.spyOn(shareRepository, 'findByToken').mockResolvedValue(shareFolder);
-      const result = await service.getShareByToken(token, userOwnerMock);
+      jest.spyOn(folderRepository, 'findById').mockResolvedValue(mockFolder);
+
+      const result = await service.getShareByToken(token, code);
+
       expect(result).toMatchObject({
         id: 1,
         token: 'token',
@@ -237,32 +251,38 @@ describe('Share Use Cases', () => {
         active: true,
       });
     });
-    it('as user not owner share should return share and increment view', async () => {
+    it('as user not owner share should return share and NOT increment view', async () => {
       shareFolder.views = 0;
       shareFolder.active = true;
       jest.spyOn(shareRepository, 'findByToken').mockResolvedValue(shareFolder);
       jest.spyOn(shareRepository, 'update').mockResolvedValue(undefined);
-      const result = await service.getShareByToken(token, userMock);
+      jest.spyOn(folderRepository, 'findById').mockResolvedValue(mockFolder);
+
+      const result = await service.getShareByToken(token);
+
       expect(result).toMatchObject({
         id: 1,
         token: 'token',
-        views: 1,
+        views: 0,
         isFolder: true,
         timesValid: 10,
         active: true,
       });
     });
 
-    it('as user anonymus share should return share and increment view', async () => {
+    it('as user anonymus share should return share and NOT increment view', async () => {
       shareFolder.views = 0;
       shareFolder.active = true;
       jest.spyOn(shareRepository, 'findByToken').mockResolvedValue(shareFolder);
       jest.spyOn(shareRepository, 'update').mockResolvedValue(undefined);
+      jest.spyOn(folderRepository, 'findById').mockResolvedValue(mockFolder);
+
       const result = await service.getShareByToken(token, null);
+
       expect(result).toMatchObject({
         id: 1,
         token: 'token',
-        views: 1,
+        views: 0,
         isFolder: true,
         timesValid: 10,
         active: true,
@@ -273,22 +293,27 @@ describe('Share Use Cases', () => {
       shareFolder.active = false;
       jest.spyOn(shareRepository, 'findByToken').mockResolvedValue(shareFolder);
       await expect(service.getShareByToken(token, null)).rejects.toThrow(
-        'cannot view this share',
+        new NotFoundException('Share expired'),
       );
     });
-    it('as user share should return share with same views and timesValid', async () => {
+    it('returns the share with the same views', async () => {
       shareFolder.views = 9;
       shareFolder.active = true;
       jest.spyOn(shareRepository, 'findByToken').mockResolvedValue(shareFolder);
       jest.spyOn(shareRepository, 'update').mockResolvedValue(undefined);
+      jest
+        .spyOn(folderRepository, 'findById')
+        .mockResolvedValue(shareFolder.item as Folder);
+
       const result = await service.getShareByToken(token, null);
+
       expect(result).toMatchObject({
         id: 1,
         token: 'token',
-        views: 10,
+        views: 9,
         isFolder: true,
         timesValid: 10,
-        active: false,
+        active: true,
       });
     });
   });
@@ -319,7 +344,12 @@ describe('Share Use Cases', () => {
     it('should return share updated', async () => {
       jest.spyOn(shareRepository, 'findById').mockResolvedValue(shareFolder);
       jest.spyOn(shareRepository, 'update').mockResolvedValue(undefined);
-      const result = await service.updateShareById(1, userOwnerMock, {
+
+      const userOwnerOfShare = {
+        id: shareFolder.userId,
+      } as User;
+
+      const result = await service.updateShareById(1, userOwnerOfShare, {
         timesValid: 20,
         active: true,
       });
@@ -347,8 +377,14 @@ describe('Share Use Cases', () => {
   describe('delete share by id', () => {
     it('should return share deleted', async () => {
       jest.spyOn(shareRepository, 'findById').mockResolvedValue(shareFolder);
-      jest.spyOn(shareRepository, 'delete').mockResolvedValue(undefined);
-      const result = await service.deleteShareById(1, userOwnerMock);
+      jest.spyOn(shareRepository, 'deleteById').mockResolvedValue(undefined);
+
+      const userOwnerOfShare = {
+        id: shareFolder.userId,
+      } as unknown as User;
+
+      const result = await service.deleteShareById(1, userOwnerOfShare);
+
       expect(result).toBe(true);
     });
 
@@ -362,21 +398,23 @@ describe('Share Use Cases', () => {
 
   describe('create share file', () => {
     it('should return share pre exist', async () => {
-      jest.spyOn(fileService, 'getByFileIdAndUser').mockResolvedValue(mockFile);
+      const fileId = 1831192863;
+      jest.spyOn(fileRepository, 'findOne').mockResolvedValue(mockFile);
       jest
         .spyOn(shareRepository, 'findByFileIdAndUser')
         .mockResolvedValue(shareFile);
       jest.spyOn(shareRepository, 'create').mockResolvedValue(undefined);
-      const result = await service.createShareFile('fileId', userOwnerMock, {
+      const result = await service.createShareFile(fileId, userOwnerMock, {
         timesValid: 20,
         encryptionKey: 'key',
         itemToken: 'token',
         bucket: 'bucket',
-        mnemonic: '',
+        encryptedMnemonic: 'encryptedMnemonic',
+        encryptedCode: 'encryptedCode',
       });
-      expect(fileService.getByFileIdAndUser).toHaveBeenNthCalledWith(
+      expect(fileRepository.findOne).toHaveBeenNthCalledWith(
         1,
-        'fileId',
+        fileId,
         userOwnerMock.id,
       );
       expect(shareRepository.create).toHaveBeenCalledTimes(0);
@@ -393,22 +431,25 @@ describe('Share Use Cases', () => {
       });
     });
 
-    it('should return new share', async () => {
-      jest.spyOn(fileService, 'getByFileIdAndUser').mockResolvedValue(mockFile);
+    it('should return new file share', async () => {
+      const fileId = 4087455352;
+      jest.spyOn(fileRepository, 'findOne').mockResolvedValue(mockFile);
       jest
         .spyOn(shareRepository, 'findByFileIdAndUser')
         .mockResolvedValue(null);
       jest.spyOn(shareRepository, 'create').mockResolvedValue(undefined);
-      const result = await service.createShareFile('fileId', userOwnerMock, {
+
+      const result = await service.createShareFile(fileId, userOwnerMock, {
         timesValid: 20,
         encryptionKey: 'key',
         itemToken: 'token',
         bucket: 'bucket',
-        mnemonic: '',
+        encryptedMnemonic: 'encryptedMnemonic',
+        encryptedCode: 'encryptedCode',
       });
-      expect(fileService.getByFileIdAndUser).toHaveBeenNthCalledWith(
+      expect(fileRepository.findOne).toHaveBeenNthCalledWith(
         1,
-        'fileId',
+        fileId,
         userOwnerMock.id,
       );
       expect(shareRepository.create).toHaveBeenCalledTimes(1);
@@ -429,7 +470,7 @@ describe('Share Use Cases', () => {
     it('should return share pre exist', async () => {
       shareFolder.timesValid = 10;
       shareFolder.active = true;
-      jest.spyOn(folderService, 'getFolder').mockResolvedValue(mockFolder);
+      jest.spyOn(folderRepository, 'findById').mockResolvedValue(mockFolder);
       jest
         .spyOn(shareRepository, 'findByFolderIdAndUser')
         .mockResolvedValue(shareFolder);
@@ -439,9 +480,10 @@ describe('Share Use Cases', () => {
         encryptionKey: 'key',
         itemToken: 'token',
         bucket: 'bucket',
-        mnemonic: '',
+        encryptedMnemonic: 'encryptedMnemonic',
+        encryptedCode: 'encryptedCode',
       });
-      expect(folderService.getFolder).toHaveBeenNthCalledWith(1, 1);
+      expect(folderRepository.findById).toHaveBeenNthCalledWith(1, 1);
       expect(shareRepository.create).toHaveBeenCalledTimes(0);
       expect(result).toMatchObject({
         item: {
@@ -456,10 +498,10 @@ describe('Share Use Cases', () => {
       });
     });
 
-    it('should return new share', async () => {
+    it('should return new folder share', async () => {
       shareFolder.timesValid = 10;
       shareFolder.active = true;
-      jest.spyOn(folderService, 'getFolder').mockResolvedValue(mockFolder);
+      jest.spyOn(folderRepository, 'findById').mockResolvedValue(mockFolder);
       jest
         .spyOn(shareRepository, 'findByFolderIdAndUser')
         .mockResolvedValue(null);
@@ -469,9 +511,10 @@ describe('Share Use Cases', () => {
         encryptionKey: 'key',
         itemToken: 'token',
         bucket: 'bucket',
-        mnemonic: '',
+        encryptedMnemonic: 'encryptedMnemonic',
+        encryptedCode: 'encryptedCode',
       });
-      expect(folderService.getFolder).toHaveBeenNthCalledWith(1, 1);
+      expect(folderRepository.findById).toHaveBeenNthCalledWith(1, 1);
       expect(shareRepository.create).toHaveBeenCalledTimes(1);
       expect(result).toMatchObject({
         item: {
@@ -488,22 +531,22 @@ describe('Share Use Cases', () => {
 
   describe('delete share by fileId', () => {
     it('should delete the share if its from the user', async () => {
-      jest.spyOn(shareRepository, 'delete').mockResolvedValueOnce();
-      jest
-        .spyOn(shareRepository, 'findByFileIdAndUser')
-        .mockResolvedValueOnce({ user: { id: userMock.id } } as Share);
+      jest.spyOn(shareRepository, 'deleteById').mockResolvedValueOnce();
+      jest.spyOn(shareRepository, 'findByFileIdAndUser').mockResolvedValueOnce({
+        userId: userMock.id,
+      } as unknown as Share);
 
       await service.deleteFileShare(885045478, userMock);
 
       expect(shareRepository.findByFileIdAndUser).toBeCalled();
-      expect(shareRepository.delete).toBeCalled();
+      expect(shareRepository.deleteById).toBeCalled();
     });
 
     it('should not fail if there is no share its not from the user', async () => {
-      jest.spyOn(shareRepository, 'delete');
-      jest
-        .spyOn(shareRepository, 'findByFileIdAndUser')
-        .mockResolvedValueOnce({ user: { id: userMock.id + 1 } } as Share);
+      jest.spyOn(shareRepository, 'deleteById');
+      jest.spyOn(shareRepository, 'findByFileIdAndUser').mockResolvedValueOnce({
+        userId: userMock.id + 1,
+      } as unknown as Share);
 
       await service.deleteFileShare(885045478, userMock).catch((error) => {
         expect(error).toBeInstanceOf(ForbiddenException);
@@ -511,11 +554,11 @@ describe('Share Use Cases', () => {
       });
 
       expect(shareRepository.findByFileIdAndUser).toBeCalled();
-      expect(shareRepository.delete).toBeCalledTimes(0);
+      expect(shareRepository.deleteById).toBeCalledTimes(0);
     });
 
     it('should not fail if there is no share for the file', async () => {
-      jest.spyOn(shareRepository, 'delete');
+      jest.spyOn(shareRepository, 'deleteById');
       jest
         .spyOn(shareRepository, 'findByFileIdAndUser')
         .mockResolvedValueOnce(null);
@@ -523,7 +566,7 @@ describe('Share Use Cases', () => {
       await service.deleteFileShare(885045478, userMock);
 
       expect(shareRepository.findByFileIdAndUser).toBeCalled();
-      expect(shareRepository.delete).toBeCalledTimes(0);
+      expect(shareRepository.deleteById).toBeCalledTimes(0);
     });
   });
 });

--- a/src/modules/share/share.usecase.spec.ts
+++ b/src/modules/share/share.usecase.spec.ts
@@ -128,6 +128,7 @@ describe('Share Use Cases', () => {
     active: true,
     createdAt: new Date(),
     updatedAt: new Date(),
+    hashedPassword: null,
   });
   const shareFile = Share.build({
     id: 1,
@@ -144,6 +145,7 @@ describe('Share Use Cases', () => {
     active: true,
     createdAt: new Date(),
     updatedAt: new Date(),
+    hashedPassword: null,
   });
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({

--- a/src/modules/share/share.usecase.spec.ts
+++ b/src/modules/share/share.usecase.spec.ts
@@ -2,6 +2,7 @@ import { ForbiddenException } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { getModelToken } from '@nestjs/sequelize';
 import { Test, TestingModule } from '@nestjs/testing';
+import { CryptoModule } from '../../externals/crypto/crypto.module';
 import { BridgeModule } from '../../externals/bridge/bridge.module';
 import { File } from '../file/file.domain';
 import { FileModel, SequelizeFileRepository } from '../file/file.repository';
@@ -149,7 +150,7 @@ describe('Share Use Cases', () => {
   });
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      imports: [BridgeModule],
+      imports: [BridgeModule, CryptoModule],
       providers: [
         ShareUseCases,
         FolderUseCases,

--- a/src/modules/share/share.usecase.ts
+++ b/src/modules/share/share.usecase.ts
@@ -140,6 +140,7 @@ export class ShareUseCases {
       active: true,
       createdAt: new Date(),
       updatedAt: new Date(),
+      hashedPassword: null,
     });
     await this.shareRepository.create(shareCreated);
     // apply userReferral to share-file
@@ -178,6 +179,7 @@ export class ShareUseCases {
       active: true,
       createdAt: new Date(),
       updatedAt: new Date(),
+      hashedPassword: null,
     });
     await this.shareRepository.create(shareCreated);
 

--- a/src/modules/share/share.usecase.ts
+++ b/src/modules/share/share.usecase.ts
@@ -61,12 +61,12 @@ export class ShareUseCases {
   ): Promise<Share> {
     const share = await this.shareRepository.findByToken(token);
 
-    if (share.isProtected()) {
-      this.unlockShare(share, password);
-    }
-
     if (!share) {
       throw new NotFoundException('Share not found');
+    }
+
+    if (share.isProtected()) {
+      this.unlockShare(share, password);
     }
 
     if (!share.isActive()) {

--- a/src/modules/trash/trash.controller.ts
+++ b/src/modules/trash/trash.controller.ts
@@ -24,12 +24,14 @@ import { UserUseCases } from '../user/user.usecase';
 import { ItemsToTrashEvent } from '../../externals/notifications/events/items-to-trash.event';
 import { NotificationService } from '../../externals/notifications/notification.service';
 import { User } from '../user/user.domain';
-
 import { TrashUseCases } from './trash.usecase';
 import {
   DeleteItemsDto,
   DeleteItemType,
 } from './dto/controllers/delete-item.dto';
+import { Folder } from '../folder/folder.domain';
+import { File } from '../file/file.domain';
+
 @ApiTags('Trash')
 @Controller('storage/trash')
 export class TrashController {
@@ -61,8 +63,10 @@ export class TrashController {
     );
     return {
       ...currentFolder.toJSON(),
-      children: childrenFolders,
-      files,
+      children: childrenFolders.map((folder: Folder) =>
+        this.folderUseCases.decryptFolderName(folder),
+      ),
+      files: files.map((file: File) => this.fileUseCases.decrypFileName(file)),
     };
   }
 

--- a/src/modules/trash/trash.usecase.spec.ts
+++ b/src/modules/trash/trash.usecase.spec.ts
@@ -18,6 +18,7 @@ import {
   ShareModel,
 } from '../share/share.repository';
 import { BridgeModule } from '../../externals/bridge/bridge.module';
+import { CryptoModule } from '../..//externals/crypto/crypto.module';
 import { NotFoundException } from '@nestjs/common';
 
 describe('Trash Use Cases', () => {
@@ -55,7 +56,7 @@ describe('Trash Use Cases', () => {
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      imports: [BridgeModule],
+      imports: [BridgeModule, CryptoModule],
       providers: [
         TrashUseCases,
         FileUseCases,

--- a/test/app.e2e-spec.ts
+++ b/test/app.e2e-spec.ts
@@ -1,9 +1,21 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { INestApplication, ValidationPipe } from '@nestjs/common';
+import {
+  INestApplication,
+  NotFoundException,
+  ValidationPipe,
+} from '@nestjs/common';
 import request from 'supertest';
 import { AppModule } from './../src/app.module';
 import { TransformInterceptor } from '../src/lib/transform.interceptor';
 import { HttpStatus } from '@nestjs/common';
+import { SequelizeShareRepository } from './../src/modules/share/share.repository';
+import { ShareMother } from './share.mother';
+import { UserMother } from './user.mother';
+import { SequelizeUserRepository } from './../src/modules/user/user.repository';
+import { Share } from './../src/modules/share/share.domain';
+import { NotificationService } from './../src/externals/notifications/notification.service';
+import { CryptoService } from '../src/externals/crypto/crypto.service';
+import { File } from '../src/modules/file/file.domain';
 
 // Running e2e tests require a database named "Xcloud_test" in the mariadb database first.
 describe('AppController (e2e)', () => {
@@ -194,6 +206,200 @@ describe('AppController (e2e)', () => {
           });
         });
       });
+    });
+  });
+});
+
+describe('Share Endpoints', () => {
+  let app: INestApplication;
+
+  const fakeNotificationService = {
+    add: (_: any) => {
+      //no op
+    },
+  } as unknown as NotificationService;
+
+  const fakeUserRepository = {
+    findByUsername: (_: string) => UserMother.create(),
+  } as unknown as SequelizeUserRepository;
+
+  describe('unprotected shares', () => {
+    const databaseShare = ShareMother.createWithPassword(null);
+    const databaseSharedFile = databaseShare.item as File;
+    const unprotectedShareRepository = {
+      findByToken: (token: string) => {
+        if (token === databaseShare.token) return databaseShare;
+        throw new NotFoundException('share not found');
+      },
+      update: (_: Share) => Promise.resolve(),
+    } as unknown as SequelizeShareRepository;
+
+    beforeAll(async () => {
+      if (process.env.NODE_ENV !== 'test') {
+        throw new Error('Cannot do E2E tests without NODE_ENV=test ');
+      }
+      const moduleFixture: TestingModule = await Test.createTestingModule({
+        imports: [AppModule],
+      })
+        .overrideProvider(SequelizeShareRepository)
+        .useValue(unprotectedShareRepository)
+        .overrideProvider(SequelizeUserRepository)
+        .useValue(fakeUserRepository)
+        .overrideProvider(NotificationService)
+        .useValue(fakeNotificationService)
+        .compile();
+      app = moduleFixture.createNestApplication();
+      app.useGlobalPipes(new ValidationPipe());
+      app.useGlobalInterceptors(new TransformInterceptor());
+      await app.init();
+    });
+
+    afterAll(async () => {
+      await app.close();
+    });
+
+    it('return the shared', async () => {
+      const expectedShare = {
+        id: databaseShare.id,
+        token: databaseShare.token,
+        mnemonic: databaseShare.mnemonic,
+        bucket: databaseShare.bucket,
+        isFolder: databaseShare.isFolder,
+        views: databaseShare.views,
+        timesValid: databaseShare.timesValid,
+        active: databaseShare.active,
+        // code: databaseShare.code,
+        createdAt: databaseShare.createdAt.toISOString(),
+        updatedAt: databaseShare.updatedAt.toISOString(),
+        // fileId: databaseShare.fileId,
+        // fileSize: databaseShare.fileSize,
+        // folderId: databaseShare.folderId,
+        // fileToken: databaseShare.fileToken,
+        item: {
+          ...databaseSharedFile,
+          createdAt: databaseSharedFile.createdAt.toISOString(),
+          modificationTime: databaseSharedFile.modificationTime.toISOString(),
+          updatedAt: databaseSharedFile.updatedAt.toISOString(),
+        },
+        encryptionKey: databaseShare.encryptionKey,
+        protected: false,
+      };
+
+      const response = await request(app.getHttpServer()).get(
+        `/storage/share/${databaseShare.token}`,
+      );
+
+      expect(response.status).toBe(HttpStatus.OK);
+      expect(response.body).toBe({
+        ...expectedShare,
+        views: expectedShare.views + 1,
+      });
+    });
+
+    it('returns resource not found if the share not exist', async () => {
+      const token = '1234';
+
+      const response = await request(app.getHttpServer()).get(
+        `/storage/share/${token}`,
+      );
+
+      expect(response.status).toBe(HttpStatus.NOT_FOUND);
+    });
+  });
+
+  describe('protected shares', () => {
+    let cryptoService: CryptoService;
+
+    const password = 'KPit1mKILC';
+    const databaseShare = ShareMother.createWithPassword(password);
+    const databaseSharedFile = databaseShare.item as File;
+
+    const protectedShareRepository = {
+      findByToken: (_: string) => databaseShare,
+      update: (_: Share) => Promise.resolve(),
+    } as unknown as SequelizeShareRepository;
+
+    beforeAll(async () => {
+      if (process.env.NODE_ENV !== 'test') {
+        throw new Error('Cannot do E2E tests without NODE_ENV=test ');
+      }
+      const moduleFixture: TestingModule = await Test.createTestingModule({
+        imports: [AppModule],
+      })
+        .overrideProvider(SequelizeShareRepository)
+        .useValue(protectedShareRepository)
+        .overrideProvider(SequelizeUserRepository)
+        .useValue(fakeUserRepository)
+        .overrideProvider(NotificationService)
+        .useValue(fakeNotificationService)
+        .compile();
+      app = moduleFixture.createNestApplication();
+      app.useGlobalPipes(new ValidationPipe());
+      app.useGlobalInterceptors(new TransformInterceptor());
+      cryptoService = moduleFixture.get<CryptoService>(CryptoService);
+      await app.init();
+    });
+
+    afterAll(async () => {
+      await app.close();
+    });
+
+    it('return the shared when the correct passwrod is porvided', async () => {
+      const encryptedPassword = cryptoService.encryptText(password);
+      const expectedShare = {
+        id: databaseShare.id,
+        token: databaseShare.token,
+        mnemonic: databaseShare.mnemonic,
+        bucket: databaseShare.bucket,
+        isFolder: databaseShare.isFolder,
+        views: databaseShare.views,
+        timesValid: databaseShare.timesValid,
+        active: databaseShare.active,
+        // code: databaseShare.code,
+        createdAt: databaseShare.createdAt.toISOString(),
+        updatedAt: databaseShare.updatedAt.toISOString(),
+        // fileId: databaseShare.fileId,
+        // fileSize: databaseShare.fileSize,
+        // folderId: databaseShare.folderId,
+        // fileToken: databaseShare.fileToken,
+        item: {
+          ...databaseSharedFile,
+          createdAt: databaseSharedFile.createdAt.toISOString(),
+          modificationTime: databaseSharedFile.modificationTime.toISOString(),
+          updatedAt: databaseSharedFile.updatedAt.toISOString(),
+        },
+        encryptionKey: databaseShare.encryptionKey,
+        protected: true,
+      };
+
+      const response = await request(app.getHttpServer())
+        .get(`/storage/share/${databaseShare.token}`)
+        .set('x-send-password', encryptedPassword);
+
+      expect(response.status).toBe(HttpStatus.OK);
+      expect(response.body).toBe({
+        ...expectedShare,
+        views: expectedShare.views + 1,
+      });
+    });
+
+    it('return unauthorized response when password is not correct', async () => {
+      const token = 'mGc9eCtk8lnphJMV6SpTJmF9SYDV7x';
+      const encryptedPassword = '1234';
+
+      const response = await request(app.getHttpServer())
+        .get(`/storage/share/${token}`)
+        .set('x-send-password', encryptedPassword);
+
+      expect(response.status).toBe(HttpStatus.UNAUTHORIZED);
+    });
+
+    it('returns unauthorized response when no password provided', async () => {
+      const token = 'whHG1saU0Ex0ilILPGhM';
+      const response = await request(app.getHttpServer()).get(
+        `/storage/share/${token}`,
+      );
+      expect(response.status).toBe(HttpStatus.UNAUTHORIZED);
     });
   });
 });

--- a/test/share.mother.ts
+++ b/test/share.mother.ts
@@ -1,0 +1,71 @@
+import { File } from './../src/modules/file/file.domain';
+import { Share } from './../src/modules/share/share.domain';
+import { User } from './../src/modules/user/user.domain';
+
+const userOwnerMock = User.build({
+  id: 1,
+  userId: 'userId',
+  name: 'User Owner',
+  lastname: 'Lastname',
+  email: 'fake@internxt.com',
+  username: 'fake',
+  bridgeUser: null,
+  rootFolderId: 1,
+  errorLoginCount: 0,
+  isEmailActivitySended: 1,
+  referralCode: null,
+  referrer: null,
+  syncDate: new Date('2022-09-22T08:06:02.436Z'),
+  uuid: 'uuid',
+  lastResend: new Date('2022-09-22T08:06:02.436Z'),
+  credit: null,
+  welcomePack: true,
+  registerCompleted: true,
+  backupsBucket: 'bucket',
+  sharedWorkspace: true,
+  avatar: 'avatar',
+  password: '',
+  mnemonic: '',
+  hKey: undefined,
+  secret_2FA: '',
+  tempKey: '',
+});
+
+const mockFile = File.build({
+  id: 1,
+  fileId: 'fileId',
+  name: 'File 1',
+  type: 'png',
+  size: null,
+  bucket: 'bucket',
+  folderId: 1,
+  encryptVersion: '',
+  deleted: false,
+  deletedAt: undefined,
+  userId: 1,
+  modificationTime: new Date('2022-09-22T08:06:02.436Z'),
+  createdAt: new Date('2022-09-22T08:06:02.436Z'),
+  updatedAt: new Date('2022-09-22T08:06:02.436Z'),
+});
+
+export class ShareMother {
+  static createWithPassword(hashedPassword: string): Share {
+    return Share.build({
+      id: 1,
+      token: 'token',
+      mnemonic: 'test',
+      user: userOwnerMock,
+      item: mockFile,
+      encryptionKey: 'test',
+      bucket: 'test',
+      itemToken: 'token',
+      isFolder: false,
+      views: 0,
+      timesValid: 10,
+      active: true,
+      createdAt: new Date('2022-09-22T08:06:02.436Z'),
+      updatedAt: new Date('2022-09-22T08:06:02.436Z'),
+      hashedPassword,
+    });
+  }
+}

--- a/test/share.mother.ts
+++ b/test/share.mother.ts
@@ -1,71 +1,43 @@
-import { File } from './../src/modules/file/file.domain';
+import { Folder } from './../src/modules/folder/folder.domain';
 import { Share } from './../src/modules/share/share.domain';
-import { User } from './../src/modules/user/user.domain';
 
-const userOwnerMock = User.build({
+const mockFolder = Folder.build({
   id: 1,
-  userId: 'userId',
-  name: 'User Owner',
-  lastname: 'Lastname',
-  email: 'fake@internxt.com',
-  username: 'fake',
-  bridgeUser: null,
-  rootFolderId: 1,
-  errorLoginCount: 0,
-  isEmailActivitySended: 1,
-  referralCode: null,
-  referrer: null,
-  syncDate: new Date('2022-09-22T08:06:02.436Z'),
-  uuid: 'uuid',
-  lastResend: new Date('2022-09-22T08:06:02.436Z'),
-  credit: null,
-  welcomePack: true,
-  registerCompleted: true,
-  backupsBucket: 'bucket',
-  sharedWorkspace: true,
-  avatar: 'avatar',
-  password: '',
-  mnemonic: '',
-  hKey: undefined,
-  secret_2FA: '',
-  tempKey: '',
-});
-
-const mockFile = File.build({
-  id: 1,
-  fileId: 'fileId',
-  name: 'File 1',
-  type: 'png',
-  size: null,
+  parentId: 529,
+  name: 'ONzgORtJ77qI28jDnr+GjwJn6xELsAEqsn3FKlKNYbHR7Z129AD/WOMkAChEKx6rm7hOER2drdmXmC296dvSXtE5y5os0XCS554YYc+dcCOvvzjCQr6p+/BdhHlgRYg8cssug7p9DonVw19e',
   bucket: 'bucket',
-  folderId: 1,
-  encryptVersion: '',
-  deleted: false,
-  deletedAt: undefined,
   userId: 1,
-  modificationTime: new Date('2022-09-22T08:06:02.436Z'),
-  createdAt: new Date('2022-09-22T08:06:02.436Z'),
-  updatedAt: new Date('2022-09-22T08:06:02.436Z'),
+  encryptVersion: '2',
+  deleted: true,
+  deletedAt: new Date(),
+  createdAt: new Date(),
+  updatedAt: new Date(),
 });
 
 export class ShareMother {
   static createWithPassword(hashedPassword: string): Share {
-    return Share.build({
+    const share = Share.build({
       id: 1,
       token: 'token',
       mnemonic: 'test',
-      user: userOwnerMock,
-      item: mockFile,
-      encryptionKey: 'test',
       bucket: 'test',
-      itemToken: 'token',
-      isFolder: false,
+      isFolder: true,
       views: 0,
       timesValid: 10,
       active: true,
       createdAt: new Date('2022-09-22T08:06:02.436Z'),
       updatedAt: new Date('2022-09-22T08:06:02.436Z'),
       hashedPassword,
+      userId: 3165201048,
+      fileId: null,
+      fileSize: null,
+      folderId: 50,
+      code: 'code',
+      fileToken: 'fileToken',
     });
+
+    share.item = mockFolder;
+
+    return share;
   }
 }

--- a/test/user.mother.ts
+++ b/test/user.mother.ts
@@ -1,0 +1,36 @@
+import { User } from './../src/modules/user/user.domain';
+
+const userMock = User.build({
+  id: 2,
+  userId: 'userId',
+  name: 'User Owner',
+  lastname: 'Lastname',
+  email: 'fake@internxt.com',
+  username: 'fake',
+  bridgeUser: null,
+  rootFolderId: 1,
+  errorLoginCount: 0,
+  isEmailActivitySended: 1,
+  referralCode: null,
+  referrer: null,
+  syncDate: new Date(),
+  uuid: 'uuid',
+  lastResend: new Date(),
+  credit: null,
+  welcomePack: true,
+  registerCompleted: true,
+  backupsBucket: 'bucket',
+  sharedWorkspace: true,
+  avatar: 'avatar',
+  password: '',
+  mnemonic: '',
+  hKey: undefined,
+  secret_2FA: '',
+  tempKey: '',
+});
+
+export class UserMother {
+  static create(): User {
+    return userMock;
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1139,6 +1139,11 @@
   resolved "https://registry.yarnpkg.com/@types/cookiejar/-/cookiejar-2.1.2.tgz#66ad9331f63fe8a3d3d9d8c6e3906dd10f6446e8"
   integrity sha512-t73xJJrvdTjXrn4jLS9VSGRbz0nUY3cl2DMGDU48lKl+HR9dbbjW2A9r3g40VA++mQpy6uuHg33gy7du2BKpog==
 
+"@types/crypto-js@^4.1.1":
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/@types/crypto-js/-/crypto-js-4.1.1.tgz#602859584cecc91894eb23a4892f38cfa927890d"
+  integrity sha512-BG7fQKZ689HIoc5h+6D2Dgq1fABRa0RbBWKBd9SP/MVRVXROflpm5fhwyATX5duFmbStzyzyycPB8qUYKDH3NA==
+
 "@types/debug@^4.1.7":
   version "4.1.7"
   resolved "https://registry.yarnpkg.com/@types/debug/-/debug-4.1.7.tgz#7cc0ea761509124709b8b2d1090d8f6c17aadb82"


### PR DESCRIPTION
### Added password protection for share and send-links

Both models have a new field `hashed_password` that is nullable. When a new share of send-link is created if its not null the matching password will be needed access the resource.

To send the password it needs to be added to `x-share-password` or `x-send-password`.
To increase the views of a share its needed too. 

### Changed the file and folder decryption

In order to use the encrypt and decrypt methods of the crypto service it needs to have access to the environment variables. Previously couldn't be used on any usecase due to way nestj initializes the modules. When the singleton was created, the .env file was not loaded resulting on `undefined` variables.

Now the decryption is done when we send a file or a folder to the http layer.
⚠️  This part provably will need a refactor
