### PR TITLE
[_] feat: include thumbnails into get files

### DIFF
--- a/src/modules/file/file.usecase.spec.ts
+++ b/src/modules/file/file.usecase.spec.ts
@@ -26,6 +26,8 @@ import { CryptoService } from '../../externals/crypto/crypto.service';
 import { CryptoModule } from '../../externals/crypto/crypto.module';
 import { FileModel } from './file.model';
 import { ThumbnailModel } from '../thumbnail/thumbnail.model';
+import { newThumbnail, newUser } from '../../../test/fixtures';
+
 const fileId = '6295c99a241bb000083f1c6a';
 const userId = 1;
 const folderId = 4;
@@ -514,6 +516,65 @@ describe('FileUseCases', () => {
         expect(err).toBeInstanceOf(Error);
         expect(err.message).toBe('Unable to decrypt file name');
       }
+    });
+  });
+
+  describe('get files', () => {
+    const user = newUser();
+
+    const fileAttributes: FileAttributes = {
+      id: 0,
+      fileId: '4fda5d98-e5b4-56da-a4f2-000084ac0678',
+      name: 'Myanmar',
+      type: 'type',
+      size: BigInt(60),
+      bucket: 'bucket',
+      folderId,
+      folder: null,
+      encryptVersion: 'aes-2',
+      deleted: false,
+      deletedAt: new Date('2022-09-21T11:11:30.742Z'),
+      userId: user.id,
+      user: null,
+      modificationTime: new Date('2022-09-21T11:11:30.742Z'),
+      createdAt: new Date('2022-09-21T11:11:30.742Z'),
+      updatedAt: new Date('2022-09-21T11:11:30.742Z'),
+      uuid: '',
+      folderUuid: '',
+      removed: false,
+      removedAt: undefined,
+      plainName: 'Myanmar',
+      status: FileStatus.EXISTS,
+    };
+
+    const thumbnails = [
+      newThumbnail(fileAttributes),
+      newThumbnail(fileAttributes),
+    ];
+
+    const file = File.build({
+      ...fileAttributes,
+      thumbnails,
+    });
+
+    it('returns the thumbnails for each file', async () => {
+      jest
+        .spyOn(fileRepository, 'findAllCursorWhereUpdatedAfter')
+        .mockResolvedValue([file]);
+
+      const files = await service.getAllFilesUpdatedAfter(
+        user.id,
+        new Date('2000-09-10T11:11:30.742Z'),
+        {
+          limit: 50,
+          offset: 0,
+          sort: ['size']['ASC'],
+        },
+      );
+
+      expect(files.flatMap((file) => file.thumbnails)).toHaveLength(
+        thumbnails.length,
+      );
     });
   });
 });

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -5,7 +5,8 @@ import { Folder } from '../src/modules/folder/folder.domain';
 import { User } from '../src/modules/user/user.domain';
 import { PrivateSharingFolder } from '../src/modules/private-share-folder/private-sharing-folder.domain';
 import { Sharing, SharingRole } from '../src/modules/sharing/sharing.domain';
-import { File } from '../src/modules/file/file.domain';
+import { File, FileAttributes } from '../src/modules/file/file.domain';
+import { Thumbnail } from '../src/modules/thumbnail/thumbnail.domain';
 
 export const constants = {
   BUCKET_ID_LENGTH: 24,
@@ -145,3 +146,19 @@ export const newSharingRole = (bindTo?: {
     updatedAt: randomDataGenerator.date(),
   });
 };
+
+export const newThumbnail = (file: FileAttributes): Thumbnail => {
+  return Thumbnail.build({
+    id: randomDataGenerator.integer({ min: 1 }),
+    fileId: file.id,
+    type: 'png',
+    size: randomDataGenerator.integer({ min: 100, max: 300 }),
+    bucketId: file.bucket,
+    bucketFile: file.fileId,
+    encryptVersion: 'aes-3',
+    createdAt: randomDataGenerator.date(),
+    updatedAt: undefined,
+    maxWidth: 300,
+    maxHeight: 300,
+  });
+}

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -161,4 +161,4 @@ export const newThumbnail = (file: FileAttributes): Thumbnail => {
     maxWidth: 300,
     maxHeight: 300,
   });
-}
+};


### PR DESCRIPTION
On drive destop (windows) we retrive the files info from `api/files`, in order to download the thumbnails we need them to be included on the payload.

I've added a test but since the test are not passing for other reasons and the use case only parses the response of the repository here is also a screenshot of a manual test
![image](https://github.com/internxt/drive-server-wip/assets/38570230/89fc242f-0062-4806-9b4f-256c0c77eaf9)
