### PR TITLE
[_]: feat/add-folder-uuid-files-index

### DIFF
--- a/migrations/20230216192042-create-index-folder-uuid-files.js
+++ b/migrations/20230216192042-create-index-folder-uuid-files.js
@@ -1,0 +1,16 @@
+'use strict';
+
+const indexName = 'files_folder_uuid_index';
+
+module.exports = {
+  async up(queryInterface) {
+    await queryInterface.addIndex('files', {
+      fields: ['folder_uuid'],
+      name: indexName,
+    });
+  },
+
+  async down(queryInterface) {
+    await queryInterface.removeIndex('files', indexName);
+  },
+};


### PR DESCRIPTION
As we are moving to UUIDs, the relation between files and folders is through these UUIDs, so we need to index them for the high usage they are going to get. 