### PR TITLE
[PB-1617]: fix/files can not be trashed if status = deleted

### DIFF
--- a/src/modules/file/file.repository.ts
+++ b/src/modules/file/file.repository.ts
@@ -380,6 +380,9 @@ export class SequelizeFileRepository implements FileRepository {
           fileId: {
             [Op.in]: fileIds,
           },
+          status: {
+            [Op.not]: FileStatus.DELETED,
+          },
         },
       },
     );


### PR DESCRIPTION
Files status are being updated despite have been already DELETED. This leads to users not being able to empty their trash and might have access to files that are not in our network anymore. 

What happens:

1. File is marked as STATUS = DELETED
2. This triggers a function that saves data in a table called 'deleted_files' which is used as a queue to delete files from the network.
3. File, for some reason, is marked to STATUS != DELETED 

The send to trash function is currently targeting all files you pass to it, so it does not care what the status is.