### PR TITLE
[PB-1706]: Retrieve subitems by folder UUID

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,5 +36,6 @@ lerna-debug.log*
 
 .npmrc
 
+.env
 .env.development
 .env.production

--- a/src/externals/notifications/events/event.ts
+++ b/src/externals/notifications/events/event.ts
@@ -1,6 +1,9 @@
 export class Event {
   private createdAt: Date;
-  constructor(public name: string, public payload: Record<string, any>) {
+  constructor(
+    public name: string,
+    public payload: Record<string, any>,
+  ) {
     this.createdAt = new Date();
   }
 }

--- a/src/modules/file/file.controller.ts
+++ b/src/modules/file/file.controller.ts
@@ -112,7 +112,7 @@ export class FileController {
     @UserDecorator() user: User,
     @Query('limit') limit: number,
     @Query('offset') offset: number,
-    @Query('status') status: typeof filesStatuses[number],
+    @Query('status') status: (typeof filesStatuses)[number],
     @Query('sort') sort?: string,
     @Query('order') order?: 'ASC' | 'DESC',
     @Query('updatedAt') updatedAt?: string,

--- a/src/modules/folder/folder.attributes.ts
+++ b/src/modules/folder/folder.attributes.ts
@@ -3,7 +3,7 @@ import { Sharing } from '../sharing/sharing.domain';
 export interface FolderAttributes {
   id: number;
   parentId: number;
-  parentUuid: string;
+  parentUuid?: string;
   parent?: any;
   name: string;
   bucket: string;

--- a/src/modules/folder/folder.attributes.ts
+++ b/src/modules/folder/folder.attributes.ts
@@ -3,6 +3,7 @@ import { Sharing } from '../sharing/sharing.domain';
 export interface FolderAttributes {
   id: number;
   parentId: number;
+  parentUuid: string;
   parent?: any;
   name: string;
   bucket: string;

--- a/src/modules/folder/folder.controller.spec.ts
+++ b/src/modules/folder/folder.controller.spec.ts
@@ -135,5 +135,133 @@ describe('FolderController', () => {
 
       expect(result).toEqual({ folders: mappedSubfolders });
     });
+
+    it('When get folder subfiles are requested by invalid params, then it should throw an error', async () => {
+      try {
+        await folderController.getFolderContentFiles(
+          userMocked,
+          'invalidUUID',
+          50,
+          0,
+          'id',
+          'ASC',
+        );
+        expect(true).toBeFalsy; // getFolderContentFiles should throw an error
+      } catch (err) {
+        expect((err as Error).message).toEqual('Invalid UUID provided');
+      }
+
+      try {
+        await folderController.getFolderContentFiles(
+          userMocked,
+          folder.uuid,
+          0,
+          0,
+          'id',
+          'ASC',
+        );
+        expect(true).toBeFalsy; // getFolderContentFiles should throw an error
+      } catch (err) {
+        expect((err as Error).message).toEqual(
+          'Limit should be between 1 and 50',
+        );
+      }
+
+      try {
+        await folderController.getFolderContentFiles(
+          userMocked,
+          folder.uuid,
+          51,
+          0,
+          'id',
+          'ASC',
+        );
+        expect(true).toBeFalsy; // getFolderContentFiles should throw an error
+      } catch (err) {
+        expect((err as Error).message).toEqual(
+          'Limit should be between 1 and 50',
+        );
+      }
+
+      try {
+        await folderController.getFolderContentFiles(
+          userMocked,
+          folder.uuid,
+          50,
+          -1,
+          'id',
+          'ASC',
+        );
+        expect(true).toBeFalsy; // getFolderContentFiles should throw an error
+      } catch (err) {
+        expect((err as Error).message).toEqual(
+          'Offset should be higher than 0',
+        );
+      }
+    });
+
+    it('When get folder subfolders are requested by invalid folder uuid, then it should throw an error', async () => {
+      try {
+        await folderController.getFolderContentFolders(
+          userMocked,
+          'invalidUUID',
+          50,
+          0,
+          'id',
+          'ASC',
+        );
+        expect(true).toBeFalsy; // getFolderContentFolders should throw an error
+      } catch (err) {
+        expect((err as Error).message).toEqual('Invalid UUID provided');
+      }
+
+      try {
+        await folderController.getFolderContentFolders(
+          userMocked,
+          folder.uuid,
+          0,
+          0,
+          'id',
+          'ASC',
+        );
+        expect(true).toBeFalsy; // getFolderContentFolders should throw an error
+      } catch (err) {
+        expect((err as Error).message).toEqual(
+          'Limit should be between 1 and 50',
+        );
+      }
+
+      try {
+        await folderController.getFolderContentFolders(
+          userMocked,
+          folder.uuid,
+          51,
+          0,
+          'id',
+          'ASC',
+        );
+        expect(true).toBeFalsy; // getFolderContentFolders should throw an error
+      } catch (err) {
+        expect((err as Error).message).toEqual(
+          'Limit should be between 1 and 50',
+        );
+      }
+
+      try {
+        await folderController.getFolderContentFolders(
+          userMocked,
+          folder.uuid,
+          50,
+          -1,
+          'id',
+          'ASC',
+        );
+        expect(true).toBeFalsy; // getFolderContentFolders should throw an error
+      } catch (err) {
+        expect((err as Error).message).toEqual(
+          'Offset should be higher than 0',
+        );
+      }
+    });
   });
 });

