### PR TITLE
[PB-1429]: Feat/max storage days limit

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "@nestjs/jwt": "^10.2.0",
     "@nestjs/passport": "^10.0.2",
     "@nestjs/platform-express": "^10.2.8",
+    "@nestjs/schedule": "^4.0.1",
     "@nestjs/sequelize": "^10.0.0",
     "@nestjs/swagger": "^7.1.16",
     "@nestjs/throttler": "^5.0.1",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -23,6 +23,7 @@ import { FuzzySearchModule } from './modules/fuzzy-search/fuzzy-search.module';
 import { SharingModule } from './modules/sharing/sharing.module';
 import { AppSumoModule } from './modules/app-sumo/app-sumo.module';
 import { PlanModule } from './modules/plan/plan.module';
+import { ScheduleModule } from '@nestjs/schedule';
 
 @Module({
   imports: [
@@ -97,6 +98,7 @@ import { PlanModule } from './modules/plan/plan.module';
         limit: 5,
       },
     ]),
+    ScheduleModule.forRoot(),
     NotificationModule,
     FileModule,
     FolderModule,

--- a/src/modules/feature-limit/feature-limit.usecase.ts
+++ b/src/modules/feature-limit/feature-limit.usecase.ts
@@ -149,4 +149,8 @@ export class FeatureLimitUsecases {
       LimitLabels.MaxTrashStorageDays,
     );
   }
+
+  async getFreeTier() {
+    return this.limitsRepository.getFreeTier();
+  }
 }

--- a/src/modules/feature-limit/feature-limit.usecase.ts
+++ b/src/modules/feature-limit/feature-limit.usecase.ts
@@ -142,4 +142,11 @@ export class FeatureLimitUsecases {
   async getLimitByLabelAndTier(label: string, tierId: string) {
     return this.limitsRepository.findLimitByLabelAndTier(tierId, label);
   }
+
+  async getTierMaxTrashStorageDays(tierId: string) {
+    return this.limitsRepository.findLimitByLabelAndTier(
+      tierId,
+      LimitLabels.MaxTrashStorageDays,
+    );
+  }
 }

--- a/src/modules/feature-limit/limit.domain.ts
+++ b/src/modules/feature-limit/limit.domain.ts
@@ -26,6 +26,14 @@ export class Limit {
     return this.type === LimitTypes.Boolean;
   }
 
+  getLimitValue() {
+    if (this.isBooleanLimit()) {
+      return this.value === 'true';
+    }
+
+    return Number(this.value);
+  }
+
   private isFeatureEnabled() {
     return this.isBooleanLimit() && this.value === 'true';
   }

