### PR TITLE
[_]: fix/list-shares-shared-workspace

### DIFF
--- a/src/modules/share/share.repository.ts
+++ b/src/modules/share/share.repository.ts
@@ -21,6 +21,7 @@ import { UserModel } from '../user/user.repository';
 import { FolderModel } from '../folder/folder.repository';
 import { Folder, FolderAttributes } from '../folder/folder.domain';
 import { Pagination } from '../../lib/pagination';
+import { Op } from 'sequelize';
 
 @Table({
   underscored: true,
@@ -98,7 +99,7 @@ export class ShareModel extends Model {
 export interface ShareRepository {
   findById(id: number): Promise<Share | null>;
   findByToken(token: string): Promise<Share | null>;
-  findAllByUserPaginated(
+  findAllByUsersPaginated(
     user: any,
     page: number,
     perPage: number,
@@ -220,8 +221,8 @@ export class SequelizeShareRepository implements ShareRepository {
     await this.shareModel.destroy({ where: { id: shareId } });
   }
 
-  async findAllByUserPaginated(
-    user: User,
+  async findAllByUsersPaginated(
+    users: User[],
     page: number,
     perPage: number,
     orderBy?: 'views:ASC' | 'views:DESC' | 'createdAt:ASC' | 'createdAt:DESC',
@@ -234,7 +235,9 @@ export class SequelizeShareRepository implements ShareRepository {
 
     const shares = await this.shareModel.findAndCountAll({
       where: {
-        user_id: user.id,
+        user_id: {
+          [Op.or]: users.map((u) => u.id),
+        },
       },
       include: [
         this.userModel,

--- a/src/modules/share/share.repository.ts
+++ b/src/modules/share/share.repository.ts
@@ -103,7 +103,7 @@ export interface ShareRepository {
     user: any,
     page: number,
     perPage: number,
-  ): Promise<{ count: number; items: Array<Share> | [] }>;
+  ): Promise<Share[]>;
   update(share: Share): Promise<void>;
   deleteById(shareId: Share['id']): Promise<void>;
   create(share: Share): Promise<Share>;
@@ -226,14 +226,14 @@ export class SequelizeShareRepository implements ShareRepository {
     page: number,
     perPage: number,
     orderBy?: 'views:ASC' | 'views:DESC' | 'createdAt:ASC' | 'createdAt:DESC',
-  ): Promise<{ count: number; items: Array<Share> }> {
+  ): Promise<Share[]> {
     const { offset, limit } = Pagination.calculatePagination(page, perPage);
 
     const order = orderBy
       ? [orderBy.split(':') as [string, string]]
       : undefined;
 
-    const shares = await this.shareModel.findAndCountAll({
+    const shares = await this.shareModel.findAll({
       where: {
         user_id: {
           [Op.or]: users.map((u) => u.id),
@@ -260,12 +260,7 @@ export class SequelizeShareRepository implements ShareRepository {
       limit,
       order,
     });
-    return {
-      count: shares.count,
-      items: shares.rows.map((share) => {
-        return this.toDomain(share);
-      }),
-    };
+    return shares.map(this.toDomain.bind(this));
   }
 
   private toDomain(model: ShareModel): Share {

--- a/src/modules/share/share.usecase.ts
+++ b/src/modules/share/share.usecase.ts
@@ -147,13 +147,21 @@ export class ShareUseCases {
   }
 
   async listByUserPaginated(
-    user: any,
+    user: User,
     page = 0,
     perPage = 50,
     orderBy?: 'views:ASC' | 'views:DESC' | 'createdAt:ASC' | 'createdAt:DESC',
   ) {
-    const { count, items } = await this.shareRepository.findAllByUserPaginated(
-      user,
+    const sharesUsersOwners = [user];
+
+    if (user.isGuestOnSharedWorkspace()) {
+      const host = await this.usersRepository.findByBridgeUser(user.bridgeUser);
+
+      sharesUsersOwners.push(host);
+    }
+
+    const { count, items } = await this.shareRepository.findAllByUsersPaginated(
+      sharesUsersOwners,
       page,
       perPage,
       orderBy,

--- a/src/modules/share/share.usecase.ts
+++ b/src/modules/share/share.usecase.ts
@@ -160,7 +160,7 @@ export class ShareUseCases {
       sharesUsersOwners.push(host);
     }
 
-    const { count, items } = await this.shareRepository.findAllByUsersPaginated(
+    const shares = await this.shareRepository.findAllByUsersPaginated(
       sharesUsersOwners,
       page,
       perPage,
@@ -171,10 +171,9 @@ export class ShareUseCases {
       pagination: {
         page,
         perPage,
-        countAll: count,
         orderBy,
       },
-      items: items.map((share) => {
+      items: shares.map((share) => {
         return {
           id: share.id,
           token: share.token,


### PR DESCRIPTION
Listing shares was not handled for shared workspaces. 

Listing shares whose owner is the host or any guest solves this issue.

These changes also remove the usage of a total count which is completely unnecessary and an overload for the database.