### PR TITLE
chore/use automock for missing dependencies in unit tests

### DIFF
--- a/src/modules/file/file.usecase.spec.ts
+++ b/src/modules/file/file.usecase.spec.ts
@@ -1,4 +1,5 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { createMock } from '@golevelup/ts-jest';
 import { FileUseCases } from './file.usecase';
 import { SequelizeFileRepository, FileRepository } from './file.repository';
 import {
@@ -6,26 +7,15 @@ import {
   NotFoundException,
   UnprocessableEntityException,
 } from '@nestjs/common';
-import { getModelToken } from '@nestjs/sequelize';
 import { File, FileAttributes, FileStatus } from './file.domain';
 import { User } from '../user/user.domain';
 import { ShareUseCases } from '../share/share.usecase';
-import { FolderUseCases } from '../folder/folder.usecase';
-import {
-  SequelizeShareRepository,
-  ShareModel,
-} from '../share/share.repository';
-import {
-  FolderModel,
-  SequelizeFolderRepository,
-} from '../folder/folder.repository';
-import { SequelizeUserRepository, UserModel } from '../user/user.repository';
+
 import { BridgeModule } from '../../externals/bridge/bridge.module';
 import { BridgeService } from '../../externals/bridge/bridge.service';
 import { CryptoService } from '../../externals/crypto/crypto.service';
 import { CryptoModule } from '../../externals/crypto/crypto.module';
-import { FileModel } from './file.model';
-import { ThumbnailModel } from '../thumbnail/thumbnail.model';
+
 const fileId = '6295c99a241bb000083f1c6a';
 const userId = 1;
 const folderId = 4;
@@ -69,37 +59,10 @@ describe('FileUseCases', () => {
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       imports: [BridgeModule, CryptoModule],
-      providers: [
-        FileUseCases,
-        SequelizeFileRepository,
-        {
-          provide: getModelToken(FileModel),
-          useValue: jest.fn(),
-        },
-        ShareUseCases,
-        SequelizeShareRepository,
-        {
-          provide: getModelToken(ShareModel),
-          useValue: jest.fn(),
-        },
-        FolderUseCases,
-        SequelizeFolderRepository,
-        {
-          provide: getModelToken(FolderModel),
-          useValue: jest.fn(),
-        },
-        SequelizeUserRepository,
-        {
-          provide: getModelToken(UserModel),
-          useValue: jest.fn(),
-        },
-        {
-          provide: getModelToken(ThumbnailModel),
-          useValue: jest.fn(),
-        },
-        CryptoService,
-      ],
-    }).compile();
+      providers: [FileUseCases, CryptoService],
+    })
+      .useMocker(() => createMock())
+      .compile();
 
     service = module.get<FileUseCases>(FileUseCases);
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment

--- a/src/modules/folder/folder.usecase.spec.ts
+++ b/src/modules/folder/folder.usecase.spec.ts
@@ -1,4 +1,5 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { createMock } from '@golevelup/ts-jest';
 import { FolderUseCases } from './folder.usecase';
 import {
   SequelizeFolderRepository,
@@ -8,24 +9,11 @@ import {
   NotFoundException,
   UnprocessableEntityException,
 } from '@nestjs/common';
-import { getModelToken } from '@nestjs/sequelize';
 import { Folder, FolderAttributes, FolderOptions } from './folder.domain';
-import { FileUseCases } from '../file/file.usecase';
-import { SequelizeFileRepository } from '../file/file.repository';
-import {
-  SequelizeShareRepository,
-  ShareModel,
-} from '../share/share.repository';
-import { ShareUseCases } from '../share/share.usecase';
-import { SequelizeUserRepository, UserModel } from '../user/user.repository';
 import { BridgeModule } from '../../externals/bridge/bridge.module';
 import { CryptoModule } from '../../externals/crypto/crypto.module';
 import { CryptoService } from '../../externals/crypto/crypto.service';
 import { User } from '../user/user.domain';
-import { FolderModel } from './folder.model';
-import { FileModel } from '../file/file.model';
-import { SequelizeThumbnailRepository } from '../thumbnail/thumbnail.repository';
-import { ThumbnailModel } from '../thumbnail/thumbnail.model';
 
 const folderId = 4;
 const userId = 1;
@@ -37,37 +25,10 @@ describe('FolderUseCases', () => {
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       imports: [BridgeModule, CryptoModule],
-      providers: [
-        FolderUseCases,
-        FileUseCases,
-        SequelizeFileRepository,
-        SequelizeFolderRepository,
-        {
-          provide: getModelToken(FolderModel),
-          useValue: jest.fn(),
-        },
-        {
-          provide: getModelToken(FileModel),
-          useValue: jest.fn(),
-        },
-        ShareUseCases,
-        SequelizeShareRepository,
-        SequelizeThumbnailRepository,
-        {
-          provide: getModelToken(ShareModel),
-          useValue: jest.fn(),
-        },
-        SequelizeUserRepository,
-        {
-          provide: getModelToken(ThumbnailModel),
-          useValue: jest.fn(),
-        },
-        {
-          provide: getModelToken(UserModel),
-          useValue: jest.fn(),
-        },
-      ],
-    }).compile();
+      providers: [FolderUseCases],
+    })
+      .useMocker(() => createMock())
+      .compile();
 
     service = module.get<FolderUseCases>(FolderUseCases);
     folderRepository = module.get<FolderRepository>(SequelizeFolderRepository);

