### PR TITLE
fix: prevent shared items duplication for owners

### DIFF
--- a/src/modules/sharing/sharing.repository.ts
+++ b/src/modules/sharing/sharing.repository.ts
@@ -313,14 +313,8 @@ export class SequelizeSharingRepository implements SharingRepository {
           'encryptionKey',
         ],
         [sequelize.literal(`MAX("SharingModel"."created_at")`), 'createdAt'],
-        [sequelize.literal(`"SharingModel"."type"`), 'sharingType'],
       ],
-      group: [
-        'folder.id',
-        'folder->user.id',
-        'SharingModel.item_id',
-        'sharingType',
-      ],
+      group: ['folder.id', 'folder->user.id', 'SharingModel.item_id'],
       include: [
         {
           model: FolderModel,
@@ -351,7 +345,6 @@ export class SequelizeSharingRepository implements SharingRepository {
     });
 
     return sharedFolders.map((shared) => {
-      shared.set('type', shared.get('sharingType'));
       return this.toDomain(shared);
     });
   }
@@ -372,14 +365,8 @@ export class SequelizeSharingRepository implements SharingRepository {
           'encryptionKey',
         ],
         [sequelize.literal(`MAX("SharingModel"."created_at")`), 'createdAt'],
-        [sequelize.literal(`"SharingModel"."type"`), 'sharingType'],
       ],
-      group: [
-        'file.id',
-        'file->user.id',
-        'SharingModel.item_id',
-        'sharingType',
-      ],
+      group: ['file.id', 'file->user.id', 'SharingModel.item_id'],
       include: [
         {
           model: FileModel,
@@ -409,7 +396,6 @@ export class SequelizeSharingRepository implements SharingRepository {
     });
 
     return sharedFiles.map((shared) => {
-      shared.set('type', shared.get('sharingType'));
       return this.toDomainFile(shared);
     });
   }

--- a/src/modules/sharing/sharing.service.ts
+++ b/src/modules/sharing/sharing.service.ts
@@ -1526,7 +1526,6 @@ export class SharingService {
             this.folderUsecases.decryptFolderName(folderWithSharedInfo.folder)
               .plainName,
           sharingId: folderWithSharedInfo.id,
-          sharingType: folderWithSharedInfo.type,
           encryptionKey: folderWithSharedInfo.encryptionKey,
           dateShared: folderWithSharedInfo.createdAt,
           sharedWithMe: user.uuid !== folderWithSharedInfo.folder.user.uuid,
@@ -1553,7 +1552,6 @@ export class SharingService {
             fileWithSharedInfo.file.plainName ||
             this.fileUsecases.decrypFileName(fileWithSharedInfo.file).plainName,
           sharingId: fileWithSharedInfo.id,
-          sharingType: fileWithSharedInfo.type,
           encryptionKey: fileWithSharedInfo.encryptionKey,
           dateShared: fileWithSharedInfo.createdAt,
           sharedWithMe: user.uuid !== fileWithSharedInfo.file.user.uuid,
@@ -1606,7 +1604,6 @@ export class SharingService {
             fileWithSharedInfo.file.plainName ||
             this.fileUsecases.decrypFileName(fileWithSharedInfo.file).plainName,
           sharingId: fileWithSharedInfo.id,
-          sharingType: fileWithSharedInfo.type,
           encryptionKey: fileWithSharedInfo.encryptionKey,
           dateShared: fileWithSharedInfo.createdAt,
           sharedWithMe: user.uuid !== fileWithSharedInfo.file.user.uuid,


### PR DESCRIPTION
We had this implemented previously but had to rollback to align with the frontend. Now the frontend does not need this field so we are removing it again to prevent this:

![image](https://github.com/internxt/drive-server-wip/assets/143480783/eebf452e-519c-44fa-800b-84f900cd71cd)
