### PR TITLE
[PB-1087] fix: added name to search results

### DIFF
--- a/src/modules/fuzzy-search/look-up.repository.ts
+++ b/src/modules/fuzzy-search/look-up.repository.ts
@@ -83,7 +83,15 @@ export class SequelizeLookUpRepository implements LookUpRepository {
       include: [
         {
           model: FileModel,
-          attributes: ['type', 'id', 'size', 'bucket', 'fileId', 'plainName'],
+          attributes: [
+            'type',
+            'id',
+            'size',
+            'bucket',
+            'fileId',
+            'plainName',
+            'name',
+          ],
           as: 'file',
         },
         {


### PR DESCRIPTION
Please just discard this PR if not necessary as we are using plainName as the main naming source. 

**If all the files have "plainName" then merging this is not necessary, otherwise, please merge it so those files can decrypt 'name' as fallback**

https://github.com/internxt/drive-web/pull/898
