### PR TITLE
[_]: fix/create-index-folders-using-bucket-field

### DIFF
--- a/migrations/20221003080000-create-index-folders-bucket.js
+++ b/migrations/20221003080000-create-index-folders-bucket.js
@@ -1,0 +1,14 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface) => {
+    return queryInterface.addIndex('folders', {
+      fields: ['bucket'],
+      name: 'bucket_index',
+    });
+  },
+
+  down: async (queryInterface) => {
+    return queryInterface.removeIndex('folders', 'bucket_index');
+  },
+};


### PR DESCRIPTION
Changes introduced:
- Creates an index with the field `bucket` from the `folders` table. 
 
This fixes the slow response from the database when the folders table starts to be big enough to make a select by this field to find the folders. Backups rely on this field a lot, so the response starts to be slow in those cases where backups are involved.