### PR TITLE
[_]: feat/mark-resources-as-removed

### DIFF
--- a/migrations/20230508130907-add-removed-column-to-folders.js
+++ b/migrations/20230508130907-add-removed-column-to-folders.js
@@ -1,0 +1,20 @@
+'use strict';
+
+const tableName = 'folders';
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.addColumn(tableName, 'removed', {
+      type: Sequelize.BOOLEAN,
+      defaultValue: false,
+      allowNull: false
+    });
+
+    await queryInterface.addColumn(tableName, 'removed_at', { type: Sequelize.DATE });
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.removeColumn(tableName, 'removed');
+    await queryInterface.removeColumn(tableName, 'removed_at');
+  }
+};

--- a/src/modules/file/dto/file.dto.ts
+++ b/src/modules/file/dto/file.dto.ts
@@ -12,10 +12,12 @@ export class FileDto {
   folderUuid: FolderDto['uuid'];
   encryptVersion: string;
   deleted: boolean;
+  removed: boolean;
   deletedAt: Date;
   userId: number;
   plainName: string;
   modificationTime: Date;
   createdAt: Date;
   updatedAt: Date;
+  removedAt: Date;
 }

--- a/src/modules/file/file.domain.ts
+++ b/src/modules/file/file.domain.ts
@@ -28,6 +28,7 @@ export interface FileAttributes {
 
 export interface FileOptions {
   deleted: FileAttributes['deleted'];
+  removed?: FileAttributes['removed'];
   page?: number;
   perPage?: number;
 }

--- a/src/modules/file/file.domain.ts
+++ b/src/modules/file/file.domain.ts
@@ -154,6 +154,8 @@ export class File implements FileAttributes {
       createdAt: this.createdAt,
       updatedAt: this.updatedAt,
       plainName: this.plainName,
+      removed: this.removed,
+      removedAt: this.removedAt,
     };
   }
 }

