### PR TITLE
[PB-1920]: fix/stop sharing items when they are trashed

### DIFF
--- a/src/modules/file/file.repository.ts
+++ b/src/modules/file/file.repository.ts
@@ -64,6 +64,10 @@ export interface FileRepository {
     user: User,
     fileUuids: File['uuid'][],
   ): Promise<void>;
+  findByFileIds(
+    userId: User['id'],
+    fileIds: FileAttributes['fileId'][],
+  ): Promise<File[]>;
 }
 
 @Injectable()
@@ -86,6 +90,22 @@ export class SequelizeFileRepository implements FileRepository {
     return files.map((file) => {
       return this.toDomain(file);
     });
+  }
+
+  async findByFileIds(
+    userId: User['id'],
+    fileIds: FileAttributes['fileId'][],
+  ): Promise<File[]> {
+    const files = await this.fileModel.findAll({
+      where: {
+        userId: userId,
+        fileId: {
+          [Op.in]: fileIds,
+        },
+      },
+    });
+
+    return files.map(this.toDomain.bind(this));
   }
 
   async findById(

--- a/src/modules/file/file.usecase.ts
+++ b/src/modules/file/file.usecase.ts
@@ -250,11 +250,11 @@ export class FileUseCases {
     user: User,
     fileIds: FileAttributes['fileId'][],
     fileUuids: FileAttributes['uuid'][] = [],
-  ): Promise<[void, void, void]> {
+  ): Promise<void> {
     const files = await this.fileRepository.findByFileIds(user.id, fileIds);
     const allFileUuids = [...fileUuids, ...files.map((file) => file.uuid)];
 
-    return Promise.all([
+    await Promise.all([
       this.fileRepository.updateFilesStatusToTrashed(user, fileIds),
       this.fileRepository.updateFilesStatusToTrashedByUuid(user, fileUuids),
       this.sharingUsecases.bulkRemoveSharings(

--- a/src/modules/folder/folder.module.ts
+++ b/src/modules/folder/folder.module.ts
@@ -9,6 +9,7 @@ import { CryptoService } from '../../externals/crypto/crypto.service';
 import { FolderController } from './folder.controller';
 import { UserModel } from '../user/user.model';
 import { UserModule } from '../user/user.module';
+import { SharingModule } from '../sharing/sharing.module';
 
 @Module({
   imports: [
@@ -16,6 +17,7 @@ import { UserModule } from '../user/user.module';
     forwardRef(() => FileModule),
     forwardRef(() => UserModule),
     CryptoModule,
+    forwardRef(() => SharingModule),
   ],
   controllers: [FolderController],
   providers: [SequelizeFolderRepository, CryptoService, FolderUseCases],

--- a/src/modules/folder/folder.usecase.spec.ts
+++ b/src/modules/folder/folder.usecase.spec.ts
@@ -17,6 +17,7 @@ import { CryptoService } from '../../externals/crypto/crypto.service';
 import { User } from '../user/user.domain';
 import { newFolder, newUser } from '../../../test/fixtures';
 import { CalculateFolderSizeTimeoutException } from './exception/calculate-folder-size-timeout.exception';
+import { SharingService } from '../sharing/sharing.service';
 
 const folderId = 4;
 const user = newUser();
@@ -25,6 +26,7 @@ describe('FolderUseCases', () => {
   let service: FolderUseCases;
   let folderRepository: FolderRepository;
   let cryptoService: CryptoService;
+  let sharingService: SharingService;
 
   const userMocked = User.build({
     id: 1,
@@ -67,6 +69,7 @@ describe('FolderUseCases', () => {
     service = module.get<FolderUseCases>(FolderUseCases);
     folderRepository = module.get<FolderRepository>(SequelizeFolderRepository);
     cryptoService = module.get<CryptoService>(CryptoService);
+    sharingService = module.get<SharingService>(SharingService);
   });
 
   it('should be defined', () => {
@@ -142,7 +145,7 @@ describe('FolderUseCases', () => {
         deletedAt: new Date(),
         createdAt: new Date(),
         updatedAt: new Date(),
-        uuid: '',
+        uuid: '656a3abb-36ab-47ee-8303-6e4198f2a32a',
         plainName: '',
         removed: false,
         removedAt: null,
@@ -181,6 +184,11 @@ describe('FolderUseCases', () => {
           removed: true,
           removedAt: expect.any(Date),
         },
+      );
+      expect(sharingService.bulkRemoveSharings).toHaveBeenCalledWith(
+        user,
+        [mockBackupFolder.uuid, mockFolder.uuid],
+        'folder',
       );
     });
 

--- a/src/modules/folder/folder.usecase.ts
+++ b/src/modules/folder/folder.usecase.ts
@@ -1,10 +1,12 @@
 import {
   ConflictException,
   ForbiddenException,
+  Inject,
   Injectable,
   Logger,
   NotFoundException,
   UnprocessableEntityException,
+  forwardRef,
 } from '@nestjs/common';
 import { CryptoService } from '../../externals/crypto/crypto.service';
 import { User } from '../user/user.domain';
@@ -17,6 +19,8 @@ import {
 } from './folder.domain';
 import { FolderAttributes } from './folder.attributes';
 import { SequelizeFolderRepository } from './folder.repository';
+import { SharingService } from '../sharing/sharing.service';
+import { SharingItemType } from '../sharing/sharing.domain';
 
 const invalidName = /[\\/]|^\s*$/;
 
@@ -27,6 +31,8 @@ export class FolderUseCases {
   constructor(
     private folderRepository: SequelizeFolderRepository,
     private userRepository: SequelizeUserRepository,
+    @Inject(forwardRef(() => SharingService))
+    private sharingUsecases: SharingService,
     private readonly cryptoService: CryptoService,
   ) {}
 
@@ -329,6 +335,11 @@ export class FolderUseCases {
             },
           )
         : Promise.resolve(),
+      this.sharingUsecases.bulkRemoveSharings(
+        user,
+        folders.map((folder) => folder.uuid),
+        SharingItemType.Folder,
+      ),
     ]);
   }
 

--- a/src/modules/sharing/sharing.domain.ts
+++ b/src/modules/sharing/sharing.domain.ts
@@ -14,6 +14,11 @@ export enum SharingType {
   Private = 'private',
 }
 
+export enum SharingItemType {
+  File = 'file',
+  Folder = 'folder',
+}
+
 export interface SharingAttributes {
   id: string;
   itemId: ItemId;

--- a/src/modules/sharing/sharing.repository.ts
+++ b/src/modules/sharing/sharing.repository.ts
@@ -594,6 +594,36 @@ export class SequelizeSharingRepository implements SharingRepository {
     });
   }
 
+  async bulkDeleteInvites(
+    itemIds: SharingInvite['itemId'][],
+    type: SharingInvite['itemType'],
+  ): Promise<void> {
+    await this.sharingInvites.destroy({
+      where: {
+        itemId: {
+          [Op.in]: itemIds,
+        },
+        itemType: type,
+      },
+    });
+  }
+
+  async bulkDeleteSharings(
+    userUuid: User['uuid'],
+    itemIds: SharingInvite['itemId'][],
+    type: SharingInvite['itemType'],
+  ): Promise<void> {
+    await this.sharings.destroy({
+      where: {
+        itemId: {
+          [Op.in]: itemIds,
+        },
+        itemType: type,
+        ownerId: userUuid,
+      },
+    });
+  }
+
   async deleteInvite(invite: SharingInvite): Promise<void> {
     await this.sharingInvites.destroy({
       where: {

--- a/src/modules/sharing/sharing.service.spec.ts
+++ b/src/modules/sharing/sharing.service.spec.ts
@@ -379,6 +379,26 @@ describe('Sharing Use Cases', () => {
     });
   });
 
+  describe('Bulk remove sharings', () => {
+    it('When function is called, then invitations and sharings are removed ', async () => {
+      const owner = newUser();
+      const itemIds = ['uuid1', 'uuid2'];
+      const itemType = 'file';
+
+      await sharingService.bulkRemoveSharings(owner, itemIds, itemType);
+
+      expect(sharingRepository.bulkDeleteInvites).toHaveBeenCalledWith(
+        itemIds,
+        itemType,
+      );
+      expect(sharingRepository.bulkDeleteSharings).toHaveBeenCalledWith(
+        owner.uuid,
+        itemIds,
+        itemType,
+      );
+    });
+  });
+
   describe('Access to public shared item info', () => {
     const owner = newUser();
     const otherUser = publicUser();

--- a/src/modules/sharing/sharing.service.ts
+++ b/src/modules/sharing/sharing.service.ts
@@ -2,9 +2,11 @@ import {
   BadRequestException,
   ConflictException,
   ForbiddenException,
+  Inject,
   Injectable,
   Logger,
   NotFoundException,
+  forwardRef,
 } from '@nestjs/common';
 import { v4, validate as validateUuid } from 'uuid';
 
@@ -198,7 +200,9 @@ type SharingItemInfo = Pick<Item, 'plainName' | 'type' | 'size'>;
 export class SharingService {
   constructor(
     private readonly sharingRepository: SequelizeSharingRepository,
+    @Inject(forwardRef(() => FileUseCases))
     private readonly fileUsecases: FileUseCases,
+    @Inject(forwardRef(() => FolderUseCases))
     private readonly folderUsecases: FolderUseCases,
     private readonly usersUsecases: UserUseCases,
     private readonly configService: ConfigService,
@@ -1458,6 +1462,19 @@ export class SharingService {
       itemId,
       itemType,
     });
+  }
+
+  async bulkRemoveSharings(
+    user: User,
+    itemIds: Sharing['itemId'][],
+    itemType: Sharing['itemType'],
+  ) {
+    await this.sharingRepository.bulkDeleteInvites(itemIds, itemType);
+    await this.sharingRepository.bulkDeleteSharings(
+      user.uuid,
+      itemIds,
+      itemType,
+    );
   }
 
   async getRoles(): Promise<Role[]> {

--- a/src/modules/user/user.usecase.ts
+++ b/src/modules/user/user.usecase.ts
@@ -3,9 +3,11 @@ import {
   ForbiddenException,
   HttpException,
   HttpStatus,
+  Inject,
   Injectable,
   Logger,
   NotFoundException,
+  forwardRef,
 } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { Environment } from '@internxt/inxt-js';
@@ -129,7 +131,9 @@ export class UserUseCases {
     private userReferralsRepository: SequelizeUserReferralsRepository,
     private readonly attemptChangeEmailRepository: SequelizeAttemptChangeEmailRepository,
     private sharingRepository: SequelizeSharingRepository,
+    @Inject(forwardRef(() => FileUseCases))
     private fileUseCases: FileUseCases,
+    @Inject(forwardRef(() => FolderUseCases))
     private folderUseCases: FolderUseCases,
     private shareUseCases: ShareUseCases,
     private configService: ConfigService,
@@ -137,7 +141,6 @@ export class UserUseCases {
     private networkService: BridgeService,
     private notificationService: NotificationService,
     private readonly paymentsService: PaymentsService,
-    private readonly newsletterService: NewsletterService,
     private readonly keyServerRepository: SequelizeKeyServerRepository,
     private readonly avatarService: AvatarService,
     private readonly mailerService: MailerService,


### PR DESCRIPTION
This PR intends to stop sharing files/folders when you trash them. 

**Why**?

With features limits being implemented, we should stop sharing items when they are trashed to provide a smooth and clear experience. If I trash an item, I expect it to stop counting as a sharing.

**What could be improved?**

This PR adds this proccess in a sync way, however, we could also add an event listener in a future to decouple this process and make it async. 