### PR TITLE
fix: set ready-for-preview instead of preview tag

### DIFF
--- a/.github/workflows/deploy-pr-preview.yml
+++ b/.github/workflows/deploy-pr-preview.yml
@@ -30,7 +30,7 @@ jobs:
           file: ./infrastructure/preview.Dockerfile
           push: true
           tags: ${{ secrets.DOCKERHUB_USERNAME }}/${{ github.event.repository.name }}-dev:preview-${{ github.event.number }}-${{ github.event.pull_request.head.sha }}
-  add_preview_label:
+  add_ready_for_preview_label:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     needs: build
@@ -38,9 +38,9 @@ jobs:
     - uses: actions-ecosystem/action-add-labels@v1
       with:
         labels: |
-          preview
+          ready-for-preview
   dispatch_update_deployment:
-    needs: add_preview_label
+    needs: add_ready_for_preview_label
     runs-on: ubuntu-latest
     if: ${{ contains(github.event.pull_request.labels.*.name, 'deployed') }}
     steps:
@@ -75,8 +75,9 @@ jobs:
               } 
             }
   dispatch_check_deployment:
-    needs: add_preview_label
+    needs: add_ready_for_preview_label
     runs-on: ubuntu-latest
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'preview') }}
     steps:
       - name: Dispatch Check Preview Repository Command
         uses: myrotvorets/trigger-repository-dispatch-action@1.0.0


### PR DESCRIPTION
# Preview Environments

Now the `preview` tag must be set manually to reduce the amount of environments