### PR TITLE
[_]: feat/split-private-sharing-items-listing

### DIFF
--- a/src/modules/folder/folder.controller.ts
+++ b/src/modules/folder/folder.controller.ts
@@ -298,6 +298,10 @@ export class FolderController {
         user,
       );
 
+      if (!folder) {
+        throw new NotFoundException();
+      }
+
       return folder;
     } catch (err) {
       if (

--- a/src/modules/folder/folder.usecase.ts
+++ b/src/modules/folder/folder.usecase.ts
@@ -72,15 +72,11 @@ export class FolderUseCases {
     return folder;
   }
 
-  async getFolder(
+  getFolder(
     folderId: FolderAttributes['id'],
     { deleted }: FolderOptions = { deleted: false },
   ) {
-    const folder = await this.folderRepository.findById(folderId, deleted);
-    if (!folder) {
-      throw new NotFoundException(`Folder with ID ${folderId} not found`);
-    }
-    return folder;
+    return this.folderRepository.findById(folderId, deleted);
   }
 
   async isFolderInsideFolder(

--- a/src/modules/private-share-folder/dto/get-items-and-shared-folders.dto.ts
+++ b/src/modules/private-share-folder/dto/get-items-and-shared-folders.dto.ts
@@ -13,7 +13,30 @@ export interface GetItemsReponse {
   token: string;
 }
 
+export interface GetFoldersReponse {
+  items: FolderWithSharedInfo[];
+  credentials: {
+    networkPass: User['userId'];
+    networkUser: User['bridgeUser'];
+  };
+  token: string;
+}
+
+export interface GetFilesResponse {
+  items: FileWithSharedInfo[];
+  credentials: {
+    networkPass: User['userId'];
+    networkUser: User['bridgeUser'];
+  };
+  token: string;
+}
 export interface FolderWithSharedInfo extends Folder {
+  encryptionKey: PrivateSharingFolder['encryptionKey'] | null;
+  dateShared: Date | null;
+  sharedWithMe: boolean | null;
+}
+
+export interface FileWithSharedInfo extends File {
   encryptionKey: PrivateSharingFolder['encryptionKey'] | null;
   dateShared: Date | null;
   sharedWithMe: boolean | null;


### PR DESCRIPTION
Changes: 
- Split private sharing items listing in two EPs to make API consumption easier (one for files, one for folders)
- Fix security issues when navigating above shared folder