### PR TITLE
[PB-1433]: feat/add-feature-limit-guard

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -40,3 +40,5 @@ STRIPE_SK_TEST=sk_test_y
 
 GATEWAY_USER=user
 GATEWAY_PASS=gatewaypass
+
+PAYMENTS_API_URL=http://host.docker.internal:8003

--- a/migrations/20240128230532-create-tiers-table.js
+++ b/migrations/20240128230532-create-tiers-table.js
@@ -1,0 +1,38 @@
+'use strict';
+
+const tableName = 'tiers';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.createTable(tableName, {
+      id: {
+        type: Sequelize.UUID,
+        allowNull: false,
+        primaryKey: true,
+      },
+      label: {
+        type: Sequelize.STRING,
+        allowNull: false,
+      },
+      context: {
+        type: Sequelize.STRING,
+        allowNull: false,
+      },
+      created_at: {
+        type: Sequelize.DATE,
+        allowNull: false,
+        defaultValue: Sequelize.NOW,
+      },
+      updated_at: {
+        type: Sequelize.DATE,
+        allowNull: false,
+        defaultValue: Sequelize.NOW,
+      },
+    });
+  },
+
+  async down(queryInterface) {
+    await queryInterface.dropTable(tableName);
+  },
+};

--- a/migrations/20240128230532-create-tiers-table.js
+++ b/migrations/20240128230532-create-tiers-table.js
@@ -17,7 +17,6 @@ module.exports = {
       },
       context: {
         type: Sequelize.STRING,
-        allowNull: false,
       },
       created_at: {
         type: Sequelize.DATE,

--- a/migrations/20240128230553-create-limits-table.js
+++ b/migrations/20240128230553-create-limits-table.js
@@ -20,7 +20,7 @@ module.exports = {
         allowNull: false,
       },
       value: {
-        type: Sequelize.INTEGER,
+        type: Sequelize.STRING,
         allowNull: false,
       },
       created_at: {

--- a/migrations/20240128230553-create-limits-table.js
+++ b/migrations/20240128230553-create-limits-table.js
@@ -1,0 +1,42 @@
+'use strict';
+
+const tableName = 'limits';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.createTable(tableName, {
+      id: {
+        type: Sequelize.UUID,
+        allowNull: false,
+        primaryKey: true,
+      },
+      label: {
+        type: Sequelize.STRING,
+        allowNull: false,
+      },
+      type: {
+        type: Sequelize.ENUM('counter', 'boolean'),
+        allowNull: false,
+      },
+      value: {
+        type: Sequelize.INTEGER,
+        allowNull: false,
+      },
+      created_at: {
+        type: Sequelize.DATE,
+        allowNull: false,
+        defaultValue: Sequelize.NOW,
+      },
+      updated_at: {
+        type: Sequelize.DATE,
+        allowNull: false,
+        defaultValue: Sequelize.NOW,
+      },
+    });
+  },
+
+  async down(queryInterface) {
+    await queryInterface.dropTable(tableName);
+  },
+};

--- a/migrations/20240128230608-create-tiers-limits-table.js
+++ b/migrations/20240128230608-create-tiers-limits-table.js
@@ -1,0 +1,40 @@
+'use strict';
+
+const tableName = 'tiers_limits';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.createTable(tableName, {
+      id: {
+        type: Sequelize.UUID,
+        allowNull: false,
+        primaryKey: true,
+      },
+      tier_id: {
+        type: Sequelize.UUID,
+        allowNull: false,
+        references: { model: 'tiers', key: 'id' },
+      },
+      limit_id: {
+        type: Sequelize.UUID,
+        allowNull: false,
+        references: { model: 'limits', key: 'id' },
+      },
+      created_at: {
+        type: Sequelize.DATE,
+        allowNull: false,
+        defaultValue: Sequelize.NOW,
+      },
+      updated_at: {
+        type: Sequelize.DATE,
+        allowNull: false,
+        defaultValue: Sequelize.NOW,
+      },
+    });
+  },
+
+  async down(queryInterface) {
+    await queryInterface.dropTable(tableName);
+  },
+};

--- a/migrations/20240128230626-add-tier-id-to-users.js
+++ b/migrations/20240128230626-add-tier-id-to-users.js
@@ -1,0 +1,17 @@
+'use strict';
+
+const tableName = 'users';
+const newColumn = 'tier_id';
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.addColumn(tableName, newColumn, {
+      type: Sequelize.UUID,
+      references: { model: 'tiers', key: 'id' },
+    });
+  },
+
+  async down(queryInterface) {
+    await queryInterface.removeColumn(tableName, newColumn);
+  },
+};

--- a/migrations/20240220163114-create-paid-plans-tiers.js
+++ b/migrations/20240220163114-create-paid-plans-tiers.js
@@ -1,0 +1,43 @@
+'use strict';
+
+const tableName = 'paid_plans';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.createTable(tableName, {
+      id: {
+        type: Sequelize.INTEGER,
+        primaryKey: true,
+        allowNull: false,
+        autoIncrement: true,
+      },
+      plan_id: {
+        type: Sequelize.STRING,
+        allowNull: false,
+      },
+      tier_id: {
+        type: Sequelize.UUID,
+        allowNull: false,
+        references: {
+          model: 'tiers',
+          key: 'id',
+        },
+      },
+      created_at: {
+        type: Sequelize.DATE,
+        allowNull: false,
+        defaultValue: Sequelize.NOW,
+      },
+      updated_at: {
+        type: Sequelize.DATE,
+        allowNull: false,
+        defaultValue: Sequelize.NOW,
+      },
+    });
+  },
+
+  async down(queryInterface) {
+    await queryInterface.dropTable(tableName);
+  },
+};

--- a/migrations/20240220163114-create-paid-plans-tiers.js
+++ b/migrations/20240220163114-create-paid-plans-tiers.js
@@ -24,6 +24,9 @@ module.exports = {
           key: 'id',
         },
       },
+      description: {
+        type: Sequelize.STRING,
+      },
       created_at: {
         type: Sequelize.DATE,
         allowNull: false,

--- a/migrations/20240220203734-seed-tiers-and-limits.js
+++ b/migrations/20240220203734-seed-tiers-and-limits.js
@@ -1,0 +1,138 @@
+'use strict';
+
+const { v4: uuidv4 } = require('uuid');
+
+module.exports = {
+  async up(queryInterface) {
+    const tiersData = [
+      { id: uuidv4(), label: '10gb_individual', context: 'Plan 10GB' },
+      { id: uuidv4(), label: '200gb_individual', context: 'Plan 200GB' },
+      { id: uuidv4(), label: '2tb_individual', context: 'Plan 2TB' },
+      { id: uuidv4(), label: '5tb_individual', context: 'Plan 5TB' },
+      { id: uuidv4(), label: '10tb_individual', context: 'Plan 10TB' },
+    ];
+
+    await queryInterface.bulkInsert(
+      'tiers',
+      tiersData.map((tier) => ({
+        id: tier.id,
+        label: tier.label,
+        context: tier.context,
+        created_at: new Date(),
+        updated_at: new Date(),
+      })),
+    );
+
+    const limitsData = [
+      {
+        tierLabel: '10gb_individual',
+        limits: [
+          { label: 'max-shared-items', type: 'counter', value: '10' },
+          { label: 'max-shared-invites', type: 'counter', value: '5' },
+          { label: 'file-versioning', type: 'boolean', value: 'false' },
+          { label: 'max-file-upload-size', type: 'counter', value: '1' },
+          { label: 'max-trash-storage-days', type: 'counter', value: '7' },
+          { label: 'max-back-up-devices', type: 'counter', value: '1' },
+        ],
+      },
+      {
+        tierLabel: '200gb_individual',
+        limits: [
+          { label: 'max-shared-items', type: 'counter', value: '50' },
+          { label: 'max-shared-invites', type: 'counter', value: '50' },
+          { label: 'file-versioning', type: 'boolean', value: 'false' },
+          { label: 'max-file-upload-size', type: 'counter', value: '5' },
+          { label: 'max-trash-storage-days', type: 'counter', value: '90' },
+          { label: 'max-back-up-devices', type: 'counter', value: '5' },
+        ],
+      },
+      {
+        tierLabel: '2tb_individual',
+        limits: [
+          { label: 'max-shared-items', type: 'counter', value: '50' },
+          { label: 'max-shared-invites', type: 'counter', value: '50' },
+          { label: 'file-versioning', type: 'boolean', value: 'true' },
+          { label: 'max-file-upload-size', type: 'counter', value: '20' },
+          { label: 'max-trash-storage-days', type: 'counter', value: '90' },
+          { label: 'max-back-up-devices', type: 'counter', value: '10' },
+        ],
+      },
+      {
+        tierLabel: '5tb_individual',
+        limits: [
+          { label: 'max-shared-items', type: 'counter', value: '1000' },
+          { label: 'max-shared-invites', type: 'counter', value: '100' },
+          { label: 'file-versioning', type: 'boolean', value: 'true' },
+          { label: 'max-file-upload-size', type: 'counter', value: '20' },
+          { label: 'max-trash-storage-days', type: 'counter', value: '180' },
+          { label: 'max-back-up-devices', type: 'counter', value: '20' },
+        ],
+      },
+      {
+        tierLabel: '10tb_individual',
+        limits: [
+          { label: 'max-shared-items', type: 'counter', value: '1000' },
+          { label: 'max-shared-invites', type: 'counter', value: '100' },
+          { label: 'file-versioning', type: 'boolean', value: 'true' },
+          { label: 'max-file-upload-size', type: 'counter', value: '20' },
+          { label: 'max-trash-storage-days', type: 'counter', value: '365' },
+          { label: 'max-back-up-devices', type: 'counter', value: '20' },
+        ],
+      },
+    ];
+
+    let tierAndLimitsRelations = [];
+
+    const flattenedLimits = limitsData.flatMap((plan) => {
+      return plan.limits.map((limit) => {
+        const uuid = uuidv4();
+
+        tierAndLimitsRelations.push({
+          id: uuidv4(),
+          limit_id: uuid,
+          tier_id: tiersData.find((tier) => tier.label === plan.tierLabel).id,
+          created_at: new Date(),
+          updated_at: new Date(),
+        });
+
+        return {
+          id: uuid,
+          label: limit.label,
+          type: limit.type,
+          value: limit.value,
+          created_at: new Date(),
+          updated_at: new Date(),
+        };
+      });
+    });
+
+    await queryInterface.bulkInsert('limits', flattenedLimits);
+
+    await queryInterface.bulkInsert('tiers_limits', tierAndLimitsRelations);
+  },
+
+  async down(queryInterface) {
+    const tierLabels = [
+      '10gb_individual',
+      '200gb_individual',
+      '2tb_individual',
+      '5tb_individual',
+      '10tb_individual',
+    ];
+
+    await queryInterface.sequelize.query(
+      `DELETE FROM tiers_limits WHERE tier_id IN (SELECT id FROM tiers WHERE label IN (:tierLabels))`,
+      { replacements: { tierLabels } },
+    );
+
+    await queryInterface.sequelize.query(
+      `DELETE FROM tiers WHERE label IN (:tierLabels)`,
+      { replacements: { tierLabels } },
+    );
+
+    // Delete any orphaned limits that are no longer associated with any tier
+    await queryInterface.sequelize.query(`
+      DELETE FROM limits WHERE id NOT IN (SELECT limit_id FROM tiers_limits)
+    `);
+  },
+};

--- a/migrations/20240220215830-seed-free-plan-to-paid-plans-table.js
+++ b/migrations/20240220215830-seed-free-plan-to-paid-plans-table.js
@@ -1,0 +1,25 @@
+'use strict';
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    const tiers = await queryInterface.sequelize.query(
+      "SELECT id FROM tiers WHERE label = '10gb_individual' LIMIT 1",
+      { type: Sequelize.QueryTypes.SELECT },
+    );
+
+    if (tiers.length > 0) {
+      const tierId = tiers[0].id;
+
+      await queryInterface.sequelize.query(
+        `INSERT INTO paid_plans (plan_id, tier_id, description, created_at, updated_at) 
+           VALUES ('free_000000', '${tierId}', 'Free Tier 10gb' ,NOW(), NOW())`,
+      );
+    }
+  },
+
+  async down(queryInterface) {
+    await queryInterface.sequelize.query(
+      "DELETE FROM paid_plans WHERE plan_id = 'free_000000'",
+    );
+  },
+};

