### PR TITLE
[_]: fix/allow-failed-signups-to-register

### DIFF
--- a/src/config/configuration.ts
+++ b/src/config/configuration.ts
@@ -38,6 +38,7 @@ export default () => ({
     cryptoSecret: process.env.CRYPTO_SECRET,
     cryptoSecret2: process.env.CRYPTO_SECRET2,
     jwt: process.env.JWT_SECRET,
+    gateway: process.env.GATEWAY_SECRET,
   },
   apis: {
     notifications: {

--- a/src/modules/user/user.usecase.ts
+++ b/src/modules/user/user.usecase.ts
@@ -282,7 +282,7 @@ export class UserUseCases {
         userResult.bridgeUser,
         userId,
       ).catch((err) => {
-        Logger.error('[SIGNUP/SUBSCRIPTION/ERROR]: %s. %s', err.message, err.stack || 'NO STACK');
+        Logger.error(`[SIGNUP/SUBSCRIPTION/ERROR]: ${err.message}. ${err.stack || 'NO STACK'}`);
         notifySignUpError(err);
         return false;
       });
@@ -297,7 +297,7 @@ export class UserUseCases {
 
       await transaction.commit();
     } catch (err) {
-      Logger.error('[SIGNUP/NETWORK/ERROR]: %s. %s', err.message, err.stack || 'NO STACK');
+      Logger.error(`[SIGNUP/NETWORK/ERROR]: ${err.message}, ${err.stack || 'NO STACK'}`);
       notifySignUpError(err);
       await transaction.rollback().catch(notifySignUpError);
       throw err;
@@ -340,7 +340,7 @@ export class UserUseCases {
         uuid: userUuid,
       };
     } catch (err) {
-      Logger.error('[SIGNUP/ROOT_FOLDER/ERROR]: %s. %s', err.message, err.stack || 'NO STACK');
+      Logger.error(`[SIGNUP/ROOT_FOLDER/ERROR]: ${err.message}. ${err.stack || 'NO STACK'}`);
       notifySignUpError(err);
 
       throw err;


### PR DESCRIPTION
These changes allow a failed signup to signup again. 

**_Issue_**
We create one account on Drive and one in our network for each signup. When the network account was created successfully but the Drive one did not, the user was not able to signup again as the network was rejecting the email as it already existed. 

**_Solution_**
Calling to a gateway endpoint on the network that creates or updates the user if already exists. Therefore, if the signup fails, as long as the Drive account does not exist, the user will be able to signup again. 
