### PR TITLE
[MT-83] fix: sign token with payload correctly

### DIFF
--- a/src/middlewares/passport.ts
+++ b/src/middlewares/passport.ts
@@ -2,10 +2,23 @@ import jwt from 'jsonwebtoken';
 import passport from 'passport';
 
 export const passportAuth = passport.authenticate('jwt', { session: false });
-export function Sign(data: any, secret: string, expires = false): string {
+
+export function SignEmail(
+  email: string,
+  secret: string,
+  expires = false,
+): string {
   const token = expires
-    ? jwt.sign({ email: data }, secret, { expiresIn: '14d' })
-    : jwt.sign(data, secret);
+    ? jwt.sign({ email }, secret, { expiresIn: '14d' })
+    : jwt.sign({ email }, secret);
+
+  return token;
+}
+
+export function Sign(payload: object, secret: string, expires = false): string {
+  const token = expires
+    ? jwt.sign(payload, secret, { expiresIn: '14d' })
+    : jwt.sign(payload, secret);
 
   return token;
 }

--- a/src/modules/user/user.usecase.ts
+++ b/src/modules/user/user.usecase.ts
@@ -399,6 +399,7 @@ export class UserUseCases {
         },
       },
       this.configService.get('secrets.jwt'),
+      expires,
     );
 
     return { token, newToken };

--- a/src/modules/user/user.usecase.ts
+++ b/src/modules/user/user.usecase.ts
@@ -16,7 +16,7 @@ import { FolderUseCases } from '../folder/folder.usecase';
 import { BridgeService } from '../../externals/bridge/bridge.service';
 import { InvitationAcceptedEvent } from '../../externals/notifications/events/invitation-accepted.event';
 import { NotificationService } from '../../externals/notifications/notification.service';
-import { Sign } from '../../middlewares/passport';
+import { Sign, SignEmail } from '../../middlewares/passport';
 import { SequelizeSharedWorkspaceRepository } from '../../shared-workspace/shared-workspace.repository';
 import { SequelizeReferralRepository } from './referrals.repository';
 import { SequelizeUserReferralsRepository } from './user-referrals.repository';
@@ -221,7 +221,10 @@ export class UserUseCases {
         transaction,
       );
 
-      const token = Sign(newUser.email, this.configService.get('secrets.jwt'));
+      const token = SignEmail(
+        newUser.email,
+        this.configService.get('secrets.jwt'),
+      );
       const bucket = await this.networkService.createBucket(email, userId);
       const rootFolderName = await this.cryptoService.encryptName(
         `${bucket.name}`,
@@ -374,7 +377,12 @@ export class UserUseCases {
   }
 
   getAuthTokens(user: User): { token: string; newToken: string } {
-    const token = Sign(user.email, this.configService.get('secrets.jwt'), true);
+    const expires = true;
+    const token = SignEmail(
+      user.email,
+      this.configService.get('secrets.jwt'),
+      expires,
+    );
     const newToken = Sign(
       {
         payload: {
@@ -391,7 +399,6 @@ export class UserUseCases {
         },
       },
       this.configService.get('secrets.jwt'),
-      true,
     );
 
     return { token, newToken };


### PR DESCRIPTION
Fix new token payload not being wrapped inside the `email` element.

Example of the `newToken` payload data:
```json
{
  "payload": {
    "uuid": "e46732fa-5443-46f9-897b-1cf0b32bf259",
    "email": "pr@internxt.com",
    "name": "My",
    "lastname": "Internxt",
    "username": "pr@internxt.com",
    "sharedWorkspace": true,
    "networkCredentials": {
      "user": "jvalles@internxt.com",
      "pass": "$2a$08$74gAUBkBLswuQYuYsM/A3OnhoHu.Jds32tu3N/LkxD0w277Ka8ncG"
    }
  },
  "iat": 1669733468,
  "exp": 1670943741
}
```