--- a/src/modules/folder/folder.controller.spec.ts
+++ b/src/modules/folder/folder.controller.spec.ts
@@ -1,16 +1,50 @@
 import { createMock } from '@golevelup/ts-jest';
 import { Test, TestingModule } from '@nestjs/testing';
-import { newFolder } from '../../../test/fixtures';
+import { v4 } from 'uuid';
+import { newFile, newFolder } from '../../../test/fixtures';
 import { FileUseCases } from '../file/file.usecase';
 import { FolderController } from './folder.controller';
 import { Folder } from './folder.domain';
 import { FolderUseCases } from './folder.usecase';
 import { CalculateFolderSizeTimeoutException } from './exception/calculate-folder-size-timeout.exception';
+import { User } from '../user/user.domain';
+import { FileStatus } from '../file/file.domain';
 
 describe('FolderController', () => {
   let folderController: FolderController;
   let folderUseCases: FolderUseCases;
+  let fileUseCases: FileUseCases;
   let folder: Folder;
+
+  const userMocked = User.build({
+    id: 1,
+    userId: 'userId',
+    name: 'User Owner',
+    lastname: 'Lastname',
+    email: 'fake@internxt.com',
+    username: 'fake',
+    bridgeUser: null,
+    rootFolderId: 1,
+    errorLoginCount: 0,
+    isEmailActivitySended: 1,
+    referralCode: null,
+    referrer: null,
+    syncDate: new Date(),
+    uuid: 'uuid',
+    lastResend: new Date(),
+    credit: null,
+    welcomePack: true,
+    registerCompleted: true,
+    backupsBucket: 'bucket',
+    sharedWorkspace: true,
+    avatar: 'avatar',
+    password: '',
+    mnemonic: '',
+    hKey: undefined,
+    secret_2FA: '',
+    tempKey: '',
+    lastPasswordChangedAt: new Date(),
+  });
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -23,6 +57,7 @@ describe('FolderController', () => {
 
     folderController = module.get<FolderController>(FolderController);
     folderUseCases = module.get<FolderUseCases>(FolderUseCases);
+    fileUseCases = module.get<FileUseCases>(FileUseCases);
     folder = newFolder();
   });
 
@@ -45,6 +80,61 @@ describe('FolderController', () => {
       await expect(folderController.getFolderSize(folder.uuid)).rejects.toThrow(
         CalculateFolderSizeTimeoutException,
       );
+    });
+  });
+
+  describe('get folder content', () => {
+    it('When get folder subfiles are requested by folder uuid, then the child files are returned', async () => {
+      const expectedSubfiles = [
+        newFile({ attributes: { id: 1, folderUuid: folder.uuid } }),
+        newFile({ attributes: { id: 2, folderUuid: folder.uuid } }),
+        newFile({ attributes: { id: 3, folderUuid: folder.uuid } }),
+      ];
+      jest.spyOn(fileUseCases, 'getFiles').mockResolvedValue(expectedSubfiles);
+
+      const result = await folderController.getFolderContentFiles(
+        userMocked,
+        folder.uuid,
+        50,
+        0,
+        'id',
+        'ASC',
+      );
+      expect(result).toEqual({ files: expectedSubfiles });
+    });
+
+    it('When get folder subfolders are requested by folder uuid, then the child folders are returned', async () => {
+      const expectedSubfolders = [
+        newFolder({ attributes: { id: 1, parentUuid: folder.uuid } }),
+        newFolder({ attributes: { id: 2, parentUuid: folder.uuid } }),
+        newFolder({ attributes: { id: 3, parentUuid: folder.uuid } }),
+      ];
+      const mappedSubfolders = expectedSubfolders.map((f) => {
+        let folderStatus: FileStatus;
+        if (f.removed) {
+          folderStatus = FileStatus.DELETED;
+        } else if (f.deleted) {
+          folderStatus = FileStatus.TRASHED;
+        } else {
+          folderStatus = FileStatus.EXISTS;
+        }
+        return { ...f, status: folderStatus };
+      });
+
+      jest
+        .spyOn(folderUseCases, 'getFolders')
+        .mockResolvedValue(expectedSubfolders);
+
+      const result = await folderController.getFolderContentFolders(
+        userMocked,
+        folder.uuid,
+        50,
+        0,
+        'id',
+        'ASC',
+      );
+
+      expect(result).toEqual({ folders: mappedSubfolders });
     });
   });
 });