--- a/src/modules/send/send.usecase.spec.ts
+++ b/src/modules/send/send.usecase.spec.ts
@@ -16,6 +16,7 @@ import {
   SequelizeSendRepository,
 } from './send-link.repository';
 import { SendUseCases } from './send.usecase';
+import { createMock } from '@golevelup/ts-jest';
 
 describe('Send Use Cases', () => {
   let service: SendUseCases, notificationService, sendRepository;
@@ -80,7 +81,9 @@ describe('Send Use Cases', () => {
           useValue: jest.fn(),
         },
       ],
-    }).compile();
+    })
+      .useMocker(() => createMock())
+      .compile();
 
     service = module.get<SendUseCases>(SendUseCases);
     notificationService = module.get<NotificationService>(NotificationService);

--- a/src/modules/share/share.usecase.spec.ts
+++ b/src/modules/share/share.usecase.spec.ts
@@ -3,71 +3,23 @@ import {
   UnauthorizedException,
   NotFoundException,
 } from '@nestjs/common';
-import { ConfigService } from '@nestjs/config';
-import { getModelToken } from '@nestjs/sequelize';
 import { Test, TestingModule } from '@nestjs/testing';
-import { CryptoModule } from '../../externals/crypto/crypto.module';
-import { BridgeModule } from '../../externals/bridge/bridge.module';
 import { File, FileStatus } from '../file/file.domain';
 import {
   FileRepository,
   SequelizeFileRepository,
 } from '../file/file.repository';
-import { FileUseCases } from '../file/file.usecase';
 import { Folder } from '../folder/folder.domain';
 import {
-  FolderModel,
   FolderRepository,
   SequelizeFolderRepository,
 } from '../folder/folder.repository';
-import { FolderUseCases } from '../folder/folder.usecase';
 import { User } from '../user/user.domain';
-import { SequelizeUserRepository, UserModel } from '../user/user.repository';
-import { UserUseCases } from '../user/user.usecase';
 import { Share, ShareAttributes } from './share.domain';
-import { SequelizeShareRepository, ShareModel } from './share.repository';
+import { SequelizeShareRepository } from './share.repository';
 import { ShareUseCases } from './share.usecase';
 import { CryptoService } from '../../externals/crypto/crypto.service';