--- a/src/modules/feature-limit/limits.enum.ts
+++ b/src/modules/feature-limit/limits.enum.ts
@@ -1,6 +1,7 @@
 export enum LimitLabels {
   MaxSharedItems = 'max-shared-items',
   MaxSharedItemInvites = 'max-shared-invites',
+  MaxTrashStorageDays = 'max-trash-storage-days',
 }
 
 export enum LimitTypes {

--- a/src/modules/feature-limit/models/tier.model.ts
+++ b/src/modules/feature-limit/models/tier.model.ts
@@ -10,7 +10,7 @@ import {
 } from 'sequelize-typescript';
 import { Limitmodel } from './limit.model';
 import { TierLimitsModel } from './tier-limits.model';
-import { UserModel } from 'src/modules/user/user.model';
+import { UserModel } from '../../../modules/user/user.model';
 
 export interface TierAttributes {
   id: string;

--- a/src/modules/feature-limit/models/tier.model.ts
+++ b/src/modules/feature-limit/models/tier.model.ts
@@ -5,7 +5,12 @@ import {
   PrimaryKey,
   DataType,
   AllowNull,
+  HasMany,
+  BelongsToMany,
 } from 'sequelize-typescript';
+import { Limitmodel } from './limit.model';
+import { TierLimitsModel } from './tier-limits.model';
+import { UserModel } from 'src/modules/user/user.model';
 
 export interface TierAttributes {
   id: string;
@@ -37,4 +42,12 @@ export class TierModel extends Model implements TierAttributes {
 
   @Column
   updatedAt: Date;
+
+  @BelongsToMany(() => Limitmodel, {
+    through: () => TierLimitsModel,
+  })
+  limits: Limitmodel[];
+
+  @HasMany(() => UserModel, 'tierId')
+  users?: UserModel[];
 }

--- a/src/modules/file/file.repository.ts
+++ b/src/modules/file/file.repository.ts
@@ -49,6 +49,8 @@ export interface FileRepository {
   ): Promise<void>;
   getFilesWhoseFolderIdDoesNotExist(userId: File['userId']): Promise<number>;
   getFilesCountWhere(where: Partial<File>): Promise<number>;
+  getTrashedExpiredFiles(): Promise<FileModel[]>;
+  deleteTrashedFilesById(fileIds: File['fileId'][]): Promise<void>;
 }
 
 @Injectable()

--- a/src/modules/file/file.repository.ts
+++ b/src/modules/file/file.repository.ts
@@ -1,7 +1,7 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
 import { InjectModel } from '@nestjs/sequelize';
 import { File, FileAttributes, FileOptions, FileStatus } from './file.domain';
-import { FindOptions, Op } from 'sequelize';
+import { FindOptions, Op, Sequelize } from 'sequelize';
 
 import { User } from '../user/user.domain';
 import { Folder } from '../folder/folder.domain';
@@ -10,6 +10,10 @@ import { ShareModel } from '../share/share.repository';
 import { ThumbnailModel } from '../thumbnail/thumbnail.model';
 import { FileModel } from './file.model';
 import { SharingModel } from '../sharing/models';
+import { UserModel } from '../user/user.model';
+import { TierModel } from '../feature-limit/models/tier.model';
+import { Limitmodel } from '../feature-limit/models/limit.model';
+import { LimitLabels } from '../feature-limit/limits.enum';
 
 export interface FileRepository {
   deleteByFileId(fileId: any): Promise<any>;
@@ -359,6 +363,52 @@ export class SequelizeFileRepository implements FileRepository {
     const { count } = await this.fileModel.findAndCountAll({ where });
 
     return count;
+  }
+
+  async getTrashedExpiredFiles(limit?: number) {
+    const files = await this.fileModel.findAll({
+      attributes: ['status', 'plainName', 'updatedAt', 'fileId', 'uuid'],
+      replacements: { limitLabel: LimitLabels.MaxTrashStorageDays },
+      where: {
+        status: 'TRASHED',
+        updatedAt: {
+          [Op.lt]: Sequelize.literal(`now() - (SELECT value :: integer
+      FROM
+          limits
+          JOIN tiers_limits ON limits.id = tiers_limits.limit_id
+          JOIN tiers ON tiers_limits.tier_id = tiers.id
+      WHERE
+          tiers.id = "user"."tier_id" AND limits.label = :limitLabel) * INTERVAL '1 day'`),
+        },
+      },
+      include: {
+        model: UserModel,
+        attributes: ['uuid', 'id', 'tierId'],
+      },
+      limit,
+    });
+    return files;
+  }
+
+  async deleteTrashedFilesById(fileIds: File['fileId'][]): Promise<void> {
+    await this.fileModel.update(
+      {
+        removed: true,
+        removedAt: new Date(),
+        status: FileStatus.DELETED,
+        updatedAt: new Date(),
+      },
+      {
+        where: {
+          fileId: {
+            [Op.in]: fileIds,
+          },
+          status: {
+            [Op.eq]: FileStatus.TRASHED,
+          },
+        },
+      },
+    );
   }
 
   async updateFilesStatusToTrashed(

--- a/src/modules/file/file.usecase.spec.ts
+++ b/src/modules/file/file.usecase.spec.ts
@@ -480,4 +480,30 @@ describe('FileUseCases', () => {
       }
     });
   });
+
+  describe('Delete Trashed Expired Files', () => {
+    it('When there are no more files to fetch, then should stop', async () => {
+      jest
+        .spyOn(fileRepository, 'getTrashedExpiredFiles')
+        .mockResolvedValue([]);
+
+      await service.deleteTrashedExpiredFiles();
+
+      expect(fileRepository.getTrashedExpiredFiles).toHaveBeenCalledTimes(1);
+    });
+
+    it('When there are expired files, then it should delete them', async () => {
+      const fileIds = [{ fileId: 1 }, { fileId: 2 }] as any;
+      jest
+        .spyOn(fileRepository, 'getTrashedExpiredFiles')
+        .mockResolvedValue(fileIds);
+      jest.spyOn(fileRepository, 'deleteTrashedFilesById');
+
+      await service.deleteTrashedExpiredFiles();
+
+      expect(fileRepository.deleteTrashedFilesById).toHaveBeenCalledWith(
+        fileIds.map((f) => f.fileId),
+      );
+    });
+  });
 });

--- a/src/modules/file/file.usecase.ts
+++ b/src/modules/file/file.usecase.ts
@@ -381,4 +381,17 @@ export class FileUseCases {
       status: FileStatus.EXISTS,
     });
   }
+
+  async deleteTrashedExpiredFiles() {
+    const limit = 1000;
+    let hasMore = true;
+
+    while (hasMore) {
+      const files = await this.fileRepository.getTrashedExpiredFiles(limit);
+      await this.fileRepository.deleteTrashedFilesById(
+        files.map((file) => file.fileId),
+      );
+      hasMore = files.length === limit;
+    }
+  }
 }

--- a/src/modules/file/file.usecase.ts
+++ b/src/modules/file/file.usecase.ts
@@ -25,6 +25,7 @@ import { SequelizeFileRepository } from './file.repository';
 import { FolderUseCases } from '../folder/folder.usecase';
 import { ReplaceFileDto } from './dto/replace-file.dto';
 import { FileDto } from './dto/file.dto';
+import { Op } from 'sequelize';
 
 type SortParams = Array<[SortableFileAttributes, 'ASC' | 'DESC']>;
 
@@ -177,15 +178,20 @@ export class FileUseCases {
       offset: number;
       sort?: SortParams;
       withoutThumbnails?: boolean;
+      updatedAfter?: Date;
     } = {
       limit: 20,
       offset: 0,
     },
   ): Promise<File[]> {
     let filesWithMaybePlainName;
+    const updatedAfterCondition = options.updatedAfter
+      ? { updatedAt: { [Op.gte]: options.updatedAfter } }
+      : null;
+
     if (options?.withoutThumbnails)
       filesWithMaybePlainName = await this.fileRepository.findAllCursor(
-        { ...where, userId },
+        { ...where, userId, ...updatedAfterCondition },
         options.limit,
         options.offset,
         options.sort,
@@ -193,7 +199,7 @@ export class FileUseCases {
     else
       filesWithMaybePlainName =
         await this.fileRepository.findAllCursorWithThumbnails(
-          { ...where, userId },
+          { ...where, userId, ...updatedAfterCondition },
           options.limit,
           options.offset,
           options.sort,

--- a/src/modules/folder/folder.repository.ts
+++ b/src/modules/folder/folder.repository.ts
@@ -62,6 +62,8 @@ export interface FolderRepository {
   deleteById(folderId: FolderAttributes['id']): Promise<void>;
   clearOrphansFolders(userId: FolderAttributes['userId']): Promise<number>;
   calculateFolderSize(folderUuid: string): Promise<number>;
+  getTrashedExpiredFolders(limit: number): Promise<FolderModel[]>;
+  deleteByIds(folderIds: Folder['id'][]): Promise<void>;
 }
 
 @Injectable()

--- a/src/modules/folder/folder.repository.ts
+++ b/src/modules/folder/folder.repository.ts
@@ -1,6 +1,6 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
 import { InjectModel } from '@nestjs/sequelize';
-import { FindOptions, Op } from 'sequelize';
+import { FindOptions, Op, Sequelize } from 'sequelize';
 import { v4 } from 'uuid';
 
 import { Folder } from './folder.domain';
@@ -12,6 +12,8 @@ import { Pagination } from '../../lib/pagination';
 import { FolderModel } from './folder.model';
 import { SharingModel } from '../sharing/models';
 import { CalculateFolderSizeTimeoutException } from './exception/calculate-folder-size-timeout.exception';
+import { UserModel } from '../user/user.model';
+import { LimitLabels } from '../feature-limit/limits.enum';
 
 function mapSnakeCaseToCamelCase(data) {
   const camelCasedObject = {};
@@ -421,6 +423,24 @@ export class SequelizeFolderRepository implements FolderRepository {
     );
   }
 
+  async deleteByIds(folderIds: Folder['id'][]): Promise<void> {
+    await this.folderModel.update(
+      {
+        removed: true,
+        removedAt: new Date(),
+        deleted: true,
+        deletedAt: new Date(),
+      },
+      {
+        where: {
+          id: {
+            [Op.in]: folderIds,
+          },
+        },
+      },
+    );
+  }
+
   async findAllCursorWhereUpdatedAfter(
     where: Partial<Folder>,
     updatedAfter: Date,
@@ -444,6 +464,39 @@ export class SequelizeFolderRepository implements FolderRepository {
     });
 
     return folders.map((folder) => this.toDomain(folder));
+  }
+
+  async getTrashedExpiredFolders(limit?: number) {
+    const folders = await this.folderModel.findAll({
+      replacements: { limitLabel: LimitLabels.MaxTrashStorageDays },
+      attributes: [
+        'deleted',
+        'plainName',
+        'updatedAt',
+        'id',
+        'uuid',
+        'deletedAt',
+      ],
+      where: {
+        deleted: true,
+        removed: false,
+        deletedAt: {
+          [Op.lt]: Sequelize.literal(`now() - (SELECT value :: integer
+      FROM
+          limits
+          JOIN tiers_limits ON limits.id = tiers_limits.limit_id
+          JOIN tiers ON tiers_limits.tier_id = tiers.id
+      WHERE
+          tiers.id = "user"."tier_id" AND limits.label = :limitLabel) * INTERVAL '1 day'`),
+        },
+      },
+      include: {
+        model: UserModel,
+        attributes: ['uuid', 'id', 'tierId'],
+      },
+      limit,
+    });
+    return folders;
   }
 
   async calculateFolderSize(folderUuid: string): Promise<number> {

--- a/src/modules/folder/folder.usecase.spec.ts
+++ b/src/modules/folder/folder.usecase.spec.ts
@@ -494,4 +494,32 @@ describe('FolderUseCases', () => {
       );
     });
   });
+
+  describe('Delete Trashed Expired Folders', () => {
+    it('When there are no more folders to fetch, then should stop', async () => {
+      jest
+        .spyOn(folderRepository, 'getTrashedExpiredFolders')
+        .mockResolvedValue([]);
+
+      await service.deleteTrashedExpiredFolders();
+
+      expect(folderRepository.getTrashedExpiredFolders).toHaveBeenCalledTimes(
+        1,
+      );
+    });
+
+    it('When there are expired files, then it should delete them', async () => {
+      const folderIds = [{ id: 1 }, { id: 2 }] as any;
+      jest
+        .spyOn(folderRepository, 'getTrashedExpiredFolders')
+        .mockResolvedValue(folderIds);
+      jest.spyOn(folderRepository, 'deleteByIds');
+
+      await service.deleteTrashedExpiredFolders();
+
+      expect(folderRepository.deleteByIds).toHaveBeenCalledWith(
+        folderIds.map((f) => f.id),
+      );
+    });
+  });
 });

--- a/src/modules/folder/folder.usecase.ts
+++ b/src/modules/folder/folder.usecase.ts
@@ -17,6 +17,7 @@ import {
 import { FolderAttributes } from './folder.attributes';
 import { SequelizeFolderRepository } from './folder.repository';
 import { SequelizeFileRepository } from '../file/file.repository';
+import { Op } from 'sequelize';
 
 const invalidName = /[\\/]|^\s*$/;
 
@@ -410,13 +411,22 @@ export class FolderUseCases {
   async getFolders(
     userId: FolderAttributes['userId'],
     where: Partial<FolderAttributes>,
-    options: { limit: number; offset: number; sort?: SortParams } = {
+    options: {
+      limit: number;
+      offset: number;
+      sort?: SortParams;
+      updatedAfter?: Date;
+    } = {
       limit: 20,
       offset: 0,
     },
   ): Promise<Folder[]> {
+    const updatedAfterCondition = options.updatedAfter
+      ? { updatedAt: { [Op.gte]: options.updatedAfter } }
+      : null;
+
     const foldersWithMaybePlainName = await this.folderRepository.findAllCursor(
-      { ...where, userId },
+      { ...where, userId, ...updatedAfterCondition },
       options.limit,
       options.offset,
       options.sort,

--- a/src/modules/folder/folder.usecase.ts
+++ b/src/modules/folder/folder.usecase.ts
@@ -415,18 +415,18 @@ export class FolderUseCases {
       limit: number;
       offset: number;
       sort?: SortParams;
-      updatedAfter?: Date;
+      deletedAfter?: Date;
     } = {
       limit: 20,
       offset: 0,
     },
   ): Promise<Folder[]> {
-    const updatedAfterCondition = options.updatedAfter
-      ? { updatedAt: { [Op.gte]: options.updatedAfter } }
+    const deletedAfter = options.deletedAfter
+      ? { deletedAt: { [Op.gte]: options.deletedAfter } }
       : null;
 
     const foldersWithMaybePlainName = await this.folderRepository.findAllCursor(
-      { ...where, userId, ...updatedAfterCondition },
+      { ...where, userId, ...deletedAfter },
       options.limit,
       options.offset,
       options.sort,

--- a/src/modules/folder/folder.usecase.ts
+++ b/src/modules/folder/folder.usecase.ts
@@ -551,4 +551,16 @@ export class FolderUseCases {
   getFolderSizeByUuid(folderUuid: Folder['uuid']): Promise<number> {
     return this.folderRepository.calculateFolderSize(folderUuid);
   }
+
+  async deleteTrashedExpiredFolders() {
+    const limit = 1000;
+    let hasMore = true;
+
+    while (hasMore) {
+      const folders =
+        await this.folderRepository.getTrashedExpiredFolders(limit);
+      await this.folderRepository.deleteByIds(folders.map((f) => f.id));
+      hasMore = folders.length === limit;
+    }
+  }
 }

--- a/src/modules/trash/trash.controller.ts
+++ b/src/modules/trash/trash.controller.ts
@@ -82,7 +82,7 @@ export class TrashController {
     }
 
     let userTierId = user.tierId;
-    if (userTierId) {
+    if (!userTierId) {
       const freeTier = await this.featureLimitsUseCases.getFreeTier();
       userTierId = freeTier.id;
     }
@@ -91,7 +91,6 @@ export class TrashController {
       await this.featureLimitsUseCases.getTierMaxTrashStorageDays(userTierId);
     const storageDays = storageDaysLimit?.getLimitValue();
     const maxStorageDate = new Date();
-
     if (typeof storageDays === 'number') {
       maxStorageDate.setDate(maxStorageDate.getDate() - storageDays);
     }

--- a/src/modules/trash/trash.controller.ts
+++ b/src/modules/trash/trash.controller.ts
@@ -81,8 +81,14 @@ export class TrashController {
       throw new BadRequestException('Limit should be between 1 and 50');
     }
 
+    let userTierId = user.tierId;
+    if (userTierId) {
+      const freeTier = await this.featureLimitsUseCases.getFreeTier();
+      userTierId = freeTier.id;
+    }
+
     const storageDaysLimit =
-      await this.featureLimitsUseCases.getTierMaxTrashStorageDays(user.tierId);
+      await this.featureLimitsUseCases.getTierMaxTrashStorageDays(userTierId);
     const storageDays = storageDaysLimit?.getLimitValue();
     const maxStorageDate = new Date();
 

--- a/src/modules/trash/trash.controller.ts
+++ b/src/modules/trash/trash.controller.ts
@@ -312,8 +312,8 @@ export class TrashController {
     await this.trashUseCases.deleteItems(user, [], [folders[0]]);
   }
 
-  @Cron('*/5 * * * *', { name: 'deleteExpiredFiles' })
+  @Cron('*/5 * * * *', { name: 'deleteExpiredItems' })
   async removeExpiredItems() {
-    await this.trashUseCases.removeExpiredFiles();
+    await this.trashUseCases.removeExpiredItems();
   }
 }

--- a/src/modules/trash/trash.controller.ts
+++ b/src/modules/trash/trash.controller.ts
@@ -113,7 +113,7 @@ export class TrashController {
             deleted: true,
             removed: false,
           },
-          { limit, offset, updatedAfter: maxStorageDate },
+          { limit, offset, deletedAfter: maxStorageDate },
         );
       }
 

--- a/src/modules/trash/trash.controller.ts
+++ b/src/modules/trash/trash.controller.ts
@@ -42,6 +42,7 @@ import { v4 } from 'uuid';
 import { Response } from 'express';
 import { HttpExceptionFilter } from '../../lib/http/http-exception.filter';
 import { FeatureLimitUsecases } from '../feature-limit/feature-limit.usecase';
+import { Cron } from '@nestjs/schedule';
 
 @ApiTags('Trash')
 @Controller('storage/trash')
@@ -309,5 +310,10 @@ export class TrashController {
     }
 
     await this.trashUseCases.deleteItems(user, [], [folders[0]]);
+  }
+
+  @Cron('*/5 * * * *', { name: 'deleteExpiredFiles' })
+  async removeExpiredItems() {
+    await this.trashUseCases.removeExpiredFiles();
   }
 }

--- a/src/modules/trash/trash.module.ts
+++ b/src/modules/trash/trash.module.ts
@@ -9,6 +9,7 @@ import { TrashUseCases } from './trash.usecase';
 import { ShareModule } from '../share/share.module';
 import { ShareModel } from '../share/share.repository';
 import { FileModel } from '../file/file.model';
+import { FeatureLimitModule } from '../feature-limit/feature-limit.module';
 
 @Module({
   imports: [
@@ -19,6 +20,7 @@ import { FileModel } from '../file/file.model';
     NotificationModule,
     UserModule,
     ShareModule,
+    FeatureLimitModule,
   ],
   controllers: [TrashController],
   providers: [Logger, TrashUseCases],

--- a/src/modules/trash/trash.usecase.spec.ts
+++ b/src/modules/trash/trash.usecase.spec.ts
@@ -319,4 +319,22 @@ describe('Trash Use Cases', () => {
       );
     });
   });
+
+  describe('Delete Trashed Expired Files', () => {
+    it('Should throw if any function throws', async () => {
+      const error = Error('random error');
+      jest.spyOn(fileUseCases, 'deleteTrashedExpiredFiles');
+      jest
+        .spyOn(folderUseCases, 'deleteTrashedExpiredFolders')
+        .mockImplementationOnce(() => Promise.reject(error));
+
+      try {
+        await service.removeExpiredItems();
+      } catch (err) {
+        expect(err).toBeDefined();
+      }
+
+      expect(fileUseCases.deleteTrashedExpiredFiles).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/src/modules/trash/trash.usecase.ts
+++ b/src/modules/trash/trash.usecase.ts
@@ -1,9 +1,11 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 import { Folder } from '../folder/folder.domain';
 import { User } from '../user/user.domain';
 import { File, FileStatus } from '../file/file.domain';
 import { FolderUseCases } from '../folder/folder.usecase';
 import { FileUseCases } from '../file/file.usecase';
+import { SequelizeFileRepository } from '../file/file.repository';
+import { SequelizeFolderRepository } from '../folder/folder.repository';
 
 @Injectable()
 export class TrashUseCases {
@@ -13,6 +15,8 @@ export class TrashUseCases {
   constructor(
     private fileUseCases: FileUseCases,
     private folderUseCases: FolderUseCases,
+    private filesRepository: SequelizeFileRepository,
+    private foldersRepository: SequelizeFolderRepository,
   ) {}
 
   /**
@@ -73,6 +77,57 @@ export class TrashUseCases {
         user,
         folders.slice(i, i + itemsDeletionChunkSize),
       );
+    }
+  }
+
+  async deteleTrashedExpiredFiles() {
+    const limit = 1000;
+    let hasMore = true;
+
+    while (hasMore) {
+      const files = await this.filesRepository.getTrashedExpiredFiles(limit);
+      await this.filesRepository.deleteTrashedFilesById(
+        files.map((file) => file.fileId),
+      );
+      hasMore = files.length === limit;
+    }
+  }
+
+  async deleteTrashedExpiredFolders() {
+    const limit = 1000;
+    let hasMore = true;
+
+    while (hasMore) {
+      const folders =
+        await this.foldersRepository.getTrashedExpiredFolders(limit);
+      await this.foldersRepository.deleteByIds(folders.map((f) => f.id));
+      hasMore = folders.length === limit;
+    }
+  }
+
+  async removeExpiredFiles() {
+    const startTime = new Date();
+    try {
+      Logger.log(
+        `[TRASH/REMOVE-EXPIRED-ITEMS]: Cron job started at ${startTime.toISOString()}.`,
+      );
+
+      await this.deleteTrashedExpiredFolders();
+      await this.deteleTrashedExpiredFiles();
+
+      const endTime = new Date();
+      const duration = endTime.getTime() - startTime.getTime();
+      Logger.log(
+        `[TRASH/REMOVE-EXPIRED-ITEMS]: Cron job completed successfully. Started at: ${startTime.toISOString()}, finished at: ${endTime.toISOString()}, total duration: ${duration} ms.`,
+      );
+    } catch (err) {
+      const errorTime = new Date();
+      Logger.error(
+        `[TRASH/REMOVE-EXPIRED-ITEMS]: Error encountered. Started at: ${startTime.toISOString()}, error occurred at: ${errorTime.toISOString()}, error details: ${
+          err.message
+        }, stack trace: ${err.stack}`,
+      );
+      throw err;
     }
   }
 }

--- a/src/modules/trash/trash.usecase.ts
+++ b/src/modules/trash/trash.usecase.ts
@@ -105,7 +105,7 @@ export class TrashUseCases {
     }
   }
 
-  async removeExpiredFiles() {
+  async removeExpiredItems() {
     const startTime = new Date();
     try {
       Logger.log(

--- a/src/modules/trash/trash.usecase.ts
+++ b/src/modules/trash/trash.usecase.ts
@@ -4,8 +4,6 @@ import { User } from '../user/user.domain';
 import { File, FileStatus } from '../file/file.domain';
 import { FolderUseCases } from '../folder/folder.usecase';
 import { FileUseCases } from '../file/file.usecase';
-import { SequelizeFileRepository } from '../file/file.repository';
-import { SequelizeFolderRepository } from '../folder/folder.repository';
 
 @Injectable()
 export class TrashUseCases {
@@ -15,8 +13,6 @@ export class TrashUseCases {
   constructor(
     private fileUseCases: FileUseCases,
     private folderUseCases: FolderUseCases,
-    private filesRepository: SequelizeFileRepository,
-    private foldersRepository: SequelizeFolderRepository,
   ) {}
 
   /**
@@ -80,31 +76,6 @@ export class TrashUseCases {
     }
   }
 
-  async deteleTrashedExpiredFiles() {
-    const limit = 1000;
-    let hasMore = true;
-
-    while (hasMore) {
-      const files = await this.filesRepository.getTrashedExpiredFiles(limit);
-      await this.filesRepository.deleteTrashedFilesById(
-        files.map((file) => file.fileId),
-      );
-      hasMore = files.length === limit;
-    }
-  }
-
-  async deleteTrashedExpiredFolders() {
-    const limit = 1000;
-    let hasMore = true;
-
-    while (hasMore) {
-      const folders =
-        await this.foldersRepository.getTrashedExpiredFolders(limit);
-      await this.foldersRepository.deleteByIds(folders.map((f) => f.id));
-      hasMore = folders.length === limit;
-    }
-  }
-
   async removeExpiredItems() {
     const startTime = new Date();
     try {
@@ -112,8 +83,8 @@ export class TrashUseCases {
         `[TRASH/REMOVE-EXPIRED-ITEMS]: Cron job started at ${startTime.toISOString()}.`,
       );
 
-      await this.deleteTrashedExpiredFolders();
-      await this.deteleTrashedExpiredFiles();
+      await this.folderUseCases.deleteTrashedExpiredFolders();
+      await this.fileUseCases.deleteTrashedExpiredFiles();
 
       const endTime = new Date();
       const duration = endTime.getTime() - startTime.getTime();

--- a/src/modules/user/user.model.ts
+++ b/src/modules/user/user.model.ts
@@ -14,6 +14,7 @@ import {
 
 import { FolderModel } from '../folder/folder.model';
 import { UserAttributes } from './user.attributes';
+import { TierModel } from '../feature-limit/models/tier.model';
 
 @Table({
   underscored: true,
@@ -125,6 +126,10 @@ export class UserModel extends Model implements UserAttributes {
   lastPasswordChangedAt: Date;
 
   @AllowNull
+  @ForeignKey(() => TierModel)
   @Column
   tierId: string;
+
+  @BelongsTo(() => TierModel, 'tierId')
+  tier: TierModel;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1609,6 +1609,14 @@
     multer "1.4.4-lts.1"
     tslib "2.6.2"
 
+"@nestjs/schedule@^4.0.1":
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/@nestjs/schedule/-/schedule-4.0.1.tgz#beb69f974e7adc96fd799f555ba0121c10d2d61b"
+  integrity sha512-cz2FNjsuoma+aGsG0cMmG6Dqg/BezbBWet1UTHtAuu6d2mXNTVcmoEQM2DIVG5Lfwb2hfSE2yZt8Moww+7y+mA==
+  dependencies:
+    cron "3.1.6"
+    uuid "9.0.1"
+
 "@nestjs/schematics@^10.0.1", "@nestjs/schematics@^10.0.3":
   version "10.0.3"
   resolved "https://registry.yarnpkg.com/@nestjs/schematics/-/schematics-10.0.3.tgz#0f48af0a20983ffecabcd8763213a3e53d43f270"
@@ -2688,6 +2696,11 @@
   version "4.14.182"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.182.tgz#05301a4d5e62963227eaafe0ce04dd77c54ea5c2"
   integrity sha512-/THyiqyQAP9AfARo4pF+aCGcyiQ94tX/Is2I7HofNRqoYLgN1PBoOWu2/zTA5zMxzP5EFutMtWtGAFRKUe961Q==
+
+"@types/luxon@~3.3.0":
+  version "3.3.8"
+  resolved "https://registry.yarnpkg.com/@types/luxon/-/luxon-3.3.8.tgz#84dbf2d020a9209a272058725e168f21d331a67e"
+  integrity sha512-jYvz8UMLDgy3a5SkGJne8H7VA7zPV2Lwohjx0V8V31+SqAjNmurWMkk9cQhfvlcnXWudBpK9xPM1n4rljOcHYQ==
 
 "@types/mime@^1":
   version "1.3.2"
@@ -4198,6 +4211,14 @@ cron-parser@^4.2.1:
   integrity sha512-guZNLMGUgg6z4+eGhmHGw7ft+v6OQeuHzd1gcLxCo9Yg/qoxmG3nindp2/uwGCLizEisf2H0ptqeVXeoCpP6FA==
   dependencies:
     luxon "^3.0.1"
+
+cron@3.1.6:
+  version "3.1.6"
+  resolved "https://registry.yarnpkg.com/cron/-/cron-3.1.6.tgz#e7e1798a468e017c8d31459ecd7c2d088f97346c"
+  integrity sha512-cvFiQCeVzsA+QPM6fhjBtlKGij7tLLISnTSvFxVdnFGLdz+ZdXN37kNe0i2gefmdD17XuZA6n2uPVwzl4FxW/w==
+  dependencies:
+    "@types/luxon" "~3.3.0"
+    luxon "~3.4.0"
 
 cross-spawn@^7.0.0, cross-spawn@^7.0.2, cross-spawn@^7.0.3:
   version "7.0.3"
@@ -6475,6 +6496,11 @@ luxon@^3.0.1:
   resolved "https://registry.yarnpkg.com/luxon/-/luxon-3.0.4.tgz#d179e4e9f05e092241e7044f64aaa54796b03929"
   integrity sha512-aV48rGUwP/Vydn8HT+5cdr26YYQiUZ42NM6ToMoaGKwYfWbfLeRkEu1wXWMHBZT6+KyLfcbbtVcoQFCbbPjKlw==
 
+luxon@~3.4.0:
+  version "3.4.4"
+  resolved "https://registry.yarnpkg.com/luxon/-/luxon-3.4.4.tgz#cf20dc27dc532ba41a169c43fdcc0063601577af"
+  integrity sha512-zobTr7akeGHnv7eBOXcRgMeCP6+uyYsczwmeRCauvpvaAltgNyTbLH/+VaEAPUeWBT+1GuNmz4wC/6jtQzbbVA==
+
 macos-release@^2.5.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/macos-release/-/macos-release-2.5.0.tgz#067c2c88b5f3fb3c56a375b2ec93826220fa1ff2"
@@ -8479,7 +8505,7 @@ uuid@9.0.0:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-9.0.0.tgz#592f550650024a38ceb0c562f2f6aa435761efb5"
   integrity sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==
 
-uuid@^9.0.1:
+uuid@9.0.1, uuid@^9.0.1:
   version "9.0.1"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-9.0.1.tgz#e188d4c8853cc722220392c424cd637f32293f30"
   integrity sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==


### PR DESCRIPTION
This PR enforces the limit for the storage days in the trash.

What it includes:

1. Do not list expired trashed items in get trashed items endpoint.
2. Add a cron job to expire files every X defined time.

Some considerations:

- Cron jobs with multiple instances running: nestjs cron jobs are in memory, every instance is going to try to run the cron job. There are some ways to handle this, having a table in a shared db so the first instance that tries to run the job writes to the DB with the current timestamp (it sounds kind of a race condition I don't like it) or using redis. 

   > However, for our case, maybe it is too much trouble to handle this simple cron job that eventually is going to process a small quantity of files. It runs every few minutes, we are not going to have a lot of expired trashed files in such a small time frame.

- Folders use deleteAt and files use updatedAt. Should we index both? Should we update "updatedAt" for both when they are trashed? 


- Why is there a raw query inside the query for listing trashed/expired items? Actually, I tried to use the ORM at its max extend without writing raw SQL (they are too troublesome to maintain 😴  and people sometimes don't check them before changing models). This was my original query:

```javascript
    const files = await this.fileModel.findAll({
      attributes: ['status', 'plainName', 'updatedAt', 'fileId', 'uuid'],
      where: {
        status: 'TRASHED',
        updatedAt: {
          [Op.lt]: Sequelize.literal(
            `NOW() - "user->tier->limits"."value"::integer * INTERVAL '1 day'`,
          ),
        },
      },
      include: {
        model: UserModel,
        attributes: ['uuid', 'id', 'tierId'],
        as: 'user',
        include: [
          {
            model: TierModel,
            attributes: ['id', 'label'],
            include: [
              {
                model: Limitmodel,
                where: { label: LimitLabels.MaxTrashStorageDays },
              },
            ],
          },
        ],
      },
      limit,
    });
```

However, Sequelize seems to have a [known bug](https://github.com/sequelize/sequelize/issues/3623) when you try to nest models with many to many relations sometimes. Basically, the query works if I do not add the `limit` at the end to just get a X number of records OR if I do not ask for the `limitModel` while limiting the results. It creates a sort of subquery and introduces the limit = 1000 inside that subquery and it fails.

Of course, I do not want to get the entire database of expired trashed items, so that's the reason of the raw query being there.