--- a/src/modules/file/file.domain.ts
+++ b/src/modules/file/file.domain.ts
@@ -16,6 +16,8 @@ export interface FileAttributes {
   encryptVersion: string;
   deleted: boolean;
   deletedAt: Date;
+  removed: boolean;
+  removedAt: Date;
   userId: number;
   user?: any;
   modificationTime: Date;
@@ -43,12 +45,14 @@ export class File implements FileAttributes {
   folderUuid: string;
   encryptVersion: string;
   deleted: boolean;
+  removed: boolean;
   deletedAt: Date;
   userId: number;
   user: User;
   modificationTime: Date;
   createdAt: Date;
   updatedAt: Date;
+  removedAt: Date;
   plainName: string;
 
   private constructor({

--- a/src/modules/file/file.repository.ts
+++ b/src/modules/file/file.repository.ts
@@ -325,6 +325,7 @@ export class SequelizeFileRepository implements FileRepository {
   async deleteFilesByUser(user: User, files: File[]): Promise<void> {
     await this.fileModel.update({
       removed: true,
+      removedAt: new Date(),
     }, {
       where: {
         userId: user.id,

--- a/src/modules/file/file.repository.ts
+++ b/src/modules/file/file.repository.ts
@@ -68,6 +68,10 @@ export class FileModel extends Model implements FileAttributes {
 
   @Default(false)
   @Column
+  removed: boolean;
+
+  @Default(false)
+  @Column
   deleted: boolean;
 
   @AllowNull
@@ -89,6 +93,9 @@ export class FileModel extends Model implements FileAttributes {
 
   @Column
   updatedAt: Date;
+
+  @Column
+  removedAt: Date;
 
   @Index
   @Column
@@ -131,7 +138,7 @@ export class SequelizeFileRepository implements FileRepository {
   constructor(
     @InjectModel(FileModel)
     private fileModel: typeof FileModel,
-  ) {}
+  ) { }
 
   async findAll(): Promise<Array<File> | []> {
     const files = await this.fileModel.findAll();
@@ -316,7 +323,9 @@ export class SequelizeFileRepository implements FileRepository {
   }
 
   async deleteFilesByUser(user: User, files: File[]): Promise<void> {
-    await this.fileModel.destroy({
+    await this.fileModel.update({
+      removed: true,
+    }, {
       where: {
         userId: user.id,
         id: {

--- a/src/modules/file/file.usecase.ts
+++ b/src/modules/file/file.usecase.ts
@@ -29,7 +29,7 @@ export class FileUseCases {
     private folderUsecases: FolderUseCases,
     private network: BridgeService,
     private cryptoService: CryptoService,
-  ) {}
+  ) { }
 
   getByFileIdAndUser(
     fileId: FileAttributes['id'],
@@ -166,11 +166,6 @@ export class FileUseCases {
    * @param files Files to be deleted
    */
   async deleteByUser(user: User, files: File[]): Promise<void> {
-    for (const file of files) {
-      if (file.isOwnedBy(user)) {
-        await this.network.deleteFile(user, file.bucket, file.fileId);
-      }
-    }
     await this.fileRepository.deleteFilesByUser(user, files);
   }
 

--- a/src/modules/folder/dto/folder.dto.ts
+++ b/src/modules/folder/dto/folder.dto.ts
@@ -8,7 +8,9 @@ export class FolderDto {
   encryptVersion: '03-aes';
   plainName: string;
   size: number;
+  removed: boolean;
   deleted: boolean;
+  removedAt: Date;
   deletedAt: Date;
   createdAt: Date;
   updatedAt: Date;

--- a/src/modules/folder/folder.attributes.ts
+++ b/src/modules/folder/folder.attributes.ts
@@ -10,7 +10,9 @@ export interface FolderAttributes {
   plainName: string;
   encryptVersion: '03-aes';
   deleted: boolean;
+  removed: boolean;
   deletedAt: Date;
   createdAt: Date;
   updatedAt: Date;
+  removedAt: Date;
 }

--- a/src/modules/folder/folder.domain.ts
+++ b/src/modules/folder/folder.domain.ts
@@ -4,6 +4,7 @@ import { FolderAttributes } from './folder.attributes';
 
 export interface FolderOptions {
   deleted: FolderAttributes['deleted'];
+  removed?: FolderAttributes['removed'];
 }
 
 export class Folder implements FolderAttributes {

--- a/src/modules/folder/folder.domain.ts
+++ b/src/modules/folder/folder.domain.ts
@@ -19,6 +19,8 @@ export class Folder implements FolderAttributes {
   plainName: string;
   encryptVersion: FolderAttributes['encryptVersion'];
   deleted: boolean;
+  removed: boolean;
+  removedAt: Date;
   deletedAt: Date;
   createdAt: Date;
   updatedAt: Date;
@@ -100,6 +102,8 @@ export class Folder implements FolderAttributes {
       plainName: this.plainName,
       size: this.size,
       deleted: this.deleted,
+      removed: this.removed,
+      removedAt: this.removedAt,
       deletedAt: this.deletedAt,
       createdAt: this.createdAt,
       updatedAt: this.updatedAt,

--- a/src/modules/folder/folder.model.ts
+++ b/src/modules/folder/folder.model.ts
@@ -65,6 +65,10 @@ export class FolderModel extends Model implements FolderAttributes {
   @Column
   deleted: boolean;
 
+  @Default(false)
+  @Column
+  removed: boolean;
+
   @AllowNull
   @Column
   deletedAt: Date;
@@ -74,4 +78,7 @@ export class FolderModel extends Model implements FolderAttributes {
 
   @Column
   updatedAt: Date;
+
+  @Column
+  removedAt: Date;
 }

--- a/src/modules/folder/folder.repository.ts
+++ b/src/modules/folder/folder.repository.ts
@@ -289,6 +289,7 @@ export class SequelizeFolderRepository implements FolderRepository {
   async deleteByUser(user: User, folders: Folder[]): Promise<void> {
     await this.folderModel.update({
       removed: true,
+      removedAt: new Date(),
     }, {
       where: {
         userId: user.id,

--- a/src/modules/folder/folder.repository.ts
+++ b/src/modules/folder/folder.repository.ts
@@ -52,7 +52,7 @@ export class SequelizeFolderRepository implements FolderRepository {
     private folderModel: typeof FolderModel,
     @InjectModel(UserModel)
     private userModel: typeof UserModel,
-  ) {}
+  ) { }
 
   async findAll(where = {}): Promise<Array<Folder> | []> {
     const folders = await this.folderModel.findAll({ where });
@@ -287,7 +287,9 @@ export class SequelizeFolderRepository implements FolderRepository {
   }
 
   async deleteByUser(user: User, folders: Folder[]): Promise<void> {
-    await this.folderModel.destroy({
+    await this.folderModel.update({
+      removed: true,
+    }, {
       where: {
         userId: user.id,
         id: {

--- a/src/modules/folder/folder.usecase.ts
+++ b/src/modules/folder/folder.usecase.ts
@@ -26,7 +26,7 @@ export class FolderUseCases {
     @Inject(forwardRef(() => FileUseCases))
     private fileUseCases: FileUseCases,
     private readonly cryptoService: CryptoService,
-  ) {}
+  ) { }
 
   getFoldersByIds(user: User, folderIds: FolderAttributes['id'][]) {
     return this.folderRepository.findByIds(user, folderIds);

--- a/src/modules/trash/trash.controller.ts
+++ b/src/modules/trash/trash.controller.ts
@@ -50,7 +50,7 @@ export class TrashController {
     private userUseCases: UserUseCases,
     private notificationService: NotificationService,
     private trashUseCases: TrashUseCases,
-  ) {}
+  ) { }
 
   @Get('/')
   @HttpCode(200)
@@ -120,13 +120,13 @@ export class TrashController {
         // Root level could have different folders
         result = await this.fileUseCases.getFiles(
           user.id,
-          { deleted: true },
+          { deleted: true, removed: false },
           { limit, offset },
         );
       } else {
         result = await this.folderUseCases.getFolders(
           user.id,
-          { deleted: true },
+          { deleted: true, removed: false },
           { limit, offset },
         );
       }
@@ -214,7 +214,7 @@ export class TrashController {
 
       new Logger().error(
         `[TRASH/ADD] ERROR: ${(err as Error).message}, BODY ${JSON.stringify(
-          { ...moveItemsDto, user: { email, uuid }},
+          { ...moveItemsDto, user: { email, uuid } },
         )}, STACK: ${(err as Error).stack}`,
       );
       res.status(HttpStatus.INTERNAL_SERVER_ERROR);

--- a/src/modules/trash/trash.controller.ts
+++ b/src/modules/trash/trash.controller.ts
@@ -52,33 +52,6 @@ export class TrashController {
     private trashUseCases: TrashUseCases,
   ) { }
 
-  @Get('/')
-  @HttpCode(200)
-  @ApiOperation({
-    summary: 'Get trash content',
-  })
-  @ApiOkResponse({ description: 'Get all folders and files in trash' })
-  async getTrash(@UserDecorator() user: User) {
-    const folderId = user.rootFolderId;
-    const [currentFolder, childrenFolders] = await Promise.all([
-      this.folderUseCases.getFolder(folderId),
-      this.folderUseCases.getFoldersToUser(user.id, { deleted: true }),
-    ]);
-    const childrenFoldersIds = childrenFolders.map(({ id }) => id);
-    const files = await this.fileUseCases.getByUserExceptParents(
-      user.id,
-      childrenFoldersIds,
-      { deleted: true },
-    );
-    return {
-      ...currentFolder.toJSON(),
-      children: childrenFolders.map((folder: Folder) =>
-        this.folderUseCases.decryptFolderName(folder),
-      ),
-      files: files.map((file: File) => this.fileUseCases.decrypFileName(file)),
-    };
-  }
-
   @Get('/paginated')
   @HttpCode(200)
   @ApiOperation({

--- a/src/modules/trash/trash.usecase.ts
+++ b/src/modules/trash/trash.usecase.ts
@@ -10,7 +10,7 @@ export class TrashUseCases {
   constructor(
     private fileUseCases: FileUseCases,
     private folderUseCases: FolderUseCases,
-  ) {}
+  ) { }
 
   /**
    * Tries to find if the trash of a given user is being emptied
@@ -42,7 +42,7 @@ export class TrashUseCases {
     for (let i = 0; i < count; i += emptyTrashChunkSize) {
       const folders = await this.folderUseCases.getFolders(
         trashOwner.id,
-        { deleted: true },
+        { deleted: true, removed: false },
         { limit: emptyTrashChunkSize, offset: i },
       );
 
@@ -52,7 +52,7 @@ export class TrashUseCases {
     for (let i = 0; i < count; i += emptyTrashChunkSize) {
       const files = await this.fileUseCases.getFiles(
         trashOwner.id,
-        { deleted: true },
+        { deleted: true, removed: false },
         { limit: emptyTrashChunkSize, offset: i },
       );
 


### PR DESCRIPTION
Files and folders are marked as removed=true instead of removing the rows. Then, we can get an accurate idea of what actions have been performed and when. Thus, more efficient, simple mirroring could be implemented. 

Also, this allows us to manage all of the removal-related things on the background completely.