-import {
-  FriendInvitationModel,
-  SequelizeSharedWorkspaceRepository,
-} from '../../shared-workspace/shared-workspace.repository';
-import {
-  ReferralModel,
-  SequelizeReferralRepository,
-} from '../user/referrals.repository';
-import {
-  SequelizeUserReferralsRepository,
-  UserReferralModel,
-} from '../user/user-referrals.repository';
-import { PaymentsService } from '../../externals/payments/payments.service';
-import { EventEmitter2 } from '@nestjs/event-emitter';
-import { NotificationService } from '../../externals/notifications/notification.service';
-import { NewsletterService } from '../../externals/newsletter';
-import { HttpClient } from '../../externals/http/http.service';
-import { HttpModule } from '@nestjs/axios';
-import { FileModel } from '../file/file.model';
-import { ThumbnailModel } from '../thumbnail/thumbnail.model';
-import { SequelizeKeyServerRepository } from '../keyserver/key-server.repository';
-import { AvatarService } from '../../externals/avatar/avatar.service';
-import { SequelizePreCreatedUsersRepository } from '../user/pre-created-users.repository';
-import { PreCreatedUserModel } from '../user/pre-created-users.model';
-import { SequelizeSharingRepository } from '../sharing/sharing.repository';
-import {
-  PermissionModel,
-  RoleModel,
-  SharingInviteModel,
-  SharingModel,
-} from '../sharing/models';
-import { SharingRolesModel } from '../sharing/models/sharing-roles.model';
-import { AppSumoUseCase } from '../app-sumo/app-sumo.usecase';
-import { AppSumoModel } from '../app-sumo/app-sumo.model';
-import { SequelizeAppSumoRepository } from '../app-sumo/app-sumo.repository';
-import { SequelizePlanRepository } from '../plan/plan.repository';
-import { PlanModel } from '../plan/plan.model';
-import { SequelizeAttemptChangeEmailRepository } from '../user/attempt-change-email.repository';
 import { createMock } from '@golevelup/ts-jest';