--- a/src/modules/folder/folder.controller.spec.ts
+++ b/src/modules/folder/folder.controller.spec.ts
@@ -1,6 +1,5 @@
 import { createMock } from '@golevelup/ts-jest';
 import { Test, TestingModule } from '@nestjs/testing';
-import { v4 } from 'uuid';
 import { newFile, newFolder } from '../../../test/fixtures';
 import { FileUseCases } from '../file/file.usecase';
 import { FolderController } from './folder.controller';

--- a/src/modules/folder/folder.controller.spec.ts
+++ b/src/modules/folder/folder.controller.spec.ts
@@ -1,8 +1,13 @@
 import { createMock } from '@golevelup/ts-jest';
 import { Test, TestingModule } from '@nestjs/testing';
+import { BadRequestException } from '@nestjs/common';
 import { newFile, newFolder } from '../../../test/fixtures';
 import { FileUseCases } from '../file/file.usecase';
-import { FolderController } from './folder.controller';
+import {
+  BadRequestInvalidOffsetException,
+  BadRequestOutOfRangeLimitException,
+  FolderController,
+} from './folder.controller';
 import { Folder } from './folder.domain';
 import { FolderUseCases } from './folder.usecase';
 import { CalculateFolderSizeTimeoutException } from './exception/calculate-folder-size-timeout.exception';
@@ -136,132 +141,96 @@ describe('FolderController', () => {
       expect(result).toEqual({ folders: mappedSubfolders });
     });
 
-    it('When get folder subfiles are requested by invalid params, then it should throw an error', async () => {
-      try {
-        await folderController.getFolderContentFiles(
+    it('When get folder subfiles are requested by invalid params, then it should throw an error', () => {
+      expect(
+        folderController.getFolderContentFiles(
           userMocked,
           'invalidUUID',
           50,
           0,
           'id',
           'ASC',
-        );
-        expect(true).toBeFalsy; // getFolderContentFiles should throw an error
-      } catch (err) {
-        expect((err as Error).message).toEqual('Invalid UUID provided');
-      }
+        ),
+      ).rejects.toThrow(BadRequestException);
 
-      try {
-        await folderController.getFolderContentFiles(
+      expect(
+        folderController.getFolderContentFiles(
           userMocked,
           folder.uuid,
           0,
           0,
           'id',
           'ASC',
-        );
-        expect(true).toBeFalsy; // getFolderContentFiles should throw an error
-      } catch (err) {
-        expect((err as Error).message).toEqual(
-          'Limit should be between 1 and 50',
-        );
-      }
+        ),
+      ).rejects.toThrow(BadRequestOutOfRangeLimitException);
 
-      try {
-        await folderController.getFolderContentFiles(
+      expect(
+        folderController.getFolderContentFiles(
           userMocked,
           folder.uuid,
           51,
           0,
           'id',
           'ASC',
-        );
-        expect(true).toBeFalsy; // getFolderContentFiles should throw an error
-      } catch (err) {
-        expect((err as Error).message).toEqual(
-          'Limit should be between 1 and 50',
-        );
-      }
+        ),
+      ).rejects.toThrow(BadRequestOutOfRangeLimitException);
 
-      try {
-        await folderController.getFolderContentFiles(
+      expect(
+        folderController.getFolderContentFiles(
           userMocked,
           folder.uuid,
           50,
           -1,
           'id',
           'ASC',
-        );
-        expect(true).toBeFalsy; // getFolderContentFiles should throw an error
-      } catch (err) {
-        expect((err as Error).message).toEqual(
-          'Offset should be higher than 0',
-        );
-      }
+        ),
+      ).rejects.toThrow(BadRequestInvalidOffsetException);
     });
 
     it('When get folder subfolders are requested by invalid folder uuid, then it should throw an error', async () => {
-      try {
-        await folderController.getFolderContentFolders(
+      expect(
+        folderController.getFolderContentFolders(
           userMocked,
           'invalidUUID',
           50,
           0,
           'id',
           'ASC',
-        );
-        expect(true).toBeFalsy; // getFolderContentFolders should throw an error
-      } catch (err) {
-        expect((err as Error).message).toEqual('Invalid UUID provided');
-      }
+        ),
+      ).rejects.toThrow(BadRequestException);
 
-      try {
-        await folderController.getFolderContentFolders(
+      expect(
+        folderController.getFolderContentFolders(
           userMocked,
           folder.uuid,
           0,
           0,
           'id',
           'ASC',
-        );
-        expect(true).toBeFalsy; // getFolderContentFolders should throw an error
-      } catch (err) {
-        expect((err as Error).message).toEqual(
-          'Limit should be between 1 and 50',
-        );
-      }
+        ),
+      ).rejects.toThrow(BadRequestOutOfRangeLimitException);
 
-      try {
-        await folderController.getFolderContentFolders(
+      expect(
+        folderController.getFolderContentFolders(
           userMocked,
           folder.uuid,
           51,
           0,
           'id',
           'ASC',
-        );
-        expect(true).toBeFalsy; // getFolderContentFolders should throw an error
-      } catch (err) {
-        expect((err as Error).message).toEqual(
-          'Limit should be between 1 and 50',
-        );
-      }
+        ),
+      ).rejects.toThrow(BadRequestOutOfRangeLimitException);
 
-      try {
-        await folderController.getFolderContentFolders(
+      expect(
+        folderController.getFolderContentFolders(
           userMocked,
           folder.uuid,
           50,
           -1,
           'id',
           'ASC',
-        );
-        expect(true).toBeFalsy; // getFolderContentFolders should throw an error
-      } catch (err) {
-        expect((err as Error).message).toEqual(
-          'Offset should be higher than 0',
-        );
-      }
+        ),
+      ).rejects.toThrow(BadRequestInvalidOffsetException);
     });
   });
 });

--- a/src/modules/folder/folder.controller.ts
+++ b/src/modules/folder/folder.controller.ts
@@ -16,11 +16,20 @@ import { FolderUseCases } from './folder.usecase';
 import { User as UserDecorator } from '../auth/decorators/user.decorator';
 import { User } from '../user/user.domain';
 import { FileUseCases } from '../file/file.usecase';
-import { Folder, SortableFolderAttributes } from './folder.domain';
-import { FileStatus, SortableFileAttributes } from '../file/file.domain';
+import {
+  Folder,
+  FolderAttributes,
+  SortableFolderAttributes,
+} from './folder.domain';
+import {
+  FileAttributes,
+  FileStatus,
+  SortableFileAttributes,
+} from '../file/file.domain';
 import logger from '../../externals/logger';
 import { validate } from 'uuid';
 import { HttpExceptionFilter } from '../../lib/http/http-exception.filter';
+import { isNumber } from '../../lib/validators';
 
 const foldersStatuses = ['ALL', 'EXISTS', 'TRASHED', 'DELETED'] as const;
 
@@ -112,6 +121,47 @@ export class FolderController {
     }
   }
 
+  @Get('/content/:uuid/files')
+  async getFolderContentFiles(
+    @UserDecorator() user: User,
+    @Param('uuid') folderUuid: string,
+    @Query('limit') limit: number,
+    @Query('offset') offset: number,
+    @Query('sort') sort?: SortableFileAttributes,
+    @Query('order') order?: 'ASC' | 'DESC',
+  ): Promise<{ files: FileAttributes[] }> {
+    if (!validate(folderUuid)) {
+      throw new BadRequestException('Invalid UUID provided');
+    }
+
+    if (!isNumber(limit) || !isNumber(offset)) {
+      throw new BadRequestWrongOffsetOrLimitException();
+    }
+
+    if (limit < 1 || limit > 50) {
+      throw new BadRequestOutOfRangeLimitException();
+    }
+
+    if (offset < 0) {
+      throw new BadRequestInvalidOffsetException();
+    }
+
+    const files = await this.fileUseCases.getFiles(
+      user.id,
+      {
+        folderUuid,
+        status: FileStatus.EXISTS,
+      },
+      {
+        limit,
+        offset,
+        sort: sort && order && [[sort, order]],
+      },
+    );
+
+    return { files };
+  }
+
   @Get(':id/files')
   async getFolderFiles(
     @UserDecorator() user: User,
@@ -121,8 +171,6 @@ export class FolderController {
     @Query('sort') sort?: SortableFileAttributes,
     @Query('order') order?: 'ASC' | 'DESC',
   ) {
-    const isNumber = (n) => !Number.isNaN(parseInt(n.toString()));
-
     if (folderId < 1 || !isNumber(folderId)) {
       throw new BadRequestWrongFolderIdException();
     }
@@ -162,8 +210,6 @@ export class FolderController {
     @Query('name') name: string,
     @Query('type') type: string,
   ) {
-    const isNumber = (n) => !Number.isNaN(parseInt(n.toString()));
-
     if (folderId < 1 || !isNumber(folderId)) {
       throw new BadRequestWrongFolderIdException();
     }
@@ -195,6 +241,61 @@ export class FolderController {
     return singleFile;
   }
 
+  @Get('/content/:uuid/folders')
+  async getFolderContentFolders(
+    @UserDecorator() user: User,
+    @Param('uuid') folderUuid: string,
+    @Query('limit') limit: number,
+    @Query('offset') offset: number,
+    @Query('sort') sort?: SortableFolderAttributes,
+    @Query('order') order?: 'ASC' | 'DESC',
+  ): Promise<{ folders: (FolderAttributes & { status: FileStatus })[] }> {
+    if (!validate(folderUuid)) {
+      throw new BadRequestException('Invalid UUID provided');
+    }
+
+    if (!isNumber(limit) || !isNumber(offset)) {
+      throw new BadRequestWrongOffsetOrLimitException();
+    }
+
+    if (limit < 1 || limit > 50) {
+      throw new BadRequestOutOfRangeLimitException();
+    }
+
+    if (offset < 0) {
+      throw new BadRequestInvalidOffsetException();
+    }
+
+    const folders = await this.folderUseCases.getFolders(
+      user.id,
+      {
+        parentUuid: folderUuid,
+        deleted: false,
+      },
+      {
+        limit,
+        offset,
+        sort: sort && order && [[sort, order]],
+      },
+    );
+
+    return {
+      folders: folders.map((f) => {
+        let folderStatus: FileStatus;
+
+        if (f.removed) {
+          folderStatus = FileStatus.DELETED;
+        } else if (f.deleted) {
+          folderStatus = FileStatus.TRASHED;
+        } else {
+          folderStatus = FileStatus.EXISTS;
+        }
+
+        return { ...f, status: folderStatus };
+      }),
+    };
+  }
+
   @Get(':id/folders')
   async getFolderFolders(
     @UserDecorator() user: User,
@@ -204,8 +305,6 @@ export class FolderController {
     @Query('sort') sort?: SortableFolderAttributes,
     @Query('order') order?: 'ASC' | 'DESC',
   ) {
-    const isNumber = (n) => !Number.isNaN(parseInt(n.toString()));
-
     if (folderId < 1 || !isNumber(folderId)) {
       throw new BadRequestWrongFolderIdException();
     }
@@ -272,8 +371,6 @@ export class FolderController {
     if (!knownStatus) {
       throw new BadRequestException(`Unknown status "${status.toString()}"`);
     }
-
-    const isNumber = (n) => !Number.isNaN(parseInt(n.toString()));
 
     if (!isNumber(limit) || !isNumber(offset)) {
       throw new BadRequestWrongOffsetOrLimitException();

--- a/src/modules/folder/folder.domain.ts
+++ b/src/modules/folder/folder.domain.ts
@@ -16,6 +16,7 @@ export interface FolderOptions {
 export class Folder implements FolderAttributes {
   id: number;
   parentId: number | null;
+  parentUuid: string | null;
   parent: Folder;
   type: string;
   name: string;
@@ -38,6 +39,7 @@ export class Folder implements FolderAttributes {
     id,
     uuid,
     parentId,
+    parentUuid,
     parent,
     name,
     bucket,
@@ -56,6 +58,7 @@ export class Folder implements FolderAttributes {
     this.type = 'folder';
     this.id = id;
     this.parentId = parentId;
+    this.parentUuid = parentUuid;
     this.name = name;
     this.setParent(parent);
     this.bucket = bucket;

--- a/src/modules/folder/folder.usecase.spec.ts
+++ b/src/modules/folder/folder.usecase.spec.ts
@@ -9,6 +9,7 @@ import {
   NotFoundException,
   UnprocessableEntityException,
 } from '@nestjs/common';
+import { v4 } from 'uuid';
 import { Folder, FolderAttributes, FolderOptions } from './folder.domain';
 import { BridgeModule } from '../../externals/bridge/bridge.module';
 import { CryptoModule } from '../../externals/crypto/crypto.module';
@@ -46,6 +47,7 @@ describe('FolderUseCases', () => {
       const mockFolder = Folder.build({
         id: 1,
         parentId: null,
+        parentUuid: null,
         name: 'name',
         bucket: 'bucket',
         userId: 1,
@@ -81,6 +83,7 @@ describe('FolderUseCases', () => {
       const mockFolder = Folder.build({
         id: 1,
         parentId: null,
+        parentUuid: null,
         name: 'name',
         bucket: 'bucket',
         userId: 1,
@@ -143,6 +146,7 @@ describe('FolderUseCases', () => {
         Folder.build({
           id: 4,
           parentId: 1,
+          parentUuid: v4(),
           name: nameEncrypted,
           bucket: 'bucket',
           userId: 1,
@@ -213,6 +217,7 @@ describe('FolderUseCases', () => {
       const folder = Folder.build({
         id: folderId,
         parentId: 3388762609,
+        parentUuid: v4(),
         name: 'name',
         bucket: 'bucket',
         userId: 1,
@@ -272,6 +277,7 @@ describe('FolderUseCases', () => {
       const folder = Folder.build({
         id: folderId,
         parentId: 3388762609,
+        parentUuid: v4(),
         name: 'name',
         bucket: 'bucket',
         userId: 1,
@@ -336,6 +342,7 @@ describe('FolderUseCases', () => {
       const folder = Folder.build({
         id: folderId,
         parentId: null,
+        parentUuid: null,
         name: 'name',
         bucket: 'bucket',
         userId: 1,
@@ -401,6 +408,7 @@ describe('FolderUseCases', () => {
     const folderAtributes: FolderAttributes = {
       id: 1,
       parentId: null,
+      parentUuid: null,
       parent: null,
       name: 'name',
       bucket: 'bucket',
@@ -437,6 +445,7 @@ describe('FolderUseCases', () => {
         size: 0,
       };
       delete expectedResult.parentId;
+      delete expectedResult.parentUuid;
 
       expect(result).toStrictEqual({ ...expectedResult, sharings: undefined });
     });

--- a/src/modules/fuzzy-search/look-up.domain.ts
+++ b/src/modules/fuzzy-search/look-up.domain.ts
@@ -4,7 +4,7 @@ import { UserModel } from '../user/user.model';
 
 export const itemTypes = ['file', 'folder'] as const;
 
-export type ItemType = typeof itemTypes[number];
+export type ItemType = (typeof itemTypes)[number];
 
 export interface LookUpAttributes {
   id: string;

--- a/src/modules/share/share.usecase.spec.ts
+++ b/src/modules/share/share.usecase.spec.ts
@@ -90,7 +90,6 @@ describe('Share Use Cases', () => {
   const mockFolder = Folder.build({
     id: 1,
     parentId: null,
-    parentUuid: null,
     name: 'name',
     bucket: 'bucket',
     userId: 1,

--- a/src/modules/share/share.usecase.spec.ts
+++ b/src/modules/share/share.usecase.spec.ts
@@ -90,6 +90,7 @@ describe('Share Use Cases', () => {
   const mockFolder = Folder.build({
     id: 1,
     parentId: null,
+    parentUuid: null,
     name: 'name',
     bucket: 'bucket',
     userId: 1,

--- a/src/modules/sharing/dto/create-sharing-role.dto.ts
+++ b/src/modules/sharing/dto/create-sharing-role.dto.ts
@@ -1,7 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { IsNotEmpty } from 'class-validator';
-import { SharingInvite, SharingRole } from '../sharing.domain';
-import { User } from '../../user/user.domain';
+import { SharingRole } from '../sharing.domain';
 
 export class CreateSharingRoleDto {
   @ApiProperty({

--- a/src/modules/sharing/sharing.controller.spec.ts
+++ b/src/modules/sharing/sharing.controller.spec.ts
@@ -2,7 +2,7 @@ import { SharingController } from './sharing.controller';
 import { SharingService } from './sharing.service';
 import { UuidDto } from '../../common/uuid.dto';
 import { createMock } from '@golevelup/ts-jest';
-import { Sharing } from './sharing.domain'
+import { Sharing } from './sharing.domain';
 import { newSharing } from '../../../test/fixtures';
 
 describe('SharingController', () => {
@@ -13,7 +13,7 @@ describe('SharingController', () => {
   beforeEach(async () => {
     sharingService = createMock<SharingService>();
     controller = new SharingController(sharingService);
-    sharing = newSharing({})
+    sharing = newSharing({});
   });
 
   describe('get public sharing folder size', () => {

--- a/src/modules/sharing/sharing.controller.ts
+++ b/src/modules/sharing/sharing.controller.ts
@@ -58,9 +58,6 @@ import { ThrottlerGuard } from '../../guards/throttler.guard';
 import { SetSharingPasswordDto } from './dto/set-sharing-password.dto';
 import { UuidDto } from '../../common/uuid.dto';
 import { HttpExceptionFilter } from '../../lib/http/http-exception.filter';
-import { ApplyLimit } from '../feature-limit/decorators/apply-limit.decorator';
-import { LimitLabels } from '../feature-limit/limits.enum';
-import { FeatureLimit } from '../feature-limit/feature-limits.guard';
 
 @ApiTags('Sharing')
 @Controller('sharings')

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -34,12 +34,12 @@ export type FilesSettableAttributes = Pick<
 >;
 
 type NewFolderParams = {
-  attributes?: Partial<FolderSettableAttributes>;
+  attributes?: Partial<Folder>;
   owner?: User;
 };
 
 type NewFilesParams = {
-  attributes?: Partial<FilesSettableAttributes>;
+  attributes?: Partial<File>;
   owner?: User;
   folder?: Folder;
 };

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -54,6 +54,7 @@ export const newFolder = (params?: NewFolderParams): Folder => {
       length: 20,
     }),
     parentId: randomDataGenerator.natural({ min: 1 }),
+    parentUuid: v4(),
     userId: randomDataGenerator.natural({ min: 1 }),
     createdAt: randomCreatedAt,
     updatedAt: new Date(


### PR DESCRIPTION
- Added missing parentUuid property to folders
- Added getFolderContentFolders function to get the subfolders from a folder
- Added getFolderContentFiles function to get the subfiles from a folder
- Added unit tests