--- a/src/config/configuration.ts
+++ b/src/config/configuration.ts
@@ -63,6 +63,9 @@ export default () => ({
       url: process.env.RECAPTCHA_V3_ENDPOINT,
       threshold: process.env.RECAPTCHA_V3_SCORE_THRESHOLD,
     },
+    payments: {
+      url: process.env.PAYMENTS_API_URL,
+    },
   },
   clients: {
     drive: {

--- a/src/externals/payments/payments.service.ts
+++ b/src/externals/payments/payments.service.ts
@@ -4,7 +4,7 @@ import Stripe from 'stripe';
 
 import { UserAttributes } from '../../modules/user/user.attributes';
 import { HttpClient } from '../http/http.service';
-import { Sign } from 'src/middlewares/passport';
+import { Sign } from '../../middlewares/passport';
 
 @Injectable()
 export class PaymentsService {

--- a/src/externals/payments/payments.service.ts
+++ b/src/externals/payments/payments.service.ts
@@ -13,6 +13,7 @@ export class PaymentsService {
   constructor(
     @Inject(ConfigService)
     private configService: ConfigService,
+    @Inject(HttpClient)
     private httpClient: HttpClient,
   ) {
     const stripeTest = new Stripe(process.env.STRIPE_SK_TEST, {

--- a/src/modules/feature-limit/decorators/apply-limit.decorator.ts
+++ b/src/modules/feature-limit/decorators/apply-limit.decorator.ts
@@ -9,6 +9,7 @@ interface DataSource {
 export interface ApplyLimitMetadata {
   limitLabel: LimitLabels;
   dataSources?: DataSource[];
+  context?: object;
 }
 
 export const FEATURE_LIMIT_KEY = 'feature-limit';

--- a/src/modules/feature-limit/decorators/apply-limit.decorator.ts
+++ b/src/modules/feature-limit/decorators/apply-limit.decorator.ts
@@ -7,7 +7,7 @@ interface DataSource {
 }
 
 export interface ApplyLimitMetadata {
-  limitLabel: LimitLabels;
+  limitLabels: LimitLabels[];
   dataSources?: DataSource[];
   context?: object;
 }

--- a/src/modules/feature-limit/decorators/apply-limit.decorator.ts
+++ b/src/modules/feature-limit/decorators/apply-limit.decorator.ts
@@ -1,0 +1,17 @@
+import { SetMetadata } from '@nestjs/common';
+import { LimitLabels } from '../limits.enum';
+
+interface DataSource {
+  sourceKey: 'body' | 'params' | 'query' | 'headers';
+  fieldName: string;
+}
+
+export interface ApplyLimitMetadata {
+  limitLabel: LimitLabels;
+  dataSources?: DataSource[];
+}
+
+export const FEATURE_LIMIT_KEY = 'feature-limit';
+
+export const ApplyLimit = (metadata: ApplyLimitMetadata) =>
+  SetMetadata(FEATURE_LIMIT_KEY, metadata);

--- a/src/modules/feature-limit/exceptions/payment-required.exception.ts
+++ b/src/modules/feature-limit/exceptions/payment-required.exception.ts
@@ -3,7 +3,8 @@ import { HttpException, HttpStatus } from '@nestjs/common';
 export class PaymentRequiredException extends HttpException {
   constructor(message?: string) {
     super(
-      message ?? 'It seems you reached the limit for your current plan tier',
+      message ??
+        'It seems you reached the limit or feature is not available for your current plan tier',
       HttpStatus.PAYMENT_REQUIRED,
     );
   }

--- a/src/modules/feature-limit/exceptions/payment-required.exception.ts
+++ b/src/modules/feature-limit/exceptions/payment-required.exception.ts
@@ -1,0 +1,10 @@
+import { HttpException, HttpStatus } from '@nestjs/common';
+
+export class PaymentRequiredException extends HttpException {
+  constructor(message?: string) {
+    super(
+      message ?? 'It seems you reached the limit for your current plan tier',
+      HttpStatus.PAYMENT_REQUIRED,
+    );
+  }
+}

--- a/src/modules/feature-limit/feature-limit-migration.service.ts
+++ b/src/modules/feature-limit/feature-limit-migration.service.ts
@@ -5,7 +5,7 @@ import { AxiosError } from 'axios';
 import { User } from '../user/user.domain';
 import { PaymentsService } from 'src/externals/payments/payments.service';
 
-const FREE_TIER_ID = 'free';
+const FREE_TIER_ID = 'free_000000';
 
 @Injectable()
 export class FeatureLimitsMigrationService {
@@ -119,7 +119,7 @@ export class FeatureLimitsMigrationService {
 
     if (!this.planIdTierIdMap.get(FREE_TIER_ID)) {
       Logger.error(
-        `[FEATURE_LIMIT_MIGRATION/NO_FREE]: No free tier mapped found, please add a tier for free users`,
+        `[FEATURE_LIMIT_MIGRATION/NO_FREE]: No free tier mapped found, please add a tier for free users to your DB`,
       );
       throw Error(
         'There is no free tier mapped, please add a tier for free users',

--- a/src/modules/feature-limit/feature-limit-migration.service.ts
+++ b/src/modules/feature-limit/feature-limit-migration.service.ts
@@ -1,0 +1,148 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { SequelizeUserRepository } from '../user/user.repository';
+import { SequelizeFeatureLimitsRepository } from './feature-limit.repository';
+import { HttpClient } from 'src/externals/http/http.service';
+import { Sign } from 'src/middlewares/passport';
+import { ConfigService } from '@nestjs/config';
+import { AxiosError } from 'axios';
+import { User } from '../user/user.domain';
+
+const FREE_TIER_ID = 'free';
+
+@Injectable()
+export class FeatureLimitsMigrationService {
+  private readonly delayBetweenUsers = 10;
+  private readonly maxRetries = 3;
+  private readonly paymentsAPIThrottlingDelay = 60000;
+
+  private planIdTierIdMap: Map<string, string>; // PlanId/tierId mapping
+
+  constructor(
+    private userRepository: SequelizeUserRepository,
+    private tiersRepository: SequelizeFeatureLimitsRepository,
+    private httpClient: HttpClient,
+    private readonly configService: ConfigService,
+  ) {}
+
+  async asignTiersToUsers() {
+    const limit = 20;
+    let offset = 0;
+    let processed = 0;
+    await this.loadTiers();
+
+    while (true) {
+      const users = await this.userRepository.findAllByWithPagination(
+        { tierId: null },
+        limit,
+        offset,
+      );
+
+      if (users.length === 0) {
+        break;
+      }
+
+      for (const user of users) {
+        await this.assignTier(user);
+        await this.delay(this.delayBetweenUsers); // Delay between requests to prevent Stripe Throttling
+      }
+
+      processed += users.length;
+      Logger.log(
+        `[FEATURE_LIMIT_MIGRATION]: Processed : ${processed}, current offset: ${offset} `,
+      );
+      offset += limit;
+    }
+    Logger.log('[FEATURE_LIMIT_MIGRATION]: Tiers applied successfuly.');
+  }
+
+  private async assignTier(user: User) {
+    try {
+      const subscription = await this.getUserSubscription(user);
+      let tierId = this.planIdTierIdMap.get(FREE_TIER_ID);
+
+      if (subscription?.priceId) {
+        if (this.planIdTierIdMap.has(subscription.priceId)) {
+          tierId = this.planIdTierIdMap.get(subscription.priceId);
+        } else {
+          Logger.error(
+            `[FEATURE_LIMIT_MIGRATION/NOT_MAPPED_TIER]: tier priceId ${subscription?.priceId}  has not mapped tier, applying free tier to user userUuid: ${user.uuid} email: ${user.email}`,
+          );
+        }
+      }
+
+      await this.userRepository.updateBy(
+        { uuid: user.uuid },
+        {
+          tierId,
+        },
+      );
+    } catch (error) {
+      Logger.error(
+        `[FEATURE_LIMIT_MIGRATION/ERROR]: error applying applying tier to user userUuid: ${user.uuid} email: ${user.email}  error: ${error.message}`,
+      );
+    }
+  }
+
+  private async getUserSubscription(user: User, retries = 0) {
+    const jwt = Sign(
+      { payload: { uuid: user.uuid } },
+      this.configService.get('secrets.jwt'),
+    );
+
+    const params = {
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${jwt}`,
+      },
+    };
+    try {
+      const res = await this.httpClient.get(
+        `${this.configService.get('apis.payments.url')}/subscriptions`,
+        params,
+      );
+      return res.data;
+    } catch (error) {
+      if (error instanceof AxiosError) {
+        if (error.response && error.response.status === 404) {
+          return;
+        } else if (error.response && error.response.status === 429) {
+          if (retries < this.maxRetries) {
+            Logger.warn(
+              `[FEATURE_LIMIT_MIGRATION/PAYMENTS_REQUEST]: Throttling detected, waiting for 1 minute for payments API throttling retry number: ${
+                retries + 1
+              }`,
+            );
+            await this.delay(this.paymentsAPIThrottlingDelay);
+            return this.getUserSubscription(user, retries + 1);
+          }
+        }
+      }
+      Logger.error(
+        `[FEATURE_LIMIT_MIGRATION/PAYMENTS_REQUEST]: error getting user plan userUuid: ${user.uuid} email: ${user.email}  error: ${error.message}`,
+      );
+      throw error;
+    }
+  }
+
+  private async loadTiers() {
+    this.planIdTierIdMap = new Map();
+
+    const tiers = await this.tiersRepository.findAllPlansTiersMap();
+    tiers.forEach((tier) => {
+      this.planIdTierIdMap.set(tier.planId, tier.tierId);
+    });
+
+    if (!this.planIdTierIdMap.get(FREE_TIER_ID)) {
+      Logger.error(
+        `[FEATURE_LIMIT_MIGRATION/NO_FREE]: No free tier mapped found, please add a tier for free users`,
+      );
+      throw Error(
+        'There is no free tier mapped, please add a tier for free users',
+      );
+    }
+  }
+
+  delay(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+}

--- a/src/modules/feature-limit/feature-limit-migration.service.ts
+++ b/src/modules/feature-limit/feature-limit-migration.service.ts
@@ -4,8 +4,7 @@ import { SequelizeFeatureLimitsRepository } from './feature-limit.repository';
 import { AxiosError } from 'axios';
 import { User } from '../user/user.domain';
 import { PaymentsService } from 'src/externals/payments/payments.service';
-
-const FREE_TIER_ID = 'free_000000';
+import { PLAN_FREE_TIER_ID } from './limits.enum';
 
 @Injectable()
 export class FeatureLimitsMigrationService {
@@ -55,7 +54,7 @@ export class FeatureLimitsMigrationService {
   private async assignTier(user: User) {
     try {
       const subscription = await this.getUserSubscription(user);
-      let tierId = this.planIdTierIdMap.get(FREE_TIER_ID);
+      let tierId = this.planIdTierIdMap.get(PLAN_FREE_TIER_ID);
 
       if (subscription?.priceId) {
         if (this.planIdTierIdMap.has(subscription.priceId)) {
@@ -117,7 +116,7 @@ export class FeatureLimitsMigrationService {
       this.planIdTierIdMap.set(tier.planId, tier.tierId);
     });
 
-    if (!this.planIdTierIdMap.get(FREE_TIER_ID)) {
+    if (!this.planIdTierIdMap.get(PLAN_FREE_TIER_ID)) {
       Logger.error(
         `[FEATURE_LIMIT_MIGRATION/NO_FREE]: No free tier mapped found, please add a tier for free users to your DB`,
       );

--- a/src/modules/feature-limit/feature-limit.module.ts
+++ b/src/modules/feature-limit/feature-limit.module.ts
@@ -7,6 +7,12 @@ import { FeatureLimitUsecases } from './feature-limit.usecase';
 import { FeatureLimit } from './feature-limits.guard';
 import { TierLimitsModel } from './models/tier-limits.model';
 import { SharingModule } from '../sharing/sharing.module';
+import { FeatureLimitsMigrationService } from './feature-limit-migration.service';
+import { UserModule } from '../user/user.module';
+import { FeatureLimitsController } from './feature-limit.controller';
+import { HttpClientModule } from 'src/externals/http/http.module';
+import { ConfigModule } from '@nestjs/config';
+import { PaidPlansModel } from './models/paid-plans.model';
 
 @Module({
   imports: [
@@ -15,14 +21,20 @@ import { SharingModule } from '../sharing/sharing.module';
       Limitmodel,
       TierLimitsModel,
       TierLimitsModel,
+      PaidPlansModel,
     ]),
+    HttpClientModule,
     forwardRef(() => SharingModule),
+    forwardRef(() => UserModule),
   ],
   providers: [
     SequelizeFeatureLimitsRepository,
     FeatureLimitUsecases,
     FeatureLimit,
+    FeatureLimitsMigrationService,
+    ConfigModule,
   ],
+  controllers: [FeatureLimitsController],
   exports: [FeatureLimit, FeatureLimitUsecases],
 })
 export class FeatureLimitModule {}

--- a/src/modules/feature-limit/feature-limit.module.ts
+++ b/src/modules/feature-limit/feature-limit.module.ts
@@ -13,6 +13,7 @@ import { FeatureLimitsController } from './feature-limit.controller';
 import { HttpClientModule } from 'src/externals/http/http.module';
 import { ConfigModule } from '@nestjs/config';
 import { PaidPlansModel } from './models/paid-plans.model';
+import { PaymentsService } from 'src/externals/payments/payments.service';
 
 @Module({
   imports: [
@@ -33,6 +34,7 @@ import { PaidPlansModel } from './models/paid-plans.model';
     FeatureLimit,
     FeatureLimitsMigrationService,
     ConfigModule,
+    PaymentsService,
   ],
   controllers: [FeatureLimitsController],
   exports: [FeatureLimit, FeatureLimitUsecases],

--- a/src/modules/feature-limit/feature-limit.module.ts
+++ b/src/modules/feature-limit/feature-limit.module.ts
@@ -1,0 +1,28 @@
+import { Module, forwardRef } from '@nestjs/common';
+import { SequelizeModule } from '@nestjs/sequelize';
+import { TierModel } from './models/tier.model';
+import { Limitmodel } from './models/limit.model';
+import { SequelizeFeatureLimitsRepository } from './feature-limit.repository';
+import { LimitCheckService } from './limit-check.service';
+import { FeatureLimit } from './feature-limits.guard';
+import { TierLimitsModel } from './models/tier-limits.model';
+import { SharingModule } from '../sharing/sharing.module';
+
+@Module({
+  imports: [
+    SequelizeModule.forFeature([
+      TierModel,
+      Limitmodel,
+      TierLimitsModel,
+      TierLimitsModel,
+    ]),
+    forwardRef(() => SharingModule),
+  ],
+  providers: [
+    SequelizeFeatureLimitsRepository,
+    LimitCheckService,
+    FeatureLimit,
+  ],
+  exports: [FeatureLimit, LimitCheckService],
+})
+export class FeatureLimitModule {}

--- a/src/modules/feature-limit/feature-limit.module.ts
+++ b/src/modules/feature-limit/feature-limit.module.ts
@@ -3,7 +3,7 @@ import { SequelizeModule } from '@nestjs/sequelize';
 import { TierModel } from './models/tier.model';
 import { Limitmodel } from './models/limit.model';
 import { SequelizeFeatureLimitsRepository } from './feature-limit.repository';
-import { LimitCheckService } from './limit-check.service';
+import { FeatureLimitUsecases } from './feature-limit.usecase';
 import { FeatureLimit } from './feature-limits.guard';
 import { TierLimitsModel } from './models/tier-limits.model';
 import { SharingModule } from '../sharing/sharing.module';
@@ -20,9 +20,9 @@ import { SharingModule } from '../sharing/sharing.module';
   ],
   providers: [
     SequelizeFeatureLimitsRepository,
-    LimitCheckService,
+    FeatureLimitUsecases,
     FeatureLimit,
   ],
-  exports: [FeatureLimit, LimitCheckService],
+  exports: [FeatureLimit, FeatureLimitUsecases],
 })
 export class FeatureLimitModule {}

--- a/src/modules/feature-limit/feature-limit.module.ts
+++ b/src/modules/feature-limit/feature-limit.module.ts
@@ -9,7 +9,6 @@ import { TierLimitsModel } from './models/tier-limits.model';
 import { SharingModule } from '../sharing/sharing.module';
 import { FeatureLimitsMigrationService } from './feature-limit-migration.service';
 import { UserModule } from '../user/user.module';
-import { FeatureLimitsController } from './feature-limit.controller';
 import { HttpClientModule } from 'src/externals/http/http.module';
 import { ConfigModule } from '@nestjs/config';
 import { PaidPlansModel } from './models/paid-plans.model';
@@ -36,7 +35,6 @@ import { PaymentsService } from 'src/externals/payments/payments.service';
     ConfigModule,
     PaymentsService,
   ],
-  controllers: [FeatureLimitsController],
   exports: [FeatureLimit, FeatureLimitUsecases],
 })
 export class FeatureLimitModule {}

--- a/src/modules/feature-limit/feature-limit.module.ts
+++ b/src/modules/feature-limit/feature-limit.module.ts
@@ -35,6 +35,10 @@ import { PaymentsService } from 'src/externals/payments/payments.service';
     ConfigModule,
     PaymentsService,
   ],
-  exports: [FeatureLimit, FeatureLimitUsecases],
+  exports: [
+    FeatureLimit,
+    FeatureLimitUsecases,
+    SequelizeFeatureLimitsRepository,
+  ],
 })
 export class FeatureLimitModule {}

--- a/src/modules/feature-limit/feature-limit.repository.ts
+++ b/src/modules/feature-limit/feature-limit.repository.ts
@@ -16,11 +16,6 @@ export class SequelizeFeatureLimitsRepository {
     private tierLimitmodel: typeof TierLimitsModel,
   ) {}
 
-  async findById(id: string) {
-    const tier = await this.tierModel.findByPk(id);
-    return tier;
-  }
-
   async findLimitByLabelAndTier(
     tierId: string,
     label: string,

--- a/src/modules/feature-limit/feature-limit.repository.ts
+++ b/src/modules/feature-limit/feature-limit.repository.ts
@@ -1,0 +1,44 @@
+import { Injectable } from '@nestjs/common';
+import { InjectModel } from '@nestjs/sequelize';
+import { TierModel } from './models/tier.model';
+import { Limitmodel } from './models/limit.model';
+import { TierLimitsModel } from './models/tier-limits.model';
+import { Limit } from './limit.domain';
+
+@Injectable()
+export class SequelizeFeatureLimitsRepository {
+  constructor(
+    @InjectModel(TierModel)
+    private tierModel: typeof TierModel,
+    @InjectModel(Limitmodel)
+    private limitModel: typeof Limitmodel,
+    @InjectModel(TierLimitsModel)
+    private tierLimitmodel: typeof TierLimitsModel,
+  ) {}
+
+  async findById(id: string) {
+    const tier = await this.tierModel.findByPk(id);
+    return tier;
+  }
+
+  async findLimitByLabelAndTier(
+    tierId: string,
+    label: string,
+  ): Promise<Limit | null> {
+    const limit = await this.limitModel.findOne({
+      where: {
+        label,
+      },
+      include: [
+        {
+          model: TierModel,
+          where: {
+            id: tierId,
+          },
+        },
+      ],
+    });
+
+    return limit ? Limit.build(limit) : null;
+  }
+}

--- a/src/modules/feature-limit/feature-limit.repository.ts
+++ b/src/modules/feature-limit/feature-limit.repository.ts
@@ -4,6 +4,7 @@ import { TierModel } from './models/tier.model';
 import { Limitmodel } from './models/limit.model';
 import { TierLimitsModel } from './models/tier-limits.model';
 import { Limit } from './limit.domain';
+import { PaidPlansModel } from './models/paid-plans.model';
 
 @Injectable()
 export class SequelizeFeatureLimitsRepository {
@@ -14,6 +15,8 @@ export class SequelizeFeatureLimitsRepository {
     private limitModel: typeof Limitmodel,
     @InjectModel(TierLimitsModel)
     private tierLimitmodel: typeof TierLimitsModel,
+    @InjectModel(PaidPlansModel)
+    private paidPlansModel: typeof PaidPlansModel,
   ) {}
 
   async findLimitByLabelAndTier(
@@ -35,5 +38,9 @@ export class SequelizeFeatureLimitsRepository {
     });
 
     return limit ? Limit.build(limit) : null;
+  }
+
+  async findAllPlansTiersMap(): Promise<PaidPlansModel[]> {
+    return this.paidPlansModel.findAll();
   }
 }

--- a/src/modules/feature-limit/feature-limit.usecase.spec.ts
+++ b/src/modules/feature-limit/feature-limit.usecase.spec.ts
@@ -1,0 +1,263 @@
+import { SequelizeFeatureLimitsRepository } from './feature-limit.repository';
+import { SequelizeSharingRepository } from '../sharing/sharing.repository';
+import { DeepMocked, createMock } from '@golevelup/ts-jest';
+import { PaymentRequiredException } from './exceptions/payment-required.exception';
+import { FeatureLimitUsecases } from './feature-limit.usecase';
+import { newFeatureLimit, newUser } from '../../../test/fixtures';
+import { LimitLabels, LimitTypes } from './limits.enum';
+import { Sharing } from '../sharing/sharing.domain';
+import { InternalServerErrorException } from '@nestjs/common';
+
+describe('FeatureLimitUsecases', () => {
+  let service: FeatureLimitUsecases;
+  let limitsRepository: DeepMocked<SequelizeFeatureLimitsRepository>;
+  let sharingRepository: DeepMocked<SequelizeSharingRepository>;
+
+  beforeEach(async () => {
+    limitsRepository = createMock<SequelizeFeatureLimitsRepository>();
+    sharingRepository = createMock<SequelizeSharingRepository>();
+    service = new FeatureLimitUsecases(limitsRepository, sharingRepository);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('enforceLimit', () => {
+    const user = newUser();
+
+    it('When limit is boolean type and it is false, then it should throw to enforce limit', async () => {
+      const limit = newFeatureLimit({
+        type: LimitTypes.Boolean,
+        value: 'false',
+      });
+      limitsRepository.findLimitByLabelAndTier.mockResolvedValueOnce(limit);
+
+      await expect(
+        service.enforceLimit('' as LimitLabels, user, {}),
+      ).rejects.toThrow(PaymentRequiredException);
+    });
+
+    it('When limit is boolean type and it is true, then it should not enforce limit', async () => {
+      const limit = newFeatureLimit({
+        type: LimitTypes.Boolean,
+        value: 'true',
+      });
+
+      limitsRepository.findLimitByLabelAndTier.mockResolvedValueOnce(limit);
+
+      const enforceLimit = await service.enforceLimit(
+        '' as LimitLabels,
+        user,
+        {},
+      );
+
+      expect(enforceLimit).toBeFalsy();
+    });
+
+    it('When limit is counter and is surprassed, then limit should be enforced', async () => {
+      limitsRepository.findLimitByLabelAndTier.mockResolvedValueOnce(
+        newFeatureLimit({
+          type: LimitTypes.Counter,
+          value: '4',
+        }),
+      );
+      jest.spyOn(service, 'checkCounterLimit').mockResolvedValueOnce(true);
+
+      await expect(
+        service.enforceLimit('' as LimitLabels, user, {}),
+      ).rejects.toThrow(PaymentRequiredException);
+    });
+
+    it('When limit is counter and is not surprassed, then limit should be not be enforced', async () => {
+      limitsRepository.findLimitByLabelAndTier.mockResolvedValueOnce(
+        newFeatureLimit({
+          type: LimitTypes.Counter,
+          value: '4',
+        }),
+      );
+      jest.spyOn(service, 'checkCounterLimit').mockResolvedValueOnce(false);
+
+      const enforceLimit = await service.enforceLimit(
+        '' as LimitLabels,
+        user,
+        {},
+      );
+
+      expect(enforceLimit).toBeFalsy();
+    });
+  });
+
+  describe('checkMaxSharedItemsLimit', () => {
+    const user = newUser();
+
+    it('When if item is already shared, then should bypassLimit', async () => {
+      const limit = newFeatureLimit({
+        type: LimitTypes.Counter,
+        value: '3',
+      });
+
+      const shouldLimitBeEnforcedSpy = jest.spyOn(
+        limit,
+        'shouldLimitBeEnforced',
+      );
+      sharingRepository.findOneSharingBy.mockResolvedValueOnce({
+        id: '',
+      } as Sharing);
+
+      const enforceMaxSharedItemsLimit = await service.checkMaxSharedItemsLimit(
+        {
+          limit,
+          user,
+          data: { itemId: '', isPublicSharing: false, user },
+        },
+      );
+
+      expect(enforceMaxSharedItemsLimit).toBeFalsy();
+      expect(shouldLimitBeEnforcedSpy).toHaveBeenCalledWith({
+        bypassLimit: true,
+        currentCount: 0,
+      });
+    });
+
+    it('When user has equal or more sharings than limit, limit should be enforced', async () => {
+      const limit = newFeatureLimit({
+        type: LimitTypes.Counter,
+        value: '3',
+      });
+
+      sharingRepository.findOneSharingBy.mockResolvedValueOnce(null);
+      sharingRepository.getSharedItemsNumberByUser.mockResolvedValueOnce(3);
+
+      const enforceMaxSharedItemsLimit = await service.checkMaxSharedItemsLimit(
+        {
+          limit,
+          user,
+          data: { itemId: '', isPublicSharing: false, user },
+        },
+      );
+
+      expect(enforceMaxSharedItemsLimit).toBeTruthy();
+    });
+
+    it('When user has less sharings than limit, limit should not be enforced', async () => {
+      const limit = newFeatureLimit({
+        type: LimitTypes.Counter,
+        value: '4',
+      });
+
+      sharingRepository.findOneSharingBy.mockResolvedValueOnce(null);
+      sharingRepository.getSharedItemsNumberByUser.mockResolvedValueOnce(3);
+
+      const enforceMaxSharedItemsLimit = await service.checkMaxSharedItemsLimit(
+        {
+          limit,
+          user,
+          data: { itemId: '', isPublicSharing: false, user },
+        },
+      );
+
+      expect(enforceMaxSharedItemsLimit).toBeFalsy();
+    });
+  });
+
+  describe('checkMaxInviteesPerItemLimit', () => {
+    it('When item has more invitations than the limit, limit should be enforced', async () => {
+      const limit = newFeatureLimit({
+        type: LimitTypes.Counter,
+        value: '3',
+      });
+
+      sharingRepository.getSharingsCountBy.mockResolvedValueOnce(3);
+      sharingRepository.getInvitesCountBy.mockResolvedValueOnce(3);
+
+      const enforceMaxInvitesPerItem =
+        await service.checkMaxInviteesPerItemLimit({
+          limit,
+          data: { itemId: '', itemType: 'file' },
+        });
+
+      expect(enforceMaxInvitesPerItem).toBeTruthy();
+    });
+
+    it('When item has less invitations than the limit, limit should not be enforced', async () => {
+      const limit = newFeatureLimit({
+        type: LimitTypes.Counter,
+        value: '3',
+      });
+
+      sharingRepository.getSharingsCountBy.mockResolvedValueOnce(0);
+      sharingRepository.getInvitesCountBy.mockResolvedValueOnce(1);
+
+      const enforceMaxInvitesPerItem =
+        await service.checkMaxInviteesPerItemLimit({
+          limit,
+          data: { itemId: '', itemType: 'file' },
+        });
+
+      expect(enforceMaxInvitesPerItem).toBeFalsy();
+    });
+
+    it('When limit has enough invitations to surprass limit including owner, then limit should be enforced', async () => {
+      const limit = newFeatureLimit({
+        type: LimitTypes.Counter,
+        value: '3',
+      });
+
+      sharingRepository.getSharingsCountBy.mockResolvedValueOnce(0);
+      sharingRepository.getInvitesCountBy.mockResolvedValueOnce(2);
+
+      const enforceMaxInvitesPerItem =
+        await service.checkMaxInviteesPerItemLimit({
+          limit,
+          data: { itemId: '', itemType: 'file' },
+        });
+
+      expect(enforceMaxInvitesPerItem).toBeTruthy();
+    });
+  });
+
+  describe('checkCounterLimit', () => {
+    const user = newUser();
+
+    it('When checkfunction is not defined, then it should throw', async () => {
+      const limit = newFeatureLimit({
+        label: 'notExistentLabel' as LimitLabels,
+        type: LimitTypes.Counter,
+        value: '3',
+      });
+
+      // limitCheckFunctions is a private value, this is just to access at runtime
+      service['limitCheckFunctions']['limitLabel'] = jest.fn();
+
+      await expect(
+        service.checkCounterLimit(user, limit, {
+          itemId: '',
+          itemType: 'file',
+        }),
+      ).rejects.toBeInstanceOf(InternalServerErrorException);
+    });
+
+    it('When checkfunction is defined, then it should be called with passed data', async () => {
+      const limit = newFeatureLimit({
+        label: 'limitLabel' as LimitLabels,
+        type: LimitTypes.Counter,
+        value: '3',
+      });
+
+      const mockCheckFunction = jest.fn();
+      service['limitCheckFunctions']['limitLabel'] = mockCheckFunction;
+
+      await service.checkCounterLimit(user, limit, {
+        itemId: '',
+        itemType: 'file',
+      });
+
+      expect(mockCheckFunction).toHaveBeenCalledWith({
+        limit,
+        user,
+        data: { itemId: '', itemType: 'file' },
+      });
+    });
+  });
+});

--- a/src/modules/feature-limit/feature-limit.usecase.ts
+++ b/src/modules/feature-limit/feature-limit.usecase.ts
@@ -132,8 +132,9 @@ export class FeatureLimitUsecases {
         }),
       ]);
 
+    // Add 1 to include owner in the limit count.
     limitContext.currentCount =
-      sharingsCountForThisItem + invitesCountForThisItem;
+      sharingsCountForThisItem + invitesCountForThisItem + 1;
 
     return limit.shouldLimitBeEnforced(limitContext);
   }

--- a/src/modules/feature-limit/feature-limits.guard.spec.ts
+++ b/src/modules/feature-limit/feature-limits.guard.spec.ts
@@ -1,0 +1,144 @@
+import { DeepMocked, createMock } from '@golevelup/ts-jest';
+import { PaymentRequiredException } from './exceptions/payment-required.exception';
+import { FeatureLimitUsecases } from './feature-limit.usecase';
+import { newUser } from '../../../test/fixtures';
+import { LimitLabels } from './limits.enum';
+import { BadRequestException, ExecutionContext } from '@nestjs/common';
+import { FeatureLimit } from './feature-limits.guard';
+import { Reflector } from '@nestjs/core';
+import {
+  ApplyLimitMetadata,
+  FEATURE_LIMIT_KEY,
+} from './decorators/apply-limit.decorator';
+
+const user = newUser();
+
+describe('FeatureLimitUsecases', () => {
+  let guard: FeatureLimit;
+  let reflector: DeepMocked<Reflector>;
+  let featureLimitUsecases: DeepMocked<FeatureLimitUsecases>;
+
+  beforeEach(async () => {
+    reflector = createMock<Reflector>();
+    featureLimitUsecases = createMock<FeatureLimitUsecases>();
+    guard = new FeatureLimit(reflector, featureLimitUsecases);
+  });
+
+  it('Guard should be defined', () => {
+    expect(guard).toBeDefined();
+  });
+
+  it('When metadata is missing, it should throw', async () => {
+    jest.spyOn(reflector, 'get').mockReturnValue(undefined);
+
+    const context = createMockExecutionContext({});
+
+    await expect(guard.canActivate(context)).rejects.toThrow(
+      BadRequestException,
+    );
+  });
+
+  it('When a data source is missing in the incoming request, it should throw', async () => {
+    mockMetadata(reflector, {
+      limitLabels: ['' as LimitLabels],
+      dataSources: [{ sourceKey: 'body', fieldName: 'itemId' }],
+    });
+
+    const context = createMockExecutionContext({
+      user,
+      body: {},
+    });
+
+    await expect(guard.canActivate(context)).rejects.toThrow(
+      BadRequestException,
+    );
+  });
+
+  it('When limit should not be enforced, it should allow access', async () => {
+    mockMetadata(reflector, {
+      limitLabels: ['' as LimitLabels],
+      dataSources: [{ sourceKey: 'body', fieldName: 'itemId' }],
+    });
+    jest.spyOn(featureLimitUsecases, 'enforceLimit').mockResolvedValue(false);
+
+    const context = createMockExecutionContext({
+      user,
+      body: { itemId: 'item-1' },
+    });
+
+    await expect(guard.canActivate(context)).resolves.toBeTruthy();
+  });
+
+  it('When two labels are passed, it should check two limits', async () => {
+    const limitLabels = [
+      'firstLabel' as LimitLabels,
+      'secondLabel' as LimitLabels,
+    ];
+    mockMetadata(reflector, {
+      limitLabels,
+      dataSources: [{ sourceKey: 'body', fieldName: 'itemId' }],
+    });
+    const enforceLimitSpy = jest.spyOn(featureLimitUsecases, 'enforceLimit');
+    enforceLimitSpy.mockResolvedValue(false);
+    const context = createMockExecutionContext({
+      user,
+      body: { itemId: 'item-1' },
+    });
+
+    await guard.canActivate(context);
+
+    expect(enforceLimitSpy).toHaveBeenNthCalledWith(1, limitLabels[0], user, {
+      itemId: 'item-1',
+    });
+    expect(enforceLimitSpy).toHaveBeenNthCalledWith(2, limitLabels[1], user, {
+      itemId: 'item-1',
+    });
+  });
+
+  it('When two or more limits are checked and one throws, it should propagate the error', async () => {
+    const limitLabels = [
+      'firstLabel' as LimitLabels,
+      'secondLabel' as LimitLabels,
+      'thirdLabel' as LimitLabels,
+    ];
+    mockMetadata(reflector, {
+      limitLabels,
+      dataSources: [{ sourceKey: 'body', fieldName: 'itemId' }],
+    });
+
+    jest
+      .spyOn(featureLimitUsecases, 'enforceLimit')
+      .mockResolvedValueOnce(false);
+    jest
+      .spyOn(featureLimitUsecases, 'enforceLimit')
+      .mockRejectedValueOnce(new PaymentRequiredException());
+
+    const context = createMockExecutionContext({
+      user,
+      body: { itemId: 'item-1' },
+    });
+
+    await expect(guard.canActivate(context)).rejects.toThrow(
+      PaymentRequiredException,
+    );
+  });
+});
+
+const createMockExecutionContext = (requestData: any): ExecutionContext => {
+  return {
+    getHandler: () => ({
+      name: 'endPointHandler',
+    }),
+    switchToHttp: () => ({
+      getRequest: () => requestData,
+    }),
+  } as unknown as ExecutionContext;
+};
+
+const mockMetadata = (reflector: Reflector, metadata: ApplyLimitMetadata) => {
+  jest.spyOn(reflector, 'get').mockImplementation((key) => {
+    if (key === FEATURE_LIMIT_KEY) {
+      return metadata;
+    }
+  });
+};

--- a/src/modules/feature-limit/feature-limits.guard.ts
+++ b/src/modules/feature-limit/feature-limits.guard.ts
@@ -13,6 +13,7 @@ import {
   FEATURE_LIMIT_KEY,
 } from './decorators/apply-limit.decorator';
 import { PaymentRequiredException } from './exceptions/payment-required.exception';
+import { LimitTypeMapping } from './limits.attributes';
 
 @Injectable()
 export class FeatureLimit implements CanActivate {
@@ -51,7 +52,7 @@ export class FeatureLimit implements CanActivate {
           await this.featureLimitsUseCases.enforceLimit<LimitLabels>(
             limitLabel,
             user,
-            extractedData,
+            extractedData as LimitTypeMapping[typeof limitLabel],
           );
 
         if (shouldLimitBeEnforced) {

--- a/src/modules/feature-limit/feature-limits.guard.ts
+++ b/src/modules/feature-limit/feature-limits.guard.ts
@@ -68,8 +68,8 @@ export class FeatureLimit implements CanActivate {
       return false;
     }
 
-    if (limit.isLimitBooleanAndEnabled()) {
-      return true;
+    if (limit.isLimitBoolean()) {
+      return limit.isFeatureEnabled();
     }
 
     const isLimitExceeded =

--- a/src/modules/feature-limit/feature-limits.guard.ts
+++ b/src/modules/feature-limit/feature-limits.guard.ts
@@ -1,0 +1,84 @@
+import {
+  BadRequestException,
+  CanActivate,
+  ExecutionContext,
+  Injectable,
+  Logger,
+} from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { LimitLabels } from './limits.enum';
+import { LimitCheckService } from './limit-check.service';
+import { LimitTypeMapping } from './limits.attributes';
+import {
+  ApplyLimitMetadata,
+  FEATURE_LIMIT_KEY,
+} from './decorators/apply-limit.decorator';
+
+@Injectable()
+export class FeatureLimit implements CanActivate {
+  constructor(
+    private readonly reflector: Reflector,
+    private readonly limitsCheckService: LimitCheckService,
+  ) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const handler = context.getHandler();
+    const request = context.switchToHttp().getRequest();
+    const user = request.user;
+    const metadata = this.reflector.get<ApplyLimitMetadata>(
+      FEATURE_LIMIT_KEY,
+      handler,
+    );
+
+    if (!metadata) {
+      new Logger().error(
+        `Missing metada for feature limit guard! url: ${request.url} handler: ${handler.name}`,
+      );
+      return false;
+    }
+
+    const { limitLabel, dataSources } = metadata;
+
+    if (!limitLabel) {
+      return true;
+    }
+
+    const extractedData = {} as LimitTypeMapping[typeof limitLabel];
+    if (dataSources) {
+      for (const { sourceKey, fieldName } of dataSources) {
+        const value = request[sourceKey][fieldName];
+        if (value === undefined || value === null) {
+          new Logger().error(
+            `[FEATURE_LIMIT]: Missing required field! url: ${request.url} handler: ${handler.name} field: ${fieldName}`,
+          );
+          throw new BadRequestException(`Missing required field: ${fieldName}`);
+        }
+        extractedData[fieldName] = value;
+      }
+    }
+
+    const limit = await this.limitsCheckService.getLimitByLabelAndTier(
+      limitLabel,
+      // TODO: Replace with uÏser.tier_id
+      'dfd536ca-7284-47ff-800f-957a80d98084',
+    );
+
+    if (!limit) {
+      new Logger().error(`Limit configuration not found for ${limitLabel}`);
+      return false;
+    }
+
+    if (limit.isLimitBooleanAndEnabled()) {
+      return true;
+    }
+
+    const isLimitExceeded =
+      await this.limitsCheckService.checkLimit<LimitLabels>(
+        user,
+        limit,
+        extractedData,
+      );
+
+    return !isLimitExceeded;
+  }
+}

--- a/src/modules/feature-limit/limit-check.service.ts
+++ b/src/modules/feature-limit/limit-check.service.ts
@@ -18,7 +18,7 @@ export class LimitCheckService {
   ) {}
 
   private checkFunctions: {
-    [K in LimitLabels]: (params: {
+    [K in LimitLabels]?: (params: {
       limit: Limit;
       data: LimitTypeMapping[K];
       user: User;

--- a/src/modules/feature-limit/limit-check.service.ts
+++ b/src/modules/feature-limit/limit-check.service.ts
@@ -1,0 +1,101 @@
+import { BadRequestException, Injectable, Logger } from '@nestjs/common';
+import { LimitLabels } from './limits.enum';
+import { User } from '../user/user.domain';
+import { SequelizeFeatureLimitsRepository } from './feature-limit.repository';
+import { SequelizeSharingRepository } from '../sharing/sharing.repository';
+import { SharingType } from '../sharing/sharing.domain';
+import { Limit } from './limit.domain';
+import {
+  LimitTypeMapping,
+  MaxInviteesPerItemAttribute,
+} from './limits.attributes';
+
+@Injectable()
+export class LimitCheckService {
+  constructor(
+    private readonly limitsRepository: SequelizeFeatureLimitsRepository,
+    private readonly sharingRepository: SequelizeSharingRepository,
+  ) {}
+
+  private checkFunctions: {
+    [K in LimitLabels]: (params: {
+      limit: Limit;
+      data: LimitTypeMapping[K];
+      user: User;
+    }) => Promise<boolean>;
+  } = {
+    [LimitLabels.MaxSharedItems]: this.isMaxSharedItemsLimitExceeded.bind(this),
+    [LimitLabels.MaxSharedItemInvites]:
+      this.isMaxInviteesPerItemsLimitExceeded.bind(this),
+  };
+
+  checkLimit<T extends keyof LimitTypeMapping>(
+    user: User,
+    limit: Limit,
+    data: LimitTypeMapping[T],
+  ) {
+    const checkFunction = this.checkFunctions[limit.label as LimitLabels];
+    if (!checkFunction) {
+      new Logger().error(
+        `Check function not defined for label: ${limit.label}.`,
+      );
+      return false;
+    }
+    return checkFunction({ limit, data, user });
+  }
+
+  async isMaxSharedItemsLimitExceeded({
+    limit,
+    user,
+  }: {
+    limit: Limit;
+    user: User;
+  }) {
+    const sharingsNumber =
+      await this.sharingRepository.getSharedItemsNumberByUser(user.uuid);
+    const limitExceeded = sharingsNumber >= limit.value;
+    if (limitExceeded) {
+      throw new BadRequestException('You reached the limit of shared items');
+    }
+    return false;
+  }
+
+  async isMaxInviteesPerItemsLimitExceeded({
+    limit,
+    data,
+  }: {
+    limit: Limit;
+    data: MaxInviteesPerItemAttribute;
+  }) {
+    const { itemId, itemType } = data;
+    const [sharingsCountForThisItem, invitesCountForThisItem] =
+      await Promise.all([
+        this.sharingRepository.getSharingsCountBy({
+          itemId,
+          itemType,
+          type: SharingType.Private,
+        }),
+        this.sharingRepository.getInvitesCountBy({
+          itemId,
+          itemType,
+        }),
+      ]);
+
+    const count = sharingsCountForThisItem + invitesCountForThisItem;
+
+    const limitExceeded = count >= limit.value;
+    if (limitExceeded) {
+      throw new BadRequestException(
+        'You reached the limit of invitations for this item',
+      );
+    }
+    return false;
+  }
+
+  async getLimitByLabelAndTier(label: string, tierId: string) {
+    return this.limitsRepository.findLimitByLabelAndTier(
+      'dfd536ca-7284-47ff-800f-957a80d98084',
+      label,
+    );
+  }
+}

--- a/src/modules/feature-limit/limit.domain.spec.ts
+++ b/src/modules/feature-limit/limit.domain.spec.ts
@@ -1,0 +1,71 @@
+import { newFeatureLimit } from '../../../test/fixtures';
+import { LimitTypes } from './limits.enum';
+
+describe('Limit Domain', () => {
+  describe('isBooleanLimit()', () => {
+    it('When limit is boolean type, then it should return true', async () => {
+      const limit = newFeatureLimit({
+        type: LimitTypes.Boolean,
+        value: 'false',
+      });
+
+      expect(limit.isBooleanLimit()).toBeTruthy();
+    });
+
+    it('When limit is not boolean type, then it should return false', async () => {
+      const limit = newFeatureLimit({
+        type: LimitTypes.Counter,
+        value: '3',
+      });
+
+      expect(limit.isBooleanLimit()).toBeFalsy();
+    });
+  });
+
+  describe('shouldLimitBeEnforced()', () => {
+    it('When limit is boolean type and value is false, then limit should be enforced', async () => {
+      const limit = newFeatureLimit({
+        type: LimitTypes.Boolean,
+        value: 'false',
+      });
+
+      expect(limit.shouldLimitBeEnforced()).toBeTruthy();
+    });
+
+    it('When limit is boolean type and value is true, then limit should not be enforced', async () => {
+      const limit = newFeatureLimit({
+        type: LimitTypes.Boolean,
+        value: 'true',
+      });
+
+      expect(limit.shouldLimitBeEnforced()).toBeFalsy();
+    });
+
+    it('When limit is counter type and current count from context is greater or equal than value, then limit should be enforced', async () => {
+      const limit = newFeatureLimit({
+        type: LimitTypes.Counter,
+        value: '3',
+      });
+
+      expect(limit.shouldLimitBeEnforced({ currentCount: 3 })).toBeTruthy();
+    });
+
+    it('When limit is counter type and current count from context is less than value, then limit should be not be enforced', async () => {
+      const limit = newFeatureLimit({
+        type: LimitTypes.Counter,
+        value: '3',
+      });
+
+      expect(limit.shouldLimitBeEnforced({ currentCount: 2 })).toBeFalsy();
+    });
+
+    it('When bypassLimit is passed from the context, then limit should not be enforced', async () => {
+      const limit = newFeatureLimit({
+        type: LimitTypes.Counter,
+        value: '3',
+      });
+
+      expect(limit.shouldLimitBeEnforced({ bypassLimit: true })).toBeFalsy();
+    });
+  });
+});

--- a/src/modules/feature-limit/limit.domain.ts
+++ b/src/modules/feature-limit/limit.domain.ts
@@ -5,7 +5,7 @@ export class Limit {
   id: string;
   label: LimitLabels;
   type: string;
-  value: number;
+  value: string;
   constructor({ id, label, type, value }: LimitAttributes) {
     this.id = id;
     this.label = label;
@@ -22,6 +22,12 @@ export class Limit {
   }
 
   isFeatureEnabled() {
-    return this.isLimitBoolean() && this.value === 1;
+    return this.isLimitBoolean() && Boolean(this.value);
+  }
+
+  isLimitExceeded(currentCount: number) {
+    return (
+      this.type === LimitTypes.counter && currentCount >= Number(this.value)
+    );
   }
 }

--- a/src/modules/feature-limit/limit.domain.ts
+++ b/src/modules/feature-limit/limit.domain.ts
@@ -27,7 +27,7 @@ export class Limit {
   }
 
   private isFeatureEnabled() {
-    return this.isBooleanLimit() && Boolean(this.value);
+    return this.isBooleanLimit() && this.value === 'true';
   }
 
   private isCounterLimitExceeded(currentCount: number) {

--- a/src/modules/feature-limit/limit.domain.ts
+++ b/src/modules/feature-limit/limit.domain.ts
@@ -1,0 +1,23 @@
+import { LimitAttributes } from './limits.attributes';
+import { LimitTypes, LimitLabels } from './limits.enum';
+
+export class Limit {
+  id: string;
+  label: LimitLabels;
+  type: string;
+  value: number;
+  constructor({ id, label, type, value }: LimitAttributes) {
+    this.id = id;
+    this.label = label;
+    this.type = type;
+    this.value = value;
+  }
+
+  static build(limit: LimitAttributes): Limit {
+    return new Limit(limit);
+  }
+
+  isLimitBooleanAndEnabled() {
+    return this.type === LimitTypes.Boolean && this.value !== 0;
+  }
+}

--- a/src/modules/feature-limit/limit.domain.ts
+++ b/src/modules/feature-limit/limit.domain.ts
@@ -17,7 +17,11 @@ export class Limit {
     return new Limit(limit);
   }
 
-  isLimitBooleanAndEnabled() {
-    return this.type === LimitTypes.Boolean && this.value !== 0;
+  isLimitBoolean() {
+    return this.type === LimitTypes.Boolean;
+  }
+
+  isFeatureEnabled() {
+    return this.isLimitBoolean() && this.value === 1;
   }
 }

--- a/src/modules/feature-limit/limits.attributes.ts
+++ b/src/modules/feature-limit/limits.attributes.ts
@@ -5,7 +5,7 @@ export interface LimitAttributes {
   id: string;
   label: LimitLabels;
   type: LimitTypes;
-  value: number;
+  value: string;
 }
 
 export interface MaxInviteesPerItemAttribute {
@@ -15,6 +15,8 @@ export interface MaxInviteesPerItemAttribute {
 
 export interface MaxSharedItemsAttribute {
   user: User;
+  itemId: string;
+  isPublicSharing: boolean;
 }
 
 export interface LimitTypeMapping {

--- a/src/modules/feature-limit/limits.attributes.ts
+++ b/src/modules/feature-limit/limits.attributes.ts
@@ -29,13 +29,3 @@ export interface LimitTypeMapping {
   [LimitLabels.MaxSharedItems]: MaxSharedItemsAttribute;
   [key: string]: any;
 }
-
-type ExtractDataType<T> = T extends keyof LimitTypeMapping
-  ? LimitTypeMapping[T]
-  : never;
-
-export type CheckFunction<T extends LimitLabels> = (
-  value: number,
-  user: User,
-  data: ExtractDataType<T>,
-) => Promise<boolean>;

--- a/src/modules/feature-limit/limits.attributes.ts
+++ b/src/modules/feature-limit/limits.attributes.ts
@@ -8,6 +8,11 @@ export interface LimitAttributes {
   value: string;
 }
 
+export interface ShouldLimitBeEnforcedContext {
+  bypassLimit?: boolean;
+  currentCount?: number;
+}
+
 export interface MaxInviteesPerItemAttribute {
   itemId: string;
   itemType: 'folder' | 'file';

--- a/src/modules/feature-limit/limits.attributes.ts
+++ b/src/modules/feature-limit/limits.attributes.ts
@@ -1,0 +1,34 @@
+import { User } from '../user/user.domain';
+import { LimitLabels, LimitTypes } from './limits.enum';
+
+export interface LimitAttributes {
+  id: string;
+  label: LimitLabels;
+  type: LimitTypes;
+  value: number;
+}
+
+export interface MaxInviteesPerItemAttribute {
+  itemId: string;
+  itemType: 'folder' | 'file';
+}
+
+export interface MaxSharedItemsAttribute {
+  user: User;
+}
+
+export interface LimitTypeMapping {
+  [LimitLabels.MaxSharedItemInvites]: MaxInviteesPerItemAttribute;
+  [LimitLabels.MaxSharedItems]: MaxSharedItemsAttribute;
+  [key: string]: any;
+}
+
+type ExtractDataType<T> = T extends keyof LimitTypeMapping
+  ? LimitTypeMapping[T]
+  : never;
+
+export type CheckFunction<T extends LimitLabels> = (
+  value: number,
+  user: User,
+  data: ExtractDataType<T>,
+) => Promise<boolean>;

--- a/src/modules/feature-limit/limits.enum.ts
+++ b/src/modules/feature-limit/limits.enum.ts
@@ -1,6 +1,7 @@
 export enum LimitLabels {
   MaxSharedItems = 'max-shared-items',
   MaxSharedItemInvites = 'max-shared-invites',
+  MaxTest = 'max-shared-test',
 }
 
 export enum LimitTypes {

--- a/src/modules/feature-limit/limits.enum.ts
+++ b/src/modules/feature-limit/limits.enum.ts
@@ -6,5 +6,5 @@ export enum LimitLabels {
 
 export enum LimitTypes {
   Boolean = 'boolean',
-  counter = 'counter',
+  Counter = 'counter',
 }

--- a/src/modules/feature-limit/limits.enum.ts
+++ b/src/modules/feature-limit/limits.enum.ts
@@ -7,3 +7,5 @@ export enum LimitTypes {
   Boolean = 'boolean',
   Counter = 'counter',
 }
+
+export const PLAN_FREE_TIER_ID = 'free_000000';

--- a/src/modules/feature-limit/limits.enum.ts
+++ b/src/modules/feature-limit/limits.enum.ts
@@ -1,7 +1,6 @@
 export enum LimitLabels {
   MaxSharedItems = 'max-shared-items',
   MaxSharedItemInvites = 'max-shared-invites',
-  MaxTest = 'max-shared-test',
 }
 
 export enum LimitTypes {

--- a/src/modules/feature-limit/limits.enum.ts
+++ b/src/modules/feature-limit/limits.enum.ts
@@ -1,0 +1,9 @@
+export enum LimitLabels {
+  MaxSharedItems = 'max-shared-items',
+  MaxSharedItemInvites = 'max-shared-invites',
+}
+
+export enum LimitTypes {
+  Boolean = 'boolean',
+  counter = 'counter',
+}

--- a/src/modules/feature-limit/models/limit.model.ts
+++ b/src/modules/feature-limit/models/limit.model.ts
@@ -34,8 +34,8 @@ export class Limitmodel extends Model implements LimitAttributes {
   type: LimitTypes;
 
   @AllowNull(false)
-  @Column(DataType.NUMBER)
-  value: number;
+  @Column(DataType.STRING)
+  value: string;
 
   @BelongsToMany(() => TierModel, {
     through: () => TierLimitsModel,

--- a/src/modules/feature-limit/models/limit.model.ts
+++ b/src/modules/feature-limit/models/limit.model.ts
@@ -1,0 +1,50 @@
+import {
+  Column,
+  Model,
+  Table,
+  PrimaryKey,
+  DataType,
+  AllowNull,
+  BelongsToMany,
+} from 'sequelize-typescript';
+import { LimitTypes, LimitLabels } from '../limits.enum';
+import { TierModel } from './tier.model';
+import { TierLimitsModel } from './tier-limits.model';
+import { LimitAttributes } from '../limits.attributes';
+
+@Table({
+  underscored: true,
+  timestamps: true,
+  tableName: 'limits',
+})
+export class Limitmodel extends Model implements LimitAttributes {
+  @PrimaryKey
+  @Column(DataType.UUIDV4)
+  id: string;
+
+  @AllowNull(false)
+  @Column(DataType.STRING)
+  label: LimitLabels;
+
+  @AllowNull(false)
+  @Column({
+    type: DataType.ENUM,
+    values: Object.values(LimitTypes),
+  })
+  type: LimitTypes;
+
+  @AllowNull(false)
+  @Column(DataType.NUMBER)
+  value: number;
+
+  @BelongsToMany(() => TierModel, {
+    through: () => TierLimitsModel,
+  })
+  tiers: TierModel[];
+
+  @Column
+  createdAt: Date;
+
+  @Column
+  updatedAt: Date;
+}

--- a/src/modules/feature-limit/models/limit.model.ts
+++ b/src/modules/feature-limit/models/limit.model.ts
@@ -4,8 +4,8 @@ import {
   Table,
   PrimaryKey,
   DataType,
-  AllowNull,
   BelongsToMany,
+  AllowNull,
 } from 'sequelize-typescript';
 import { LimitTypes, LimitLabels } from '../limits.enum';
 import { TierModel } from './tier.model';

--- a/src/modules/feature-limit/models/paid-plans.model.ts
+++ b/src/modules/feature-limit/models/paid-plans.model.ts
@@ -26,6 +26,7 @@ export class PaidPlansModel extends Model {
   planId: string;
 
   @ForeignKey(() => TierModel)
+  @AllowNull(false)
   @Column(DataType.UUIDV4)
   tierId: string;
 

--- a/src/modules/feature-limit/models/paid-plans.model.ts
+++ b/src/modules/feature-limit/models/paid-plans.model.ts
@@ -1,0 +1,34 @@
+import {
+  Column,
+  Model,
+  Table,
+  PrimaryKey,
+  DataType,
+  AllowNull,
+  AutoIncrement,
+  ForeignKey,
+} from 'sequelize-typescript';
+import { TierModel } from './tier.model';
+
+@Table({
+  underscored: true,
+  timestamps: true,
+  tableName: 'paid_plans',
+})
+export class PaidPlansModel extends Model {
+  @PrimaryKey
+  @AutoIncrement
+  @Column(DataType.INTEGER)
+  id: string;
+
+  @AllowNull(false)
+  @Column(DataType.STRING)
+  planId: string;
+
+  @ForeignKey(() => TierModel)
+  @Column(DataType.UUIDV4)
+  tierId: string;
+
+  @Column
+  createdAt: Date;
+}

--- a/src/modules/feature-limit/models/paid-plans.model.ts
+++ b/src/modules/feature-limit/models/paid-plans.model.ts
@@ -7,6 +7,7 @@ import {
   AllowNull,
   AutoIncrement,
   ForeignKey,
+  BelongsTo,
 } from 'sequelize-typescript';
 import { TierModel } from './tier.model';
 
@@ -29,6 +30,13 @@ export class PaidPlansModel extends Model {
   @AllowNull(false)
   @Column(DataType.UUIDV4)
   tierId: string;
+
+  @BelongsTo(() => TierModel, {
+    foreignKey: 'tier_id',
+    targetKey: 'id',
+    as: 'tier',
+  })
+  tier: TierModel;
 
   @Column
   createdAt: Date;

--- a/src/modules/feature-limit/models/tier-limits.model.ts
+++ b/src/modules/feature-limit/models/tier-limits.model.ts
@@ -1,0 +1,35 @@
+import {
+  Column,
+  DataType,
+  ForeignKey,
+  Model,
+  PrimaryKey,
+  Table,
+} from 'sequelize-typescript';
+import { TierModel } from './tier.model';
+import { Limitmodel } from './limit.model';
+
+@Table({
+  underscored: true,
+  timestamps: true,
+  tableName: 'tiers_limits',
+})
+export class TierLimitsModel extends Model {
+  @PrimaryKey
+  @Column({ type: DataType.UUID, defaultValue: DataType.UUIDV4 })
+  id: string;
+
+  @ForeignKey(() => TierModel)
+  @Column(DataType.UUIDV4)
+  tierId: string;
+
+  @ForeignKey(() => Limitmodel)
+  @Column(DataType.UUIDV4)
+  limitId: string;
+
+  @Column
+  createdAt: Date;
+
+  @Column
+  updatedAt: Date;
+}

--- a/src/modules/feature-limit/models/tier.model.ts
+++ b/src/modules/feature-limit/models/tier.model.ts
@@ -29,7 +29,6 @@ export class TierModel extends Model implements TierAttributes {
   @Column(DataType.STRING)
   label: string;
 
-  @AllowNull(false)
   @Column(DataType.STRING)
   context: string;
 

--- a/src/modules/feature-limit/models/tier.model.ts
+++ b/src/modules/feature-limit/models/tier.model.ts
@@ -1,0 +1,41 @@
+import {
+  Column,
+  Model,
+  Table,
+  PrimaryKey,
+  DataType,
+  AllowNull,
+} from 'sequelize-typescript';
+
+export interface TierAttributes {
+  id: string;
+  label: string;
+  context: string;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+@Table({
+  underscored: true,
+  timestamps: true,
+  tableName: 'tiers',
+})
+export class TierModel extends Model implements TierAttributes {
+  @PrimaryKey
+  @Column(DataType.UUIDV4)
+  id: string;
+
+  @AllowNull(false)
+  @Column(DataType.STRING)
+  label: string;
+
+  @AllowNull(false)
+  @Column(DataType.STRING)
+  context: string;
+
+  @Column
+  createdAt: Date;
+
+  @Column
+  updatedAt: Date;
+}

--- a/src/modules/feature-limit/tier.domain.ts
+++ b/src/modules/feature-limit/tier.domain.ts
@@ -1,0 +1,21 @@
+export interface TierAttributes {
+  id: string;
+  label: string;
+  context?: string;
+}
+
+export class Tier implements TierAttributes {
+  id: string;
+  label: string;
+  context?: string;
+
+  constructor(attributes: TierAttributes) {
+    this.id = attributes.id;
+    this.label = attributes.label;
+    this.context = attributes.context;
+  }
+
+  static build(tier: TierAttributes): Tier {
+    return new Tier(tier);
+  }
+}

--- a/src/modules/sharing/sharing.controller.ts
+++ b/src/modules/sharing/sharing.controller.ts
@@ -251,14 +251,14 @@ export class SharingController {
   }
 
   @Post('/invites/send')
-  @ApplyLimit({
+  /*   @ApplyLimit({
     limitLabels: [LimitLabels.MaxSharedItemInvites, LimitLabels.MaxSharedItems],
     dataSources: [
       { sourceKey: 'body', fieldName: 'itemId' },
       { sourceKey: 'body', fieldName: 'itemType' },
     ],
   })
-  @UseGuards(FeatureLimit)
+  @UseGuards(FeatureLimit) */
   createInvite(
     @UserDecorator() user: User,
     @Body() createInviteDto: CreateInviteDto,
@@ -602,11 +602,11 @@ export class SharingController {
   }
 
   @Post('/')
-  @ApplyLimit({
+  /*   @ApplyLimit({
     limitLabels: [LimitLabels.MaxSharedItems],
     dataSources: [{ sourceKey: 'body', fieldName: 'itemId' }],
   })
-  @UseGuards(FeatureLimit)
+  @UseGuards(FeatureLimit) */
   createSharing(
     @UserDecorator() user,
     @Body() acceptInviteDto: CreateSharingDto,

--- a/src/modules/sharing/sharing.controller.ts
+++ b/src/modules/sharing/sharing.controller.ts
@@ -599,6 +599,11 @@ export class SharingController {
   }
 
   @Post('/')
+  @ApplyLimit({
+    limitLabel: LimitLabels.MaxSharedItems,
+    dataSources: [{ sourceKey: 'body', fieldName: 'itemId' }],
+  })
+  @UseGuards(FeatureLimit)
   createSharing(
     @UserDecorator() user,
     @Body() acceptInviteDto: CreateSharingDto,

--- a/src/modules/sharing/sharing.controller.ts
+++ b/src/modules/sharing/sharing.controller.ts
@@ -252,8 +252,11 @@ export class SharingController {
 
   @Post('/invites/send')
   @ApplyLimit({
-    limitLabel: LimitLabels.MaxSharedItemInvites,
-    dataSources: [{ sourceKey: 'body', fieldName: 'itemId' }],
+    limitLabels: [LimitLabels.MaxSharedItemInvites, LimitLabels.MaxSharedItems],
+    dataSources: [
+      { sourceKey: 'body', fieldName: 'itemId' },
+      { sourceKey: 'body', fieldName: 'itemType' },
+    ],
   })
   @UseGuards(FeatureLimit)
   createInvite(
@@ -600,7 +603,7 @@ export class SharingController {
 
   @Post('/')
   @ApplyLimit({
-    limitLabel: LimitLabels.MaxSharedItems,
+    limitLabels: [LimitLabels.MaxSharedItems],
     dataSources: [{ sourceKey: 'body', fieldName: 'itemId' }],
   })
   @UseGuards(FeatureLimit)

--- a/src/modules/sharing/sharing.controller.ts
+++ b/src/modules/sharing/sharing.controller.ts
@@ -58,6 +58,9 @@ import { ThrottlerGuard } from '../../guards/throttler.guard';
 import { SetSharingPasswordDto } from './dto/set-sharing-password.dto';
 import { UuidDto } from '../../common/uuid.dto';
 import { HttpExceptionFilter } from '../../lib/http/http-exception.filter';
+import { ApplyLimit } from '../feature-limit/decorators/apply-limit.decorator';
+import { LimitLabels } from '../feature-limit/limits.enum';
+import { FeatureLimit } from '../feature-limit/feature-limits.guard';
 
 @ApiTags('Sharing')
 @Controller('sharings')
@@ -248,6 +251,11 @@ export class SharingController {
   }
 
   @Post('/invites/send')
+  @ApplyLimit({
+    limitLabel: LimitLabels.MaxSharedItemInvites,
+    dataSources: [{ sourceKey: 'body', fieldName: 'itemId' }],
+  })
+  @UseGuards(FeatureLimit)
   createInvite(
     @UserDecorator() user: User,
     @Body() createInviteDto: CreateInviteDto,

--- a/src/modules/sharing/sharing.module.ts
+++ b/src/modules/sharing/sharing.module.ts
@@ -20,6 +20,7 @@ import {
 import { BridgeModule } from '../../externals/bridge/bridge.module';
 import { PaymentsService } from '../../externals/payments/payments.service';
 import { AppSumoModule } from '../app-sumo/app-sumo.module';
+import { FeatureLimitModule } from '../feature-limit/feature-limit.module';
 
 @Module({
   imports: [
@@ -36,6 +37,7 @@ import { AppSumoModule } from '../app-sumo/app-sumo.module';
     BridgeModule,
     AppSumoModule,
     forwardRef(() => UserModule),
+    forwardRef(() => FeatureLimitModule),
   ],
   controllers: [SharingController],
   providers: [
@@ -44,6 +46,6 @@ import { AppSumoModule } from '../app-sumo/app-sumo.module';
     SequelizeUserReferralsRepository,
     PaymentsService,
   ],
-  exports: [SharingService, SequelizeSharingRepository],
+  exports: [SharingService, SequelizeSharingRepository, SequelizeModule],
 })
 export class SharingModule {}

--- a/src/modules/sharing/sharing.module.ts
+++ b/src/modules/sharing/sharing.module.ts
@@ -21,6 +21,7 @@ import { BridgeModule } from '../../externals/bridge/bridge.module';
 import { PaymentsService } from '../../externals/payments/payments.service';
 import { AppSumoModule } from '../app-sumo/app-sumo.module';
 import { FeatureLimitModule } from '../feature-limit/feature-limit.module';
+import { HttpClientModule } from 'src/externals/http/http.module';
 
 @Module({
   imports: [
@@ -38,6 +39,7 @@ import { FeatureLimitModule } from '../feature-limit/feature-limit.module';
     AppSumoModule,
     forwardRef(() => UserModule),
     forwardRef(() => FeatureLimitModule),
+    HttpClientModule,
   ],
   controllers: [SharingController],
   providers: [

--- a/src/modules/sharing/sharing.repository.ts
+++ b/src/modules/sharing/sharing.repository.ts
@@ -550,6 +550,16 @@ export class SequelizeSharingRepository implements SharingRepository {
     return SharingInvite.build(raw);
   }
 
+  async getSharedItemsNumberByUser(userUuid: string): Promise<number> {
+    const sharingsNumber = await this.sharings.count({
+      where: { ownerId: userUuid },
+      distinct: true,
+      col: 'itemId',
+    });
+
+    return sharingsNumber;
+  }
+
   async createSharing(sharing: Omit<Sharing, 'id'>): Promise<Sharing> {
     const raw = await this.sharings.create(sharing);
 

--- a/src/modules/sharing/sharing.repository.ts
+++ b/src/modules/sharing/sharing.repository.ts
@@ -551,13 +551,13 @@ export class SequelizeSharingRepository implements SharingRepository {
   }
 
   async getSharedItemsNumberByUser(userUuid: string): Promise<number> {
-    const sharingsNumber = await this.sharings.count({
+    const sharingsCount = await this.sharings.count({
       where: { ownerId: userUuid },
       distinct: true,
       col: 'itemId',
     });
 
-    return sharingsNumber;
+    return sharingsCount;
   }
 
   async createSharing(sharing: Omit<Sharing, 'id'>): Promise<Sharing> {

--- a/src/modules/user/user.attributes.ts
+++ b/src/modules/user/user.attributes.ts
@@ -27,4 +27,5 @@ export interface UserAttributes {
   tempKey: string;
   avatar: string;
   lastPasswordChangedAt?: Date;
+  tierId?: string;
 }

--- a/src/modules/user/user.domain.ts
+++ b/src/modules/user/user.domain.ts
@@ -27,6 +27,7 @@ export class User implements UserAttributes {
   tempKey: string;
   avatar: string;
   lastPasswordChangedAt: Date;
+  tierId: string;
   constructor({
     id,
     userId,
@@ -55,6 +56,7 @@ export class User implements UserAttributes {
     tempKey,
     avatar,
     lastPasswordChangedAt,
+    tierId,
   }: UserAttributes) {
     this.id = id;
     this.userId = userId;
@@ -83,6 +85,7 @@ export class User implements UserAttributes {
     this.tempKey = tempKey;
     this.avatar = avatar;
     this.lastPasswordChangedAt = lastPasswordChangedAt;
+    this.tierId = tierId;
   }
 
   static build(user: UserAttributes): User {

--- a/src/modules/user/user.model.ts
+++ b/src/modules/user/user.model.ts
@@ -123,4 +123,8 @@ export class UserModel extends Model implements UserAttributes {
   @AllowNull
   @Column
   lastPasswordChangedAt: Date;
+
+  @AllowNull
+  @Column
+  tierId: string;
 }

--- a/src/modules/user/user.module.ts
+++ b/src/modules/user/user.module.ts
@@ -43,6 +43,7 @@ import { SequelizeAttemptChangeEmailRepository } from './attempt-change-email.re
 import { AttemptChangeEmailModel } from './attempt-change-email.model';
 import { MailerService } from '../../externals/mailer/mailer.service';
 import { SecurityModule } from '../security/security.module';
+import { FeatureLimitModule } from '../feature-limit/feature-limit.module';
 
 @Module({
   imports: [
@@ -67,6 +68,7 @@ import { SecurityModule } from '../security/security.module';
     PlanModule,
     forwardRef(() => SharingModule),
     SecurityModule,
+    forwardRef(() => FeatureLimitModule),
   ],
   controllers: [UserController],
   providers: [

--- a/src/modules/user/user.repository.ts
+++ b/src/modules/user/user.repository.ts
@@ -93,6 +93,15 @@ export class SequelizeUserRepository implements UserRepository {
     return users.map((user) => this.toDomain(user));
   }
 
+  async findAllByWithPagination(
+    where: any,
+    limit = 20,
+    offset = 0,
+  ): Promise<Array<User> | []> {
+    const users = await this.modelUser.findAll({ where, limit, offset });
+    return users.map((user) => this.toDomain(user));
+  }
+
   async findByUsername(username: string): Promise<User | null> {
     const user = await this.modelUser.findOne({
       where: {

--- a/src/modules/user/user.repository.ts
+++ b/src/modules/user/user.repository.ts
@@ -97,7 +97,7 @@ export class SequelizeUserRepository implements UserRepository {
     where: any,
     limit = 20,
     offset = 0,
-  ): Promise<Array<User> | []> {
+  ): Promise<User[]> {
     const users = await this.modelUser.findAll({ where, limit, offset });
     return users.map((user) => this.toDomain(user));
   }

--- a/src/modules/user/user.usecase.ts
+++ b/src/modules/user/user.usecase.ts
@@ -66,6 +66,7 @@ import { getTokenDefaultIat } from '../../lib/jwt';
 import { MailTypes } from '../security/mail-limit/mailTypes';
 import { SequelizeMailLimitRepository } from '../security/mail-limit/mail-limit.repository';
 import { Time } from '../../lib/time';
+import { SequelizeFeatureLimitsRepository } from '../feature-limit/feature-limit.repository';
 
 class ReferralsNotAvailableError extends Error {
   constructor() {
@@ -141,6 +142,7 @@ export class UserUseCases {
     private readonly avatarService: AvatarService,
     private readonly mailerService: MailerService,
     private readonly mailLimitRepository: SequelizeMailLimitRepository,
+    private readonly featureLimitRepository: SequelizeFeatureLimitsRepository,
   ) {}
 
   findByEmail(email: User['email']): Promise<User | null> {
@@ -356,6 +358,8 @@ export class UserUseCases {
       return false;
     });
 
+    const freeTier = await this.featureLimitRepository.getFreeTier();
+
     const user = await this.userRepository.create({
       email,
       name: newUser.name,
@@ -372,6 +376,7 @@ export class UserUseCases {
       username: email,
       bridgeUser: email,
       mnemonic: newUser.mnemonic,
+      tierId: freeTier?.id,
     });
 
     try {

--- a/test/fixtures.spec.ts
+++ b/test/fixtures.spec.ts
@@ -1,3 +1,7 @@
+import {
+  LimitLabels,
+  LimitTypes,
+} from '../src/modules/feature-limit/limits.enum';
 import { FileStatus } from '../src/modules/file/file.domain';
 import * as fixtures from './fixtures';
 
@@ -231,6 +235,36 @@ describe('Testing fixtures tests', () => {
       const mailLimit = fixtures.newMailLimit({ attemptsLimit: 5 });
 
       expect(mailLimit.attemptsLimit).toEqual(5);
+    });
+  });
+
+  describe('Feature limit fixture', () => {
+    it('When it generates a new limit, then the identifier should be random', () => {
+      const limit = fixtures.newFeatureLimit();
+      const otherLimit = fixtures.newFeatureLimit();
+
+      expect(limit.id).toBeTruthy();
+      expect(otherLimit.id).not.toBe(limit.id);
+    });
+
+    it('When it generates a limit and a label is provided, then that label should be set', () => {
+      const limit = fixtures.newFeatureLimit({
+        label: 'anyLabel' as LimitLabels,
+        type: LimitTypes.Boolean,
+        value: '0',
+      });
+
+      expect(limit.label).toEqual('anyLabel');
+    });
+
+    it('When it generates a limit and a type and value are provided, then that those fields should be set', () => {
+      const limit = fixtures.newFeatureLimit({
+        type: LimitTypes.Boolean,
+        value: '0',
+      });
+
+      expect(limit.type).toEqual(LimitTypes.Boolean);
+      expect(limit.value).toEqual('0');
     });
   });
 });

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -239,8 +239,8 @@ export const newFeatureLimit = (bindTo?: {
 }): Limit => {
   return Limit.build({
     id: bindTo?.id ?? v4(),
-    type: bindTo.type,
-    value: bindTo.value,
+    type: bindTo?.type ?? LimitTypes.Counter,
+    value: bindTo?.value ?? '2',
     label: bindTo?.label ?? ('' as LimitLabels),
   });
 };

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -11,6 +11,11 @@ import {
 import { File, FileStatus } from '../src/modules/file/file.domain';
 import { MailTypes } from '../src/modules/security/mail-limit/mailTypes';
 import { MailLimit } from '../src/modules/security/mail-limit/mail-limit.domain';
+import {
+  LimitLabels,
+  LimitTypes,
+} from '../src/modules/feature-limit/limits.enum';
+import { Limit } from '../src/modules/feature-limit/limit.domain';
 
 export const constants = {
   BUCKET_ID_LENGTH: 24,
@@ -223,5 +228,19 @@ export const newMailLimit = (bindTo?: {
     attemptsCount: bindTo?.attemptsCount ?? 0,
     attemptsLimit: bindTo?.attemptsLimit ?? 5,
     lastMailSent: bindTo?.lastMailSent ?? new Date(),
+  });
+};
+
+export const newFeatureLimit = (bindTo?: {
+  id?: string;
+  type: LimitTypes;
+  label?: LimitLabels;
+  value: string;
+}): Limit => {
+  return Limit.build({
+    id: bindTo?.id ?? v4(),
+    type: bindTo.type,
+    value: bindTo.value,
+    label: bindTo?.label ?? ('' as LimitLabels),
   });
 };


### PR DESCRIPTION
This PR is a POC for the creation of a guard that let us to check feature limits without introducing almost zero changes on services unless it is necessary. 

Let's consider that there are 3 types of limits (from a technical view):
1. Counter Limit that is not bound to any item. You can check it just with the user.uuid.
2. Counter Limit bound to X item. You need to get the itemId or whatever you need from the request, it is not enough with just the user.uuid
3. Boolean Limit: these can be checked without any extra logic.

## Added
1. **ApplyLimit**  decorator: This decorator is used to configure the limit to be applied. There are limits that need data from the body, query, params, header to be able to check them. This decorator is on charge of defining where should we get the data from. It does not do any check by itself, data is checked and extracted in the guard.
4. **FeatureLimit** guard: It is on charge of extracting the data from the context-request and validate everything is OK before proceeding to send data to the **limit checker service**.
5. **FeatureLimitUsecases**:  contains the functions that are used to check every limit. This service should have injected the different repositories, etc that needs for its functionality, so we can encapsulate bussiness logic in it.
6. **Temporal migration service**: Added a service that connects with payments API to get users current plan.
7. **Paid Plans table**: Table created to Map paid plans (stripe) with feature limit tiers.
8. Migrations for basic tiers and their limits according to discussed limits. [here](https://inxt.atlassian.net/wiki/spaces/PROD/pages/153321481/Individual+accounts)
9. Added free tier to users on sign up.

## Key Points
### What if I want to add a new limit?
New Limits can be added. You only need to consider these two points:
1. Counter Limit = Should have a function to be checked against assigned in LimitCheckService, otherwise, the guard is going to throw an error.
2. Boolean Limit = It is not necessary to add any function, the type itself just checks if value is 1 or 0.

### What if an endpoint needs depends on more than 1 limit?
The guard decorator allows you to send a string of limitLabels, so you are able to check multiple limits at one. However, the dataSources should be consistent. 

### Can I call the service to check a limit without calling the guard?
Yes, the good thing of encapsulating the logic in this service is that you can call the service to check anything you need. As long as you pass the correct arguments.

For example, you could call  `FeatureLimitUsecases.checkMaxSharedItemsLimit({data... user... limit...})` from your controller to check whatever you need without any decorator or guard.

## Examples 

### ApplyLimit

```javascript

  @Post('/invites/send')
  @ApplyLimit({
    limitLabels: [LimitLabels.MaxSharedItemInvites, LimitLabels.MaxSharedItems],
    dataSources: [
      { sourceKey: 'body', fieldName: 'itemId' },
      { sourceKey: 'body', fieldName: 'itemType' },
    ],
  })
  @UseGuards(FeatureLimit)
  createInvite(
    @UserDecorator() user: User,
    @Body() createInviteDto: CreateInviteDto,
  ) {
    return this.sharingService.createInvite(user, createInviteDto);
  }
```