-import { MailerService } from '../../externals/mailer/mailer.service';
 
 describe('Share Use Cases', () => {
   let service: ShareUseCases;
@@ -223,119 +175,10 @@ describe('Share Use Cases', () => {
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      imports: [BridgeModule, CryptoModule, HttpModule],
-      providers: [
-        ShareUseCases,
-        FolderUseCases,
-        UserUseCases,
-        FileUseCases,
-        SequelizePreCreatedUsersRepository,
-        SequelizeSharingRepository,
-        SequelizeAppSumoRepository,
-        AppSumoUseCase,
-        SequelizePlanRepository,
-        SequelizeShareRepository,
-        SequelizeFileRepository,
-        SequelizeFolderRepository,
-        SequelizeUserRepository,
-        SequelizeSharedWorkspaceRepository,
-        SequelizeReferralRepository,
-        SequelizeUserReferralsRepository,
-        SequelizeKeyServerRepository,
-        PaymentsService,
-        EventEmitter2,
-        NotificationService,
-        ConfigService,
-        NewsletterService,
-        AvatarService,
-        {
-          provide: HttpClient,
-          useValue: {
-            post: jest.fn().mockResolvedValue({}),
-          },
-        },
-        {
-          provide: SequelizeKeyServerRepository,
-          useValue: {
-            findUserKeysOrCreate: () => {
-              return {};
-            },
-          },
-        },
-        {
-          provide: getModelToken(ShareModel),
-          useValue: jest.fn(),
-        },
-        {
-          provide: getModelToken(FileModel),
-          useValue: jest.fn(),
-        },
-        {
-          provide: getModelToken(FolderModel),
-          useValue: jest.fn(),
-        },
-        {
-          provide: getModelToken(UserModel),
-          useValue: jest.fn(),
-        },
-        {
-          provide: getModelToken(PreCreatedUserModel),
-          useValue: jest.fn(),
-        },
-        {
-          provide: getModelToken(SharingModel),
-          useValue: jest.fn(),
-        },
-        {
-          provide: getModelToken(PermissionModel),
-          useValue: jest.fn(),
-        },
-        {
-          provide: getModelToken(RoleModel),
-          useValue: jest.fn(),
-        },
-        {
-          provide: getModelToken(SharingRolesModel),
-          useValue: jest.fn(),
-        },
-        {
-          provide: getModelToken(SharingInviteModel),
-          useValue: jest.fn(),
-        },
-        {
-          provide: getModelToken(AppSumoModel),
-          useValue: jest.fn(),
-        },
-        {
-          provide: getModelToken(PlanModel),
-          useValue: jest.fn(),
-        },
-        {
-          provide: getModelToken(ReferralModel),
-          useValue: jest.fn(),
-        },
-        {
-          provide: getModelToken(UserReferralModel),
-          useValue: jest.fn(),
-        },
-        {
-          provide: getModelToken(FriendInvitationModel),
-          useValue: jest.fn(),
-        },
-        {
-          provide: getModelToken(ThumbnailModel),
-          useValue: jest.fn(),
-        },
-        {
-          provide: SequelizeAttemptChangeEmailRepository,
-          useValue: createMock<SequelizeAttemptChangeEmailRepository>(),
-        },
-        {
-          provide: MailerService,
-          useValue: createMock<MailerService>(),
-        },
-      ],
-    }).compile();
+      providers: [ShareUseCases],
+    })
+      .useMocker(() => createMock())
+      .compile();
 
     service = module.get<ShareUseCases>(ShareUseCases);
     shareRepository = module.get<SequelizeShareRepository>(

--- a/src/modules/trash/trash.usecase.spec.ts
+++ b/src/modules/trash/trash.usecase.spec.ts
@@ -1,27 +1,13 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { NotFoundException } from '@nestjs/common';
+import { createMock } from '@golevelup/ts-jest';
+
 import { TrashUseCases } from './trash.usecase';
-import { SequelizeFileRepository } from '../file/file.repository';
 import { File, FileAttributes } from '../file/file.domain';
-import {
-  FolderModel,
-  SequelizeFolderRepository,
-} from '../folder/folder.repository';
-import { getModelToken } from '@nestjs/sequelize';
 import { User } from '../user/user.domain';
-import { SequelizeUserRepository, UserModel } from '../user/user.repository';
 import { Folder, FolderAttributes } from '../folder/folder.domain';
 import { FileUseCases } from '../file/file.usecase';
 import { FolderUseCases } from '../folder/folder.usecase';
-import { ShareUseCases } from '../share/share.usecase';
-import {
-  SequelizeShareRepository,
-  ShareModel,
-} from '../share/share.repository';
-import { BridgeModule } from '../../externals/bridge/bridge.module';
-import { CryptoModule } from '../..//externals/crypto/crypto.module';
-import { NotFoundException } from '@nestjs/common';
-import { FileModel } from '../file/file.model';
-import { ThumbnailModel } from '../thumbnail/thumbnail.model';
 
 describe('Trash Use Cases', () => {
   let service: TrashUseCases,
@@ -59,38 +45,10 @@ describe('Trash Use Cases', () => {
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      imports: [BridgeModule, CryptoModule],
-      providers: [
-        TrashUseCases,
-        FileUseCases,
-        SequelizeFileRepository,
-        {
-          provide: getModelToken(FileModel),
-          useValue: jest.fn(),
-        },
-        FolderUseCases,
-        SequelizeFolderRepository,
-        {
-          provide: getModelToken(FolderModel),
-          useValue: jest.fn(),
-        },
-        ShareUseCases,
-        SequelizeShareRepository,
-        {
-          provide: getModelToken(ShareModel),
-          useValue: jest.fn(),
-        },
-        SequelizeUserRepository,
-        {
-          provide: getModelToken(UserModel),
-          useValue: jest.fn(),
-        },
-        {
-          provide: getModelToken(ThumbnailModel),
-          useValue: jest.fn(),
-        },
-      ],
-    }).compile();
+      providers: [TrashUseCases],
+    })
+      .useMocker(() => createMock())
+      .compile();
 
     service = module.get<TrashUseCases>(TrashUseCases);
     fileUseCases = module.get<FileUseCases>(FileUseCases);

--- a/src/modules/user/user.usecase.spec.ts
+++ b/src/modules/user/user.usecase.spec.ts
@@ -10,22 +10,12 @@ import { FileUseCases } from '../file/file.usecase';
 import { User } from './user.domain';
 import { SequelizeUserRepository } from './user.repository';
 import { SequelizeSharedWorkspaceRepository } from '../../shared-workspace/shared-workspace.repository';
-import { SequelizeReferralRepository } from './referrals.repository';
-import { SequelizeUserReferralsRepository } from './user-referrals.repository';
 import { CryptoService } from '../../externals/crypto/crypto.service';
 import { BridgeService } from '../../externals/bridge/bridge.service';
-import { NotificationService } from '../../externals/notifications/notification.service';
-import { PaymentsService } from '../../externals/payments/payments.service';
-import { NewsletterService } from '../../externals/newsletter';
 import { ConfigService } from '@nestjs/config';
-import { SequelizeKeyServerRepository } from '../keyserver/key-server.repository';
 import { Folder, FolderAttributes } from '../folder/folder.domain';
 import { File, FileAttributes } from '../file/file.domain';
-import { AvatarService } from '../../externals/avatar/avatar.service';
-import { SequelizePreCreatedUsersRepository } from './pre-created-users.repository';
-import { SequelizeSharingRepository } from '../sharing/sharing.repository';
 import { SequelizeAttemptChangeEmailRepository } from './attempt-change-email.repository';
-import { MailerService } from '../../externals/mailer/mailer.service';
 import { UserNotFoundException } from './exception/user-not-found.exception';
 import { AttemptChangeEmailNotFoundException } from './exception/attempt-change-email-not-found.exception';
 import { AttemptChangeEmailHasExpiredException } from './exception/attempt-change-email-has-expired.exception';
@@ -470,84 +460,8 @@ describe('User use cases', () => {
 const createTestingModule = (): Promise<TestingModule> => {
   return Test.createTestingModule({
     controllers: [],
-    providers: [
-      {
-        provide: SequelizeUserRepository,
-        useValue: createMock<SequelizeUserRepository>(),
-      },
-      {
-        provide: SequelizeSharedWorkspaceRepository,
-        useValue: createMock<SequelizeSharedWorkspaceRepository>(),
-      },
-      {
-        provide: SequelizePreCreatedUsersRepository,
-        useValue: createMock<SequelizePreCreatedUsersRepository>(),
-      },
-      {
-        provide: SequelizeSharingRepository,
-        useValue: createMock<SequelizeSharingRepository>(),
-      },
-      {
-        provide: SequelizeReferralRepository,
-        useValue: createMock<SequelizeReferralRepository>(),
-      },
-      {
-        provide: SequelizeUserReferralsRepository,
-        useValue: createMock<SequelizeUserReferralsRepository>(),
-      },
-      {
-        provide: FileUseCases,
-        useValue: createMock<FileUseCases>(),
-      },
-      {
-        provide: FolderUseCases,
-        useValue: createMock<FolderUseCases>(),
-      },
-      {
-        provide: ShareUseCases,
-        useValue: createMock<ShareUseCases>(),
-      },
-      {
-        provide: ConfigService,
-        useValue: createMock<ConfigService>(),
-      },
-      {
-        provide: CryptoService,
-        useValue: createMock<CryptoService>(),
-      },
-      {
-        provide: BridgeService,
-        useValue: createMock<BridgeService>(),
-      },
-      {
-        provide: NotificationService,
-        useValue: createMock<NotificationService>(),
-      },
-      {
-        provide: PaymentsService,
-        useValue: createMock<PaymentsService>(),
-      },
-      {
-        provide: NewsletterService,
-        useValue: createMock<NewsletterService>(),
-      },
-      {
-        provide: SequelizeKeyServerRepository,
-        useValue: createMock<SequelizeKeyServerRepository>(),
-      },
-      {
-        provide: AvatarService,
-        useValue: createMock<AvatarService>(),
-      },
-      {
-        provide: SequelizeAttemptChangeEmailRepository,
-        useValue: createMock<SequelizeAttemptChangeEmailRepository>(),
-      },
-      {
-        provide: MailerService,
-        useValue: createMock<MailerService>(),
-      },
-      UserUseCases,
-    ],
-  }).compile();
+    providers: [UserUseCases],
+  })
+    .useMocker(() => createMock())
+    .compile();
 };


### PR DESCRIPTION
This pull request introduces NestJS automocking (https://docs.nestjs.com/fundamentals/testing#auto-mocking).

As the codebase expands, the addition of dependencies to modules has become more common. This PR addresses instances where injecting a repository or dependency into a use case led to unexpected breaks in other unit tests due to missing dependencies.  (e.g: you add a dependency to user.usecase and share.usecase.spec breaks)

Automocking helps alleviate these issues by automatically generating mocks for dependencies, ensuring the independence of other unit tests.

Note: 

To prevent any change in already created unit tests, I left some dependencies without changes. The intention of this PR is just to implement the automocker. 