### PR TITLE
[PB-1483]: fix/decode sharing password header

### DIFF
--- a/src/modules/sharing/sharing.controller.ts
+++ b/src/modules/sharing/sharing.controller.ts
@@ -21,6 +21,7 @@ import {
 import { Response } from 'express';
 import {
   ApiBearerAuth,
+  ApiHeader,
   ApiOkResponse,
   ApiOperation,
   ApiParam,
@@ -70,6 +71,10 @@ export class SharingController {
     description: 'Id of the sharing',
     type: String,
   })
+  @ApiHeader({
+    name: 'x-share-password',
+    description: 'URI Encoded password to get access to the sharing',
+  })
   @ApiOkResponse({ description: 'Get sharing metadata' })
   async getPublicSharing(
     @Param('sharingId') sharingId: Sharing['id'],
@@ -79,7 +84,12 @@ export class SharingController {
     if (!code) {
       throw new BadRequestException('Code is required');
     }
-    return this.sharingService.getPublicSharingById(sharingId, code, password);
+    const decodedPassword = password ? decodeURIComponent(password) : null;
+    return this.sharingService.getPublicSharingById(
+      sharingId,
+      code,
+      decodedPassword,
+    );
   }
 
   @Get('/public/:sharingId/item')


### PR DESCRIPTION
Browsers complain when you try to send a password that does not matches with ISO-8859-1 through headers.

![image](https://github.com/internxt/drive-server-wip/assets/143480783/284e4e9b-6bd7-454a-b8e7-dfee7c0584f8)
