### PR TITLE
hotfix: Getting user by uuid because when I update the email and I try to get it by new email immediately,  it doesn't return it updated

### DIFF
--- a/src/modules/user/user.usecase.ts
+++ b/src/modules/user/user.usecase.ts
@@ -934,7 +934,16 @@ export class UserUseCases {
       attemptChangeEmailId,
     );
 
-    const user = await this.userRepository.findByEmail(emails.newEmail);
+    const user = await this.userRepository.findByUuid(
+      attemptChangeEmail.userUuid,
+    );
+
+    if (user.email !== emails.newEmail) {
+      user.email = emails.newEmail;
+      user.username = emails.newEmail;
+      user.bridgeUser = emails.newEmail;
+    }
+
     const newTokenPayload = this.getNewTokenPayload(user);
 
     return {


### PR DESCRIPTION
@apsantiso  in case what you mentioned in Slack about the bug of the change user email feature is correct, we can fix it with this PR.

FYI: @sg-gs 