### PR TITLE
[IN-31] ci: add needed actions

### DIFF
--- a/.github/workflows/build-and-publish-preview.yml
+++ b/.github/workflows/build-and-publish-preview.yml
@@ -1,0 +1,50 @@
+name: Build & Publish Stable Preview
+on:
+  push:
+    branches: ["master"]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check Out Repo
+        uses: actions/checkout@v2
+        with:
+          registry-url: 'https://npm.pkg.github.com'
+      - run: echo "registry=https://registry.yarnpkg.com/" > .npmrc
+      - run: echo "@internxt:registry=https://npm.pkg.github.com" >> .npmrc
+      # You cannot read packages from other private repos with GITHUB_TOKEN
+      # You have to use a PAT instead https://github.com/actions/setup-node/issues/49
+      - run: echo //npm.pkg.github.com/:_authToken=${{ secrets.PERSONAL_ACCESS_TOKEN }} >> .npmrc
+      - run: echo "always-auth=true" >> .npmrc
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Build and push to ${{ github.event.repository.name }}-dev
+        uses: docker/build-push-action@v2
+        with:
+          context: ./
+          file: ./infrastructure/preview.Dockerfile
+          push: true
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/${{ github.event.repository.name }}-dev:${{ github.sha }}
+  dispatch_update_preview_image:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch Update Preview Image Command
+        uses: myrotvorets/trigger-repository-dispatch-action@1.0.0
+        with:
+          token: ${{ secrets.PAT }}
+          repo: internxt/environments
+          type: update-preview-image-command
+          payload: |
+            { 
+              "image": { 
+                "name": "${{ secrets.DOCKERHUB_USERNAME }}/${{ github.event.repository.name }}",
+                "newName": "${{ secrets.DOCKERHUB_USERNAME }}/${{ github.event.repository.name }}-dev",
+                "newTag": "${{ github.sha }}"
+              }
+            }

--- a/.github/workflows/deploy-pr-preview.yml
+++ b/.github/workflows/deploy-pr-preview.yml
@@ -1,0 +1,112 @@
+name: Deploy PR Preview
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check Out Repo
+        uses: actions/checkout@v2
+        with:
+          registry-url: 'https://npm.pkg.github.com'
+      - run: echo "registry=https://registry.yarnpkg.com/" > .npmrc
+      - run: echo "@internxt:registry=https://npm.pkg.github.com" >> .npmrc
+      # You cannot read packages from other private repos with GITHUB_TOKEN
+      # You have to use a PAT instead https://github.com/actions/setup-node/issues/49
+      - run: echo //npm.pkg.github.com/:_authToken=${{ secrets.PERSONAL_ACCESS_TOKEN }} >> .npmrc
+      - run: echo "always-auth=true" >> .npmrc
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Build and push to ${{ github.event.repository.name}}-dev
+        uses: docker/build-push-action@v2
+        with:
+          context: ./
+          file: ./infrastructure/preview.Dockerfile
+          push: true
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/${{ github.event.repository.name }}-dev:preview-${{ github.event.number }}-${{ github.event.pull_request.head.sha }}
+  add_preview_label:
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+    - uses: actions-ecosystem/action-add-labels@v1
+      with:
+        labels: |
+          preview
+  dispatch_update_deployment:
+    needs: add_preview_label
+    runs-on: ubuntu-latest
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'deployed') }}
+    steps:
+      - name: Dispatch Update Preview Repository Command
+        uses: myrotvorets/trigger-repository-dispatch-action@1.0.0
+        with:
+          token: ${{ secrets.PAT }}
+          repo: internxt/environments
+          type: update-preview-command
+          payload: |
+            { 
+              "github": { 
+                "payload": { 
+                  "repository": {
+                    "name": "${{ github.event.repository.name }}",
+                    "full_name": "${{ github.event.repository.full_name }}"
+                  },
+                  "issue": {
+                    "number": ${{ github.event.number }},
+                    "labels": ${{ toJSON(github.event.pull_request.labels) }}
+                  }
+                } 
+              },
+              "slash_command": {
+                "args": {
+                  "named": {
+                    "deployment": "${{ github.event.repository.name }}",
+                    "tag": "preview-${{ github.event.number }}-${{ github.event.pull_request.head.sha }}",
+                    "imageSuffix": "-dev"
+                  }
+                }
+              } 
+            }
+  dispatch_check_deployment:
+    needs: add_preview_label
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch Check Preview Repository Command
+        uses: myrotvorets/trigger-repository-dispatch-action@1.0.0
+        with:
+          token: ${{ secrets.PAT }}
+          repo: internxt/environments
+          type: check-preview-command
+          payload: |
+            { 
+              "github": { 
+                "payload": { 
+                  "repository": {
+                    "name": "${{ github.event.repository.name }}",
+                    "full_name": "${{ github.event.repository.full_name }}",
+                    "html_url": "${{ github.event.repository.html_url }}"
+                  },
+                  "issue": {
+                    "number": ${{ github.event.number }},
+                    "labels": ${{ toJSON(github.event.pull_request.labels) }},
+                    "pull_request": {
+                      "html_url": "${{ github.event.pull_request.html_url }}"
+                    }
+                  }
+                } 
+              },
+              "slash_command": {
+                "args": {
+                  "named": {
+                    "notify": "true"
+                  }
+                }
+              } 
+            }

--- a/.github/workflows/dispatch-cleanup-pr-preview.yml
+++ b/.github/workflows/dispatch-cleanup-pr-preview.yml
@@ -1,0 +1,27 @@
+name: Clean Up PR Preview
+on:
+  pull_request:
+    types: [closed]
+jobs:
+  dispatch_cleanup_deployment:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch Cleanup Preview Repository Command
+        uses: myrotvorets/trigger-repository-dispatch-action@1.0.0
+        with:
+          token: ${{ secrets.PAT }}
+          repo: internxt/environments
+          type: cleanup-preview-command
+          payload: |
+            { 
+              "github": { 
+                "payload": { 
+                  "repository": {
+                    "name": "${{ github.event.repository.name }}"
+                  },
+                  "issue": {
+                    "number": ${{ github.event.number }}
+                  }
+                } 
+              } 
+            }

--- a/.github/workflows/slash-command-dispatcher.yaml
+++ b/.github/workflows/slash-command-dispatcher.yaml
@@ -1,0 +1,31 @@
+name: Slash Command Dispatch
+on:
+  issue_comment:
+    types: [created]
+jobs:
+  slash_command_dispatch:
+    runs-on: ubuntu-latest
+    if: ${{ contains(github.event.issue.labels.*.name, 'deployed') || contains(github.event.issue.labels.*.name, 'preview') }}
+    steps:
+      - name: Slash Command Dispatch
+        id: scd
+        uses: peter-evans/slash-command-dispatch@v4
+        with:
+          token: ${{ secrets.PAT }}
+          commands: update-preview,check-preview
+          permission: write
+          repository: internxt/environments
+          issue-type: pull-request
+          allow-edits: false
+          reactions: false
+      - name: Edit comment with error message
+        if: steps.scd.outputs.error-message
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          comment-id: ${{ github.event.comment.id }}
+          body: |
+            
+            > [!CAUTION]
+            > Couldn't dispatch your command due to error:
+            > **${{ steps.scd.outputs.error-message }}**
+  

--- a/infrastructure/preview.Dockerfile
+++ b/infrastructure/preview.Dockerfile
@@ -1,0 +1,14 @@
+FROM node:20.10-alpine
+
+WORKDIR /usr/app
+
+COPY package.json ./
+COPY yarn.lock ./
+COPY .npmrc ./
+
+RUN yarn
+COPY . ./
+
+RUN yarn build
+
+CMD yarn migrate && yarn db:seed:test:all && yarn start:dev


### PR DESCRIPTION
# Add required actions for PR Preview

These actions would

* build and publish a Docker image with every push to the branch
* add preview label when the PR is ready_for_review (this triggers the app creation)
* clean up the created app whe the PR is closed
* build and publish a Docker image when the PR is merged
* enable slash commands to check and update the created environment


> [!NOTE]
> This PR needs this secrets to be configured in order to work
> - `PAT` - A GitHub Personal Access Token with following scopes `repo:status` `public_repo`.
> - `DOCKERHUB_USERNAME` - The username for the DockerHub account.
> - `DOCKERHUB_TOKEN` - The token for the DockerHub account.
>