### PR TITLE
[PB-1468]:(fix) Allow signup with missing keys

### DIFF
--- a/src/modules/keyserver/key-server.usecase.ts
+++ b/src/modules/keyserver/key-server.usecase.ts
@@ -7,9 +7,12 @@ import { SequelizeKeyServerRepository } from './key-server.repository';
 export class KeyServerUseCases {
   constructor(private repository: SequelizeKeyServerRepository) {}
 
-  async addKeysToUser(userId: UserAttributes['id'], keys: Keys): Promise<Keys> {
+  async addKeysToUser(
+    userId: UserAttributes['id'],
+    keys: Keys,
+  ): Promise<Keys | null> {
     if (!keys.privateKey || !keys.publicKey || !keys.revocationKey) {
-      return;
+      return null;
     }
 
     const [{ publicKey, privateKey, revocationKey }] =

--- a/src/modules/user/user.controller.ts
+++ b/src/modules/user/user.controller.ts
@@ -101,7 +101,7 @@ export class UserController {
       await this.userUseCases.replacePreCreatedUser(
         response.user.email,
         response.user.uuid,
-        keys.publicKey,
+        keys?.publicKey,
       );
 
       this.notificationsService.add(

--- a/src/modules/user/user.usecase.ts
+++ b/src/modules/user/user.usecase.ts
@@ -414,7 +414,7 @@ export class UserUseCases {
   async replacePreCreatedUser(
     email: string,
     newUserUuid: string,
-    newPublicKey: string,
+    newPublicKey?: string,
   ) {
     const preCreatedUser =
       await this.preCreatedUserRepository.findByUsername(email);


### PR DESCRIPTION
This PR allows to create an user even when the keys are missing, since not all products are sending the keys on signup right now (mobile at least)