### PR TITLE
[_]: fix/share-files-from-shared-workspaces

### DIFF
--- a/src/modules/file/file.repository.ts
+++ b/src/modules/file/file.repository.ts
@@ -94,6 +94,11 @@ export interface FileRepository {
     userId: FileAttributes['userId'],
     options: FileOptions,
   ): Promise<File | null>;
+  findOneFromMultipleUsers(
+    fileId: FileAttributes['id'],
+    usersIds: FileAttributes['userId'][],
+    options: FileOptions,
+  ): Promise<File | null>;
   updateByFieldIdAndUserId(
     fileId: FileAttributes['fileId'],
     userId: FileAttributes['userId'],
@@ -170,6 +175,23 @@ export class SequelizeFileRepository implements FileRepository {
       where: {
         id: fileId,
         userId,
+        deleted,
+      },
+    });
+    return file ? this.toDomain(file) : null;
+  }
+
+  async findOneFromMultipleUsers(
+    fileId: number,
+    usersIds: number[],
+    { deleted }: FileOptions,
+  ): Promise<File | null> {
+    const file = await this.fileModel.findOne({
+      where: {
+        id: fileId,
+        userId: {
+          [Op.or]: usersIds,
+        },
         deleted,
       },
     });

--- a/src/modules/user/user.domain.ts
+++ b/src/modules/user/user.domain.ts
@@ -130,6 +130,10 @@ export class User implements UserAttributes {
     return this._rootFolder;
   }
 
+  isGuestOnSharedWorkspace(): boolean {
+    return !(this.email === this.bridgeUser);
+  }
+
   toJSON() {
     return {
       id: this.id,

--- a/src/modules/user/user.repository.ts
+++ b/src/modules/user/user.repository.ts
@@ -127,6 +127,7 @@ export class UserModel extends Model implements UserAttributes {
 export interface UserRepository {
   findById(id: number): Promise<User | null>;
   findAllBy(where: any): Promise<Array<User> | []>;
+  findByBridgeUser(bridgeUser: User['bridgeUser']): Promise<User | null>;
   findByUsername(username: string): Promise<User | null>;
   toDomain(model: UserModel): User;
   toModel(domain: User): Partial<UserAttributes>;
@@ -145,6 +146,12 @@ export class SequelizeUserRepository implements UserRepository {
 
   createTransaction(): Promise<Transaction> {
     return this.modelUser.sequelize.transaction();
+  }
+
+  async findByBridgeUser(bridgeUser: string): Promise<User | null> {
+    const user = await this.modelUser.findOne({ where: { bridgeUser } });
+
+    return user ? this.toDomain(user) : null;
   }
 
   findOrCreate(opts: FindOrCreateOptions): Promise<[User | null, boolean]> {


### PR DESCRIPTION
The file sharing was not handled for cases when the file is created by a guest on shared workspaces. 

The solution is using the network credentials from the host + checking which is the owner of the file when sharing that file on a shared workspace (sometimes is the host, sometimes is some guest, both can share files from each other if they want). 