### PR TITLE
fix: handle workspace users on email change

### DIFF
--- a/src/modules/user/user.repository.ts
+++ b/src/modules/user/user.repository.ts
@@ -23,6 +23,11 @@ export interface UserRepository {
   ): Promise<void>;
   toDomain(model: UserModel): User;
   toModel(domain: User): Partial<UserAttributes>;
+  updateBy(
+    where: Partial<UserAttributes>,
+    update: Partial<UserAttributes>,
+    transaction?: Transaction,
+  ): Promise<void>;
 }
 
 @Injectable()
@@ -103,6 +108,14 @@ export class SequelizeUserRepository implements UserRepository {
     transaction?: Transaction,
   ): Promise<void> {
     await this.modelUser.update(update, { where: { id }, transaction });
+  }
+
+  async updateBy(
+    where: Partial<UserAttributes>,
+    update: Partial<UserAttributes>,
+    transaction?: Transaction,
+  ): Promise<void> {
+    await this.modelUser.update(update, { where, transaction });
   }
 
   async updateByUuid(uuid: User['uuid'], update: Partial<User>): Promise<void> {

--- a/src/modules/user/user.usecase.ts
+++ b/src/modules/user/user.usecase.ts
@@ -934,7 +934,16 @@ export class UserUseCases {
       attemptChangeEmailId,
     );
 
-    const user = await this.userRepository.findByEmail(emails.newEmail);
+    const user = await this.userRepository.findByUuid(
+      attemptChangeEmail.userUuid,
+    );
+
+    if (user.email !== emails.newEmail) {
+      user.email = emails.newEmail;
+      user.username = emails.newEmail;
+      user.bridgeUser = emails.newEmail;
+    }
+
     const newTokenPayload = this.getNewTokenPayload(user);
 
     return {


### PR DESCRIPTION
Introduced changes: 
- Get the user by `uuid` instead of by email when the email is updated to prevent an eventual consistency error
- Update the `bridge_user` respecting how the shared workspace works: 
  - When the user is a host: update the `username`, the `email`, and the `brigde_user` of itself and all the guests
  - When the user is a guest: update the `username` and the `email` only 
  - When there is no shared workspace, update the three fields (just for that user)