### PR TITLE
[PB-1013]: feat/owner-credentials-in-shared-listing

### DIFF
--- a/src/modules/sharing/sharing.repository.ts
+++ b/src/modules/sharing/sharing.repository.ts
@@ -302,7 +302,15 @@ export class SequelizeSharingRepository implements SharingRepository {
             {
               model: UserModel,
               as: 'user',
-              attributes: ['uuid', 'email', 'name', 'lastname', 'avatar'],
+              attributes: [
+                'uuid',
+                'email',
+                'name',
+                'lastname',
+                'avatar',
+                'userId',
+                'bridgeUser',
+              ],
             },
           ],
         },
@@ -352,7 +360,15 @@ export class SequelizeSharingRepository implements SharingRepository {
             {
               model: UserModel,
               as: 'user',
-              attributes: ['uuid', 'email', 'name', 'lastname', 'avatar'],
+              attributes: [
+                'uuid',
+                'email',
+                'name',
+                'lastname',
+                'avatar',
+                'userId',
+                'bridgeUser',
+              ],
             },
           ],
         },


### PR DESCRIPTION
1. Credentials now are not empty when listing items shared by me or with me.