### PR TITLE
[PB-267]: chore/refactor passwordChangedAt middleware variable naming and remove function

### DIFF
--- a/src/lib/jwt.ts
+++ b/src/lib/jwt.ts
@@ -53,10 +53,6 @@ export function getTokenDefaultIat() {
   return Math.floor(Date.now() / 1000);
 }
 
-export function isTokenIatGreaterThanDate(date: Date, iat: number) {
-  return Math.floor(date.getTime() / 1000) < iat;
-}
-
 export function generateJitsiJWT(user: User, room: string, moderator: boolean) {
   return SignWithRS256AndHeader(
     getJitsiJWTPayload(user, room, moderator),

--- a/src/modules/auth/jwt.strategy.ts
+++ b/src/modules/auth/jwt.strategy.ts
@@ -9,7 +9,7 @@ import { PassportStrategy } from '@nestjs/passport';
 import { ExtractJwt, Strategy } from 'passport-jwt';
 import { User } from '../user/user.domain';
 import { UserUseCases } from '../user/user.usecase';
-import { isTokenIatGreaterThanDate } from '../../lib/jwt';
+import { Time } from '../../lib/time';
 
 export interface JwtPayload {
   email: string;
@@ -46,16 +46,13 @@ export class JwtStrategy extends PassportStrategy(Strategy, strategyId) {
       const userWithoutLastPasswordChangedAt =
         user.lastPasswordChangedAt === null;
 
-      const tokenOlderThanLastPasswordChangedAt =
+      const tokenIssuedBeforeLastPasswordChange =
         user.lastPasswordChangedAt &&
-        !isTokenIatGreaterThanDate(
-          new Date(user.lastPasswordChangedAt),
-          payload.iat,
-        );
+        user.lastPasswordChangedAt > Time.convertTimestampToDate(payload.iat);
 
       if (
         !userWithoutLastPasswordChangedAt &&
-        tokenOlderThanLastPasswordChangedAt
+        tokenIssuedBeforeLastPasswordChange
       ) {
         throw new UnauthorizedException();
       }


### PR DESCRIPTION
Previous variable naming was a little confusing, as well as the function. 
This makes the naming a little better and also deletes the function `isTokenIatGreaterThanDate` which just makes everything hard to read.