### PR TITLE
fix: invites are not longer being deleted when a new invite is created

### DIFF
--- a/src/modules/sharing/sharing.service.ts
+++ b/src/modules/sharing/sharing.service.ts
@@ -1178,10 +1178,12 @@ export class SharingService {
     itemId: Sharing['itemId'],
     type: Sharing['type'],
   ) {
-    await this.sharingRepository.deleteInvitesBy({
-      itemId,
-      itemType,
-    });
+    if (type === SharingType.Private) {
+      await this.sharingRepository.deleteInvitesBy({
+        itemId,
+        itemType,
+      });
+    }
 
     await this.sharingRepository.deleteSharingsBy({
       itemId,


### PR DESCRIPTION
Creating a new invite was deleting previous invites. Therefore, 1 item was not able to have more than 1 pending invite.

Steps to reproduce:

1. Invite user test@test.com to a shared folder. Dont accept the invite.
2. Invite user test2@test.com. Don't accept the invite.

Expected:
- User 1 and 2 are able to see their invitations.

Actual result:
- Invitation for user 1 is removed. 