### PR TITLE
[PB-1740]: feat/add items to trash by uuid

### DIFF
--- a/src/modules/file/file.repository.ts
+++ b/src/modules/file/file.repository.ts
@@ -416,6 +416,33 @@ export class SequelizeFileRepository implements FileRepository {
     );
   }
 
+  async updateFilesStatusToTrashedByUuid(
+    user: User,
+    fileUuids: File['uuid'][],
+  ): Promise<void> {
+    await this.fileModel.update(
+      {
+        // Remove this after status is the main field
+        deleted: true,
+        deletedAt: new Date(),
+        //
+        status: FileStatus.TRASHED,
+        updatedAt: new Date(),
+      },
+      {
+        where: {
+          userId: user.id,
+          uuid: {
+            [Op.in]: fileUuids,
+          },
+          status: {
+            [Op.not]: FileStatus.DELETED,
+          },
+        },
+      },
+    );
+  }
+
   async deleteFilesByUser(user: User, files: File[]): Promise<void> {
     await this.fileModel.update(
       {

--- a/src/modules/file/file.repository.ts
+++ b/src/modules/file/file.repository.ts
@@ -443,7 +443,6 @@ export class SequelizeFileRepository implements FileRepository {
           },
           status: {
             [Op.eq]: FileStatus.EXISTS,
-            [Op.not]: FileStatus.DELETED,
           },
         },
       },

--- a/src/modules/file/file.repository.ts
+++ b/src/modules/file/file.repository.ts
@@ -418,7 +418,6 @@ export class SequelizeFileRepository implements FileRepository {
           },
           status: {
             [Op.eq]: FileStatus.EXISTS,
-            [Op.not]: FileStatus.DELETED,
           },
         },
       },

--- a/src/modules/file/file.repository.ts
+++ b/src/modules/file/file.repository.ts
@@ -56,6 +56,14 @@ export interface FileRepository {
   ): Promise<void>;
   getFilesWhoseFolderIdDoesNotExist(userId: File['userId']): Promise<number>;
   getFilesCountWhere(where: Partial<File>): Promise<number>;
+  updateFilesStatusToTrashed(
+    user: User,
+    fileIds: File['fileId'][],
+  ): Promise<void>;
+  updateFilesStatusToTrashedByUuid(
+    user: User,
+    fileUuids: File['uuid'][],
+  ): Promise<void>;
 }
 
 @Injectable()
@@ -422,10 +430,8 @@ export class SequelizeFileRepository implements FileRepository {
   ): Promise<void> {
     await this.fileModel.update(
       {
-        // Remove this after status is the main field
         deleted: true,
         deletedAt: new Date(),
-        //
         status: FileStatus.TRASHED,
         updatedAt: new Date(),
       },

--- a/src/modules/file/file.repository.ts
+++ b/src/modules/file/file.repository.ts
@@ -417,6 +417,7 @@ export class SequelizeFileRepository implements FileRepository {
             [Op.in]: fileIds,
           },
           status: {
+            [Op.eq]: FileStatus.EXISTS,
             [Op.not]: FileStatus.DELETED,
           },
         },
@@ -442,6 +443,7 @@ export class SequelizeFileRepository implements FileRepository {
             [Op.in]: fileUuids,
           },
           status: {
+            [Op.eq]: FileStatus.EXISTS,
             [Op.not]: FileStatus.DELETED,
           },
         },

--- a/src/modules/file/file.usecase.spec.ts
+++ b/src/modules/file/file.usecase.spec.ts
@@ -4,7 +4,6 @@ import { FileUseCases } from './file.usecase';
 import { SequelizeFileRepository, FileRepository } from './file.repository';
 import {
   ForbiddenException,
-  NotFoundException,
   UnprocessableEntityException,
 } from '@nestjs/common';
 import { File, FileAttributes, FileStatus } from './file.domain';

--- a/src/modules/file/file.usecase.spec.ts
+++ b/src/modules/file/file.usecase.spec.ts
@@ -89,61 +89,45 @@ describe('FileUseCases', () => {
   });
 
   describe('move file to trash', () => {
-    it.skip('calls moveFilesToTrash and return file', async () => {
-      const mockFile = File.build({
-        id: 1,
-        fileId: '',
-        name: '',
-        type: '',
-        size: null,
-        bucket: '',
-        folderId: 4,
-        encryptVersion: '',
-        deleted: false,
-        deletedAt: new Date(),
-        userId: 1,
-        modificationTime: new Date(),
-        createdAt: new Date(),
-        updatedAt: new Date(),
-        uuid: '',
-        folderUuid: '',
-        removed: false,
-        removedAt: undefined,
-        plainName: '',
-        status: FileStatus.EXISTS,
-      });
-      jest
-        .spyOn(fileRepository, 'updateByFieldIdAndUserId')
-        .mockResolvedValue(mockFile);
-      const result = await service.moveFilesToTrash(userMocked, [fileId]);
-      expect(result).toEqual(mockFile);
+    const mockFile = File.build({
+      id: 1,
+      fileId: '',
+      name: '',
+      type: '',
+      size: null,
+      bucket: '',
+      folderId: 4,
+      encryptVersion: '',
+      deleted: false,
+      deletedAt: new Date(),
+      userId: 1,
+      modificationTime: new Date(),
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      uuid: '723274e5-ca2a-4e61-bf17-d9fba3b8d430',
+      folderUuid: '',
+      removed: false,
+      removedAt: undefined,
+      plainName: '',
+      status: FileStatus.EXISTS,
     });
 
-    it.skip('throws an error if the file is not found', async () => {
-      jest
-        .spyOn(fileRepository, 'updateByFieldIdAndUserId')
-        .mockRejectedValue(new NotFoundException());
-      expect(service.moveFilesToTrash(userMocked, [fileId])).rejects.toThrow(
-        NotFoundException,
-      );
-    });
-  });
-
-  describe('move multiple files to trash', () => {
-    it.skip('calls moveFilesToTrash', async () => {
+    it('When you try to trash files with id and uuid, then functions are called with respective values', async () => {
       const fileIds = [fileId];
-      jest
-        .spyOn(fileRepository, 'updateManyByFieldIdAndUserId')
-        .mockImplementation(() => {
-          return new Promise((resolve) => {
-            resolve();
-          });
-        });
-      const result = await service.moveFilesToTrash(userMocked, fileIds);
-      expect(result).toEqual(undefined);
-      expect(fileRepository.updateManyByFieldIdAndUserId).toHaveBeenCalledTimes(
+      const fileUuids = [mockFile.uuid];
+      jest.spyOn(fileRepository, 'updateFilesStatusToTrashed');
+      jest.spyOn(fileRepository, 'updateFilesStatusToTrashedByUuid');
+      await service.moveFilesToTrash(userMocked, fileIds, fileUuids);
+      expect(fileRepository.updateFilesStatusToTrashed).toHaveBeenCalledTimes(
         1,
       );
+      expect(fileRepository.updateFilesStatusToTrashed).toHaveBeenCalledWith(
+        userMocked,
+        fileIds,
+      );
+      expect(
+        fileRepository.updateFilesStatusToTrashedByUuid,
+      ).toHaveBeenCalledWith(userMocked, fileUuids);
     });
   });
 

--- a/src/modules/file/file.usecase.ts
+++ b/src/modules/file/file.usecase.ts
@@ -248,8 +248,12 @@ export class FileUseCases {
   moveFilesToTrash(
     user: User,
     fileIds: FileAttributes['fileId'][],
-  ): Promise<void> {
-    return this.fileRepository.updateFilesStatusToTrashed(user, fileIds);
+    fileUuids: FileAttributes['uuid'][] = [],
+  ): Promise<[void, void]> {
+    return Promise.all([
+      this.fileRepository.updateFilesStatusToTrashed(user, fileIds),
+      this.fileRepository.updateFilesStatusToTrashedByUuid(user, fileUuids),
+    ]);
   }
 
   async getEncryptionKeyFileFromShare(

--- a/src/modules/folder/folder.repository.ts
+++ b/src/modules/folder/folder.repository.ts
@@ -149,7 +149,12 @@ export class SequelizeFolderRepository implements FolderRepository {
 
   async findUserFoldersByUuid(user: User, uuids: FolderAttributes['uuid'][]) {
     const folders = await this.folderModel.findAll({
-      where: { uuid: { [Op.in]: uuids }, userId: user.id },
+      where: {
+        uuid: { [Op.in]: uuids },
+        userId: user.id,
+        deleted: false,
+        removed: false,
+      },
     });
     return folders.map((folder) => this.toDomain(folder));
   }

--- a/src/modules/folder/folder.repository.ts
+++ b/src/modules/folder/folder.repository.ts
@@ -143,6 +143,13 @@ export class SequelizeFolderRepository implements FolderRepository {
     return folders.map((folder) => this.toDomain(folder));
   }
 
+  async findUserFoldersByUuid(user: User, uuids: FolderAttributes['uuid'][]) {
+    const folders = await this.folderModel.findAll({
+      where: { uuid: { [Op.in]: uuids }, userId: user.id },
+    });
+    return folders.map((folder) => this.toDomain(folder));
+  }
+
   async findAllByParentIdCursor(
     where: Partial<FolderAttributes>,
     limit: number,

--- a/src/modules/folder/folder.repository.ts
+++ b/src/modules/folder/folder.repository.ts
@@ -65,6 +65,10 @@ export interface FolderRepository {
   deleteById(folderId: FolderAttributes['id']): Promise<void>;
   clearOrphansFolders(userId: FolderAttributes['userId']): Promise<number>;
   calculateFolderSize(folderUuid: string): Promise<number>;
+  findUserFoldersByUuid(
+    user: User,
+    uuids: FolderAttributes['uuid'][],
+  ): Promise<Folder[]>;
 }
 
 @Injectable()

--- a/src/modules/folder/folder.usecase.spec.ts
+++ b/src/modules/folder/folder.usecase.spec.ts
@@ -15,10 +15,12 @@ import { BridgeModule } from '../../externals/bridge/bridge.module';
 import { CryptoModule } from '../../externals/crypto/crypto.module';
 import { CryptoService } from '../../externals/crypto/crypto.service';
 import { User } from '../user/user.domain';
-import { newFolder } from '../../../test/fixtures';
+import { newFolder, newUser } from '../../../test/fixtures';
 import { CalculateFolderSizeTimeoutException } from './exception/calculate-folder-size-timeout.exception';
 
 const folderId = 4;
+const user = newUser();
+
 describe('FolderUseCases', () => {
   let service: FolderUseCases;
   let folderRepository: FolderRepository;
@@ -104,6 +106,76 @@ describe('FolderUseCases', () => {
       expect(service.moveFolderToTrash(folderId)).rejects.toThrow(
         NotFoundException,
       );
+    });
+  });
+
+  describe('move multiple folders to trash', () => {
+    const rootFolderBucket = 'bucketRoot';
+    const mockFolder = Folder.build({
+      id: 1,
+      parentId: null,
+      parentUuid: null,
+      name: 'name',
+      bucket: rootFolderBucket,
+      userId: 1,
+      encryptVersion: '03-aes',
+      deleted: true,
+      deletedAt: new Date(),
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      uuid: '',
+      plainName: '',
+      removed: false,
+      removedAt: null,
+    });
+
+    it('When uuid and id are passed and there is a backup and drive folder, then should backups and drive folders should be updated', async () => {
+      const mockBackupFolder = Folder.build({
+        id: 1,
+        parentId: null,
+        parentUuid: null,
+        name: 'name',
+        bucket: 'bucketIdforBackup',
+        userId: 1,
+        encryptVersion: '03-aes',
+        deleted: true,
+        deletedAt: new Date(),
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        uuid: '',
+        plainName: '',
+        removed: false,
+        removedAt: null,
+      });
+
+      jest
+        .spyOn(service, 'getFoldersByIds')
+        .mockResolvedValue([mockBackupFolder]);
+      jest
+        .spyOn(folderRepository, 'findUserFoldersByUuid')
+        .mockResolvedValue([mockFolder]);
+      jest.spyOn(service, 'getFolder').mockResolvedValue({
+        bucket: rootFolderBucket,
+      } as Folder);
+      jest.spyOn(folderRepository, 'updateManyByFolderId');
+
+      await service.moveFoldersToTrash(
+        user,
+        [mockBackupFolder.id],
+        [mockFolder.uuid],
+      );
+      expect(folderRepository.updateManyByFolderId).toHaveBeenCalledTimes(2);
+    });
+
+    it('When only ids are passed, then only folders by id should be searched', async () => {
+      jest.spyOn(service, 'getFoldersByIds').mockResolvedValue([mockFolder]);
+      jest.spyOn(service, 'getFolder').mockResolvedValue({
+        bucket: rootFolderBucket,
+      } as Folder);
+      jest.spyOn(folderRepository, 'findUserFoldersByUuid');
+
+      await service.moveFoldersToTrash(user, [mockFolder.id]);
+      expect(folderRepository.findUserFoldersByUuid).not.toHaveBeenCalled();
     });
   });
 

--- a/src/modules/folder/folder.usecase.spec.ts
+++ b/src/modules/folder/folder.usecase.spec.ts
@@ -123,13 +123,13 @@ describe('FolderUseCases', () => {
       deletedAt: new Date(),
       createdAt: new Date(),
       updatedAt: new Date(),
-      uuid: '',
+      uuid: '2545feaf-4d6b-40d8-9bf8-550285268bd3',
       plainName: '',
       removed: false,
       removedAt: null,
     });
 
-    it('When uuid and id are passed and there is a backup and drive folder, then should backups and drive folders should be updated', async () => {
+    it('When uuid and id are passed and there is a backup and drive folder, then backups and drive folders should be updated', async () => {
       const mockBackupFolder = Folder.build({
         id: 1,
         parentId: null,
@@ -164,7 +164,24 @@ describe('FolderUseCases', () => {
         [mockBackupFolder.id],
         [mockFolder.uuid],
       );
+
       expect(folderRepository.updateManyByFolderId).toHaveBeenCalledTimes(2);
+      expect(folderRepository.updateManyByFolderId).toHaveBeenCalledWith(
+        [mockFolder.id],
+        {
+          deleted: true,
+          deletedAt: expect.any(Date),
+        },
+      );
+      expect(folderRepository.updateManyByFolderId).toHaveBeenCalledWith(
+        [mockBackupFolder.id],
+        {
+          deleted: true,
+          deletedAt: expect.any(Date),
+          removed: true,
+          removedAt: expect.any(Date),
+        },
+      );
     });
 
     it('When only ids are passed, then only folders by id should be searched', async () => {
@@ -173,9 +190,13 @@ describe('FolderUseCases', () => {
         bucket: rootFolderBucket,
       } as Folder);
       jest.spyOn(folderRepository, 'findUserFoldersByUuid');
+      jest.spyOn(service, 'getFoldersByIds');
 
       await service.moveFoldersToTrash(user, [mockFolder.id]);
       expect(folderRepository.findUserFoldersByUuid).not.toHaveBeenCalled();
+      expect(service.getFoldersByIds).toHaveBeenCalledWith(user, [
+        mockFolder.id,
+      ]);
     });
   });
 

--- a/src/modules/folder/folder.usecase.ts
+++ b/src/modules/folder/folder.usecase.ts
@@ -293,11 +293,15 @@ export class FolderUseCases {
   async moveFoldersToTrash(
     user: User,
     folderIds: FolderAttributes['id'][],
+    folderUuids: FolderAttributes['uuid'][] = [],
   ): Promise<void> {
-    const [folders, driveRootFolder] = await Promise.all([
+    const [foldersById, driveRootFolder, foldersByUuid] = await Promise.all([
       this.getFoldersByIds(user, folderIds),
       this.getFolder(user.rootFolderId),
+      this.folderRepository.findUserFoldersByUuid(user, folderUuids),
     ]);
+
+    const folders = foldersById.concat(foldersByUuid);
 
     const backups = folders.filter((f) => f.isBackup(driveRootFolder));
     const driveFolders = folders.filter((f) => !f.isBackup(driveRootFolder));

--- a/src/modules/folder/folder.usecase.ts
+++ b/src/modules/folder/folder.usecase.ts
@@ -298,7 +298,9 @@ export class FolderUseCases {
     const [foldersById, driveRootFolder, foldersByUuid] = await Promise.all([
       this.getFoldersByIds(user, folderIds),
       this.getFolder(user.rootFolderId),
-      this.folderRepository.findUserFoldersByUuid(user, folderUuids),
+      folderUuids.length > 0
+        ? this.folderRepository.findUserFoldersByUuid(user, folderUuids)
+        : Promise.resolve<Folder[]>([]),
     ]);
 
     const folders = foldersById.concat(foldersByUuid);

--- a/src/modules/trash/dto/controllers/move-items-to-trash.dto.spec.ts
+++ b/src/modules/trash/dto/controllers/move-items-to-trash.dto.spec.ts
@@ -11,7 +11,7 @@ describe('MoveItemsToTrashDto', () => {
     const dto = plainToInstance(MoveItemsToTrashDto, {
       items: [
         { id: '1', type: ItemType.FILE },
-        { uuid: 'uuid-2', type: ItemType.FOLDER },
+        { uuid: '5bf9dca1-fd68-4864-9a16-ef36b77d063b', type: ItemType.FOLDER },
       ],
     });
 
@@ -35,7 +35,7 @@ describe('MoveItemsToTrashDto', () => {
     it('When both id and uuid are provided in one item, then should fail', async () => {
       const item = plainToInstance(ItemToTrash, {
         id: '1',
-        uuid: 'uuid-1',
+        uuid: '5bf9dca1-fd68-4864-9a16-ef36b77d063b',
         type: ItemType.FILE,
       });
       const errors = await validate(item);
@@ -54,7 +54,7 @@ describe('MoveItemsToTrashDto', () => {
       );
       const onlyUuidErrors = await validate(
         plainToInstance(ItemToTrash, {
-          uuid: 'uuid-1',
+          uuid: '5bf9dca1-fd68-4864-9a16-ef36b77d063b',
           type: ItemType.FILE,
         }),
       );

--- a/src/modules/trash/dto/controllers/move-items-to-trash.dto.spec.ts
+++ b/src/modules/trash/dto/controllers/move-items-to-trash.dto.spec.ts
@@ -1,0 +1,65 @@
+import { validate } from 'class-validator';
+import { plainToInstance } from 'class-transformer';
+import {
+  ItemToTrash,
+  ItemType,
+  MoveItemsToTrashDto,
+} from './move-items-to-trash.dto';
+
+describe('MoveItemsToTrashDto', () => {
+  it('When valid data is passed, then no errors should be returned', async () => {
+    const dto = plainToInstance(MoveItemsToTrashDto, {
+      items: [
+        { id: '1', type: ItemType.FILE },
+        { uuid: 'uuid-2', type: ItemType.FOLDER },
+      ],
+    });
+
+    const errors = await validate(dto);
+    expect(errors.length).toBe(0);
+  });
+
+  it('When items array exceeds max size, then should fail', async () => {
+    const items = Array.from({ length: 51 }, (_, i) => ({
+      id: `${i + 1}`,
+      type: ItemType.FILE,
+    }));
+    const dto = plainToInstance(MoveItemsToTrashDto, { items });
+
+    const errors = await validate(dto);
+    expect(errors.length).toBeGreaterThan(0);
+    expect(errors[0].constraints).toBeDefined();
+  });
+
+  describe('ItemToTrash', () => {
+    it('When both id and uuid are provided in one item, then should fail', async () => {
+      const item = plainToInstance(ItemToTrash, {
+        id: '1',
+        uuid: 'uuid-1',
+        type: ItemType.FILE,
+      });
+      const errors = await validate(item);
+      expect(errors.length).toBeGreaterThan(0);
+    });
+
+    it('When neither id nor uuid are provided in one item, then should fail', async () => {
+      const item = plainToInstance(ItemToTrash, { type: ItemType.FILE });
+      const errors = await validate(item);
+      expect(errors.length).toBeGreaterThan(0);
+    });
+
+    it('when either id or uuid are provided, then should validate successfuly ', async () => {
+      const onlyIdErrors = await validate(
+        plainToInstance(ItemToTrash, { id: '1', type: ItemType.FILE }),
+      );
+      const onlyUuidErrors = await validate(
+        plainToInstance(ItemToTrash, {
+          uuid: 'uuid-1',
+          type: ItemType.FILE,
+        }),
+      );
+      expect(onlyIdErrors.length).toBe(0);
+      expect(onlyUuidErrors.length).toBe(0);
+    });
+  });
+});

--- a/src/modules/trash/dto/controllers/move-items-to-trash.dto.ts
+++ b/src/modules/trash/dto/controllers/move-items-to-trash.dto.ts
@@ -29,7 +29,7 @@ export class ItemToTrash {
 
   @ValidateIf((item) => (!item.id && !item.uuid) || (item.id && item.uuid))
   @IsDefined({ message: 'Provide either item id or uuid, and not both' })
-  protected readonly combinedCheck: undefined;
+  readonly AreUuidAndIdDefined?: boolean;
 
   @IsEnum(ItemType)
   @ApiProperty({

--- a/src/modules/trash/dto/controllers/move-items-to-trash.dto.ts
+++ b/src/modules/trash/dto/controllers/move-items-to-trash.dto.ts
@@ -1,5 +1,12 @@
 import { Type } from 'class-transformer';
-import { ArrayMaxSize, IsEnum, IsNotEmpty } from 'class-validator';
+import {
+  ArrayMaxSize,
+  IsDefined,
+  IsEnum,
+  IsNotEmpty,
+  ValidateIf,
+  ValidateNested,
+} from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
 
 export enum ItemType {
@@ -8,12 +15,21 @@ export enum ItemType {
 }
 
 export class ItemToTrash {
-  @IsNotEmpty()
   @ApiProperty({
     example: '4',
     description: 'Id of file or folder',
   })
-  id: string;
+  id?: string;
+
+  @ApiProperty({
+    example: '4',
+    description: 'Uuid of file or folder',
+  })
+  uuid?: string;
+
+  @ValidateIf((item) => (!item.id && !item.uuid) || (item.id && item.uuid))
+  @IsDefined({ message: 'Provide either item id or uuid, and not both' })
+  protected readonly combinedCheck: undefined;
 
   @IsEnum(ItemType)
   @ApiProperty({
@@ -29,6 +45,7 @@ export class MoveItemsToTrashDto {
     description: 'Array of items with files and folders ids',
   })
   @ArrayMaxSize(50)
+  @ValidateNested()
   @Type(() => ItemToTrash)
   items: ItemToTrash[];
 }

--- a/src/modules/trash/trash.controller.spec.ts
+++ b/src/modules/trash/trash.controller.spec.ts
@@ -1,0 +1,113 @@
+import { createMock } from '@golevelup/ts-jest';
+import { TrashController } from './trash.controller';
+import { FileUseCases } from '../file/file.usecase';
+import { FolderUseCases } from '../folder/folder.usecase';
+import { UserUseCases } from '../user/user.usecase';
+import { TrashUseCases } from './trash.usecase';
+import { NotificationService } from '../../externals/notifications/notification.service';
+import { newUser } from '../../../test/fixtures';
+import { BadRequestException } from '@nestjs/common';
+import { ItemType } from './dto/controllers/move-items-to-trash.dto';
+
+const user = newUser();
+
+describe('TrashController', () => {
+  let controller: TrashController;
+  let folderUseCases: FolderUseCases;
+  let fileUseCases: FileUseCases;
+  let userUseCases: UserUseCases;
+  let trashUseCases: TrashUseCases;
+  let notificationService: NotificationService;
+
+  beforeEach(async () => {
+    folderUseCases = createMock<FolderUseCases>();
+    fileUseCases = createMock<FileUseCases>();
+    userUseCases = createMock<UserUseCases>();
+    trashUseCases = createMock<TrashUseCases>();
+    notificationService = createMock<NotificationService>();
+    controller = new TrashController(
+      fileUseCases,
+      folderUseCases,
+      userUseCases,
+      notificationService,
+      trashUseCases,
+    );
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  it('When item type is invalid, then it should throw', async () => {
+    await expect(
+      controller.moveItemsToTrash(
+        {
+          items: [
+            {
+              uuid: '5bf9dca1-fd68-4864-9a16-ef36b77d063b',
+              type: 'test' as ItemType,
+            },
+          ],
+        },
+        user,
+        'anyid',
+      ),
+    ).rejects.toThrow(BadRequestException);
+  });
+
+  it('When array is empty, then it should not call anything', async () => {
+    const body = { items: [] };
+    jest.spyOn(fileUseCases, 'moveFilesToTrash');
+
+    await controller.moveItemsToTrash(body, user, '');
+    expect(fileUseCases.moveFilesToTrash).not.toHaveBeenCalled();
+  });
+
+  it('When items are passed, then items should be deleted with their respective uuid or id', async () => {
+    const fileItems = [
+      {
+        uuid: '5bf9dca1-fd68-4864-9a16-ef36b77d063b',
+        type: ItemType.FILE,
+      },
+      {
+        id: '2',
+        type: ItemType.FILE,
+      },
+    ];
+    const folderItems = [
+      {
+        id: '1',
+        type: ItemType.FOLDER,
+      },
+      {
+        uuid: '9af7dca1-fd68-4864-9b60-ef36b77d0903',
+        type: ItemType.FOLDER,
+      },
+    ];
+
+    jest.spyOn(fileUseCases, 'moveFilesToTrash');
+    jest.spyOn(folderUseCases, 'moveFoldersToTrash');
+    jest
+      .spyOn(userUseCases, 'getWorkspaceMembersByBrigeUser')
+      .mockResolvedValue([]);
+
+    await controller.moveItemsToTrash(
+      {
+        items: [...fileItems, ...folderItems],
+      },
+      user,
+      '',
+    );
+
+    expect(fileUseCases.moveFilesToTrash).toHaveBeenCalledWith(
+      user,
+      [fileItems[1].id],
+      [fileItems[0].uuid],
+    );
+    expect(folderUseCases.moveFoldersToTrash).toHaveBeenCalledWith(
+      user,
+      [parseInt(folderItems[0].id)],
+      [folderItems[1].uuid],
+    );
+  });
+});

--- a/src/modules/trash/trash.controller.ts
+++ b/src/modules/trash/trash.controller.ts
@@ -137,19 +137,30 @@ export class TrashController {
 
     try {
       const fileIds: string[] = [];
+      const fileUuids: string[] = [];
       const folderIds: number[] = [];
+      const folderUuids: string[] = [];
+
       for (const item of moveItemsDto.items) {
         if (item.type === 'file') {
-          fileIds.push(item.id);
+          if (item.id) {
+            fileIds.push(item.id);
+          } else {
+            fileUuids.push(item.uuid);
+          }
         } else if (item.type === 'folder') {
-          folderIds.push(parseInt(item.id));
+          if (item.id) {
+            folderIds.push(parseInt(item.id));
+          } else {
+            folderUuids.push(item.uuid);
+          }
         } else {
           throw new BadRequestException(`type ${item.type} invalid`);
         }
       }
       await Promise.all([
-        this.fileUseCases.moveFilesToTrash(user, fileIds),
-        this.folderUseCases.moveFoldersToTrash(user, folderIds),
+        this.fileUseCases.moveFilesToTrash(user, fileIds, fileUuids),
+        this.folderUseCases.moveFoldersToTrash(user, folderIds, folderUuids),
       ]);
 
       this.userUseCases


### PR DESCRIPTION
This PR allows to add files by uuid to trash.

Either id or uuid should be provided inside the items. If none is provided, then the input is invalid.