### PR TITLE
[PB-845]: feat/Calculate-sharing-folder-size

### DIFF
--- a/src/common/uuid.dto.spec.ts
+++ b/src/common/uuid.dto.spec.ts
@@ -1,0 +1,33 @@
+import { validate } from 'class-validator';
+import { UuidDto } from './uuid.dto';
+import { newUser } from '../../test/fixtures';
+
+describe('UuidDto Validation', () => {
+  const user = newUser();
+
+  it('When a valid UUID is passed, then pass', async () => {
+    const dto = new UuidDto();
+    dto.id = user.uuid;
+
+    const errors = await validate(dto);
+    expect(errors.length).toBe(0);
+  });
+
+  it('When an invalid UUID is passed, then fail', async () => {
+    const dto = new UuidDto();
+    dto.id = 'invalid_uuid_string';
+
+    const errors = await validate(dto);
+    expect(errors.length).toBeGreaterThan(0);
+    expect(errors[0].constraints).toHaveProperty('isUuid');
+  });
+
+  it('When an empty string is passed, then fail', async () => {
+    const dto = new UuidDto();
+    dto.id = 'invalid-uuid';
+    const errors = await validate(dto);
+
+    expect(errors.length).toBeGreaterThan(0);
+    expect(errors[0].constraints).toHaveProperty('isUuid');
+  });
+});

--- a/src/common/uuid.dto.ts
+++ b/src/common/uuid.dto.ts
@@ -1,0 +1,6 @@
+import { IsUUID } from 'class-validator';
+
+export class UuidDto {
+  @IsUUID()
+  id: string;
+}

--- a/src/modules/sharing/exception/sharing-not-found.exception.ts
+++ b/src/modules/sharing/exception/sharing-not-found.exception.ts
@@ -1,0 +1,11 @@
+import { SharingException } from './sharing.exception';
+
+export class SharingNotFoundException extends SharingException {
+  constructor(
+    message = 'Sharing not found',
+    statusCode = 404,
+    code = 'SHARING_NOT_FOUND',
+  ) {
+    super(message, statusCode, code);
+  }
+}

--- a/src/modules/sharing/exception/sharing.exception.ts
+++ b/src/modules/sharing/exception/sharing.exception.ts
@@ -1,0 +1,7 @@
+import { BaseHttpException } from '../../../common/base-http.exception';
+
+export class SharingException extends BaseHttpException {
+  constructor(message: string, statusCode: number, code: string) {
+    super(`Sharing -> ${message}`, statusCode, code);
+  }
+}

--- a/src/modules/sharing/sharing.controller.spec.ts
+++ b/src/modules/sharing/sharing.controller.spec.ts
@@ -13,7 +13,7 @@ describe('SharingController', () => {
   beforeEach(async () => {
     sharingService = createMock<SharingService>();
     controller = new SharingController(sharingService);
-    sharing = newSharing()
+    sharing = newSharing({})
   });
 
   describe('get public sharing folder size', () => {

--- a/src/modules/sharing/sharing.controller.spec.ts
+++ b/src/modules/sharing/sharing.controller.spec.ts
@@ -1,0 +1,37 @@
+import { SharingController } from './sharing.controller';
+import { SharingService } from './sharing.service';
+import { UuidDto } from '../../common/uuid.dto';
+import { createMock } from '@golevelup/ts-jest';
+import { Sharing } from './sharing.domain'
+import { newSharing } from '../../../test/fixtures';
+
+describe('SharingController', () => {
+  let controller: SharingController;
+  let sharingService: SharingService;
+  let sharing: Sharing;
+
+  beforeEach(async () => {
+    sharingService = createMock<SharingService>();
+    controller = new SharingController(sharingService);
+    sharing = newSharing()
+  });
+
+  describe('get public sharing folder size', () => {
+    it('When request the get sharing size method, then it works', async () => {
+      const expectedResult = 100;
+
+      jest
+        .spyOn(sharingService, 'getPublicSharingFolderSize')
+        .mockImplementation(async () => expectedResult);
+
+      const result = await controller.getPublicSharingFolderSize({
+        id: sharing.id,
+      } as UuidDto);
+
+      expect(result).toStrictEqual({ size: expectedResult });
+      expect(sharingService.getPublicSharingFolderSize).toHaveBeenCalledWith(
+        sharing.id,
+      );
+    });
+  });
+});

--- a/src/modules/sharing/sharing.controller.ts
+++ b/src/modules/sharing/sharing.controller.ts
@@ -17,6 +17,7 @@ import {
   NotFoundException,
   Headers,
   Patch,
+  UseFilters,
 } from '@nestjs/common';
 import { Response } from 'express';
 import {
@@ -55,6 +56,8 @@ import { CreateSharingDto } from './dto/create-sharing.dto';
 import { ChangeSharingType } from './dto/change-sharing-type.dto';
 import { ThrottlerGuard } from '../../guards/throttler.guard';
 import { SetSharingPasswordDto } from './dto/set-sharing-password.dto';
+import { UuidDto } from '../../common/uuid.dto';
+import { HttpExceptionFilter } from '../../lib/http/http-exception.filter';
 
 @ApiTags('Sharing')
 @Controller('sharings')
@@ -1025,5 +1028,15 @@ export class SharingController {
     );
 
     return { message: 'User removed from shared folder' };
+  }
+
+  @UseFilters(new HttpExceptionFilter())
+  @UseGuards(ThrottlerGuard)
+  @Public()
+  @Get('public/:id/folder/size')
+  async getPublicSharingFolderSize(@Param() param: UuidDto) {
+    const size = await this.sharingService.getPublicSharingFolderSize(param.id);
+
+    return { size };
   }
 }

--- a/src/modules/sharing/sharing.service.ts
+++ b/src/modules/sharing/sharing.service.ts
@@ -47,6 +47,7 @@ import { CreateSharingDto } from './dto/create-sharing.dto';
 import { aes } from '@internxt/lib';
 import { Environment } from '@internxt/inxt-js';
 import { SequelizeUserReferralsRepository } from '../user/user-referrals.repository';
+import { SharingNotFoundException } from './exception/sharing-not-found.exception';
 
 export class InvalidOwnerError extends Error {
   constructor() {
@@ -2056,5 +2057,21 @@ export class SharingService {
     }
 
     return sharedItem;
+  }
+
+  async getPublicSharingFolderSize(
+    id: SharingAttributes['id'],
+  ): Promise<number> {
+    const sharing = await this.sharingRepository.findOneSharing({
+      id,
+      type: SharingType.Public,
+      itemType: 'folder',
+    });
+
+    if (!sharing) {
+      throw new SharingNotFoundException();
+    }
+
+    return this.folderUsecases.getFolderSizeByUuid(sharing.itemId);
   }
 }


### PR DESCRIPTION
This PR is to obtain the size of a public folder.

Currently filters `sharing` for the database by `ID`, `type`, and `itemType`; If it almost does not find a result, it throws a `SHARING_NOT_FOUND` error, if it exists, it continues with the request and returns the `size` of the folder.