### PR TITLE
fix: time tolerance to openpgp keys creation

### DIFF
--- a/src/lib/openpgp.ts
+++ b/src/lib/openpgp.ts
@@ -11,7 +11,7 @@ import {
   createMessage,
 } from 'openpgp';
 
-export async function generateNewKeys(): Promise<{
+export async function generateNewKeys(date?: Date): Promise<{
   privateKeyArmored: string;
   publicKeyArmored: string;
   revocationCertificate: string;
@@ -19,6 +19,7 @@ export async function generateNewKeys(): Promise<{
   const { privateKey, publicKey, revocationCertificate } = await generateKey({
     userIDs: [{ email: 'inxt@inxt.com' }],
     curve: 'ed25519',
+    date,
   });
 
   return {

--- a/src/modules/user/user.usecase.ts
+++ b/src/modules/user/user.usecase.ts
@@ -480,10 +480,11 @@ export class UserUseCases {
       defaultPass,
     );
 
-    const creationDateWithTolerance = new Date(Date.now() - 1000);
+    const keysCreationDate = new Date();
+    keysCreationDate.setHours(keysCreationDate.getHours() - 1);
 
     const { privateKeyArmored, publicKeyArmored, revocationCertificate } =
-      await generateNewKeys(creationDateWithTolerance);
+      await generateNewKeys(keysCreationDate);
 
     const encPrivateKey = aes.encrypt(privateKeyArmored, defaultPass, {
       iv: this.configService.get('secrets.magicIv'),

--- a/src/modules/user/user.usecase.ts
+++ b/src/modules/user/user.usecase.ts
@@ -410,9 +410,8 @@ export class UserUseCases {
     newUserUuid: string,
     newPublicKey: string,
   ) {
-    const preCreatedUser = await this.preCreatedUserRepository.findByUsername(
-      email,
-    );
+    const preCreatedUser =
+      await this.preCreatedUserRepository.findByUsername(email);
 
     if (!preCreatedUser) {
       return;
@@ -481,8 +480,10 @@ export class UserUseCases {
       defaultPass,
     );
 
+    const creationDateWithTolerance = new Date(Date.now() - 1000);
+
     const { privateKeyArmored, publicKeyArmored, revocationCertificate } =
-      await generateNewKeys();
+      await generateNewKeys(creationDateWithTolerance);
 
     const encPrivateKey = aes.encrypt(privateKeyArmored, defaultPass, {
       iv: this.configService.get('secrets.magicIv'),


### PR DESCRIPTION
Keys generated backend side are causing a crash on the frontend because of a difference between clocks. This does not happend everytime, it depends on the PC, connection and timezone. 

So to add a little tolerance, we need to rest some seconds to the creationDate of the generated keys. 

Error sent by sentry.
![image](https://github.com/internxt/drive-server-wip/assets/143480783/92990730-cf21-42dd-b87a-ed25f9f44b95)

Error reported on github 
https://github.com/openpgpjs/openpgpjs/issues/1099


Edit:

Changed to 1 hour to have a big marging. We don´t have control of users clock. 

