### PR TITLE
[PB-1841] feat: added change users role in workspace team

### DIFF
--- a/src/modules/workspaces/dto/change-user-role.dto.ts
+++ b/src/modules/workspaces/dto/change-user-role.dto.ts
@@ -1,16 +1,8 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { IsNotEmpty } from 'class-validator';
-import { User } from '../../user/user.domain';
 import { WorkspaceRole } from '../guards/workspace-required-access.decorator';
 
 export class ChangeUserRoleDto {
-  @ApiProperty({
-    example: 'User Id',
-    description: 'Uuid of user to modify',
-  })
-  @IsNotEmpty()
-  userId: User['uuid'];
-
   @ApiProperty({
     example: 'TEAM_MANAGER',
     description: 'Role to be assigned to user',

--- a/src/modules/workspaces/dto/change-user-role.dto.ts
+++ b/src/modules/workspaces/dto/change-user-role.dto.ts
@@ -1,0 +1,20 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty } from 'class-validator';
+import { User } from '../../user/user.domain';
+import { WorkspaceRole } from '../guards/workspace-required-access.decorator';
+
+export class ChangeUserRoleDto {
+  @ApiProperty({
+    example: 'User Id',
+    description: 'Uuid of user to modify',
+  })
+  @IsNotEmpty()
+  userId: User['uuid'];
+
+  @ApiProperty({
+    example: 'TEAM_MANAGER',
+    description: 'Role to be assigned to user',
+  })
+  @IsNotEmpty()
+  role: Omit<WorkspaceRole, 'OWNER'>;
+}

--- a/src/modules/workspaces/repositories/team.repository.ts
+++ b/src/modules/workspaces/repositories/team.repository.ts
@@ -70,6 +70,20 @@ export class SequelizeWorkspaceTeamRepository {
     };
   }
 
+  async getTeamUser(
+    userUuid: UserAttributes['uuid'],
+    teamId: WorkspaceTeamAttributes['id'],
+  ): Promise<WorkspaceTeamUser | null> {
+    const teamUser = await this.teamUserModel.findOne({
+      where: {
+        memberId: userUuid,
+        teamId,
+      },
+    });
+
+    return teamUser ? this.teamUserToDomain(teamUser) : null;
+  }
+
   async getTeamById(
     teamId: WorkspaceTeamAttributes['id'],
   ): Promise<WorkspaceTeam | null> {

--- a/src/modules/workspaces/workspaces.controller.spec.ts
+++ b/src/modules/workspaces/workspaces.controller.spec.ts
@@ -18,17 +18,29 @@ describe('Workspace Controller', () => {
     expect(workspacesController).toBeDefined();
   });
 
-  describe('PATCH /:workspaceId/teams/:teamId/members/role', () => {
-    it('When there is an error while updating user role, then the error is returned', async () => {
+  describe('PATCH /:workspaceId/teams/:teamId/members/:memberId/role', () => {
+    it('When memberId is not a valid uuid, then it throws.', async () => {
       workspacesUsecases.changeUserRole.mockRejectedValueOnce(
         new BadRequestException(),
       );
       await expect(
-        workspacesController.changeMemberRole('', '', {
-          userId: '',
+        workspacesController.changeMemberRole('', '', 'notValidUuid', {
           role: WorkspaceRole.MEMBER,
         }),
       ).rejects.toThrow(BadRequestException);
+    });
+
+    it('When input is valid, then it works', async () => {
+      await expect(
+        workspacesController.changeMemberRole(
+          '',
+          '',
+          '9aa9399e-8697-41f7-88e3-df1d78794cb8',
+          {
+            role: WorkspaceRole.MEMBER,
+          },
+        ),
+      ).resolves.toBeTruthy();
     });
   });
 });

--- a/src/modules/workspaces/workspaces.controller.spec.ts
+++ b/src/modules/workspaces/workspaces.controller.spec.ts
@@ -1,0 +1,34 @@
+import { DeepMocked, createMock } from '@golevelup/ts-jest';
+import { BadRequestException } from '@nestjs/common';
+import { WorkspacesController } from './workspaces.controller';
+import { WorkspacesUsecases } from './workspaces.usecase';
+import { WorkspaceRole } from './guards/workspace-required-access.decorator';
+
+describe('Workspace Controller', () => {
+  let workspacesController: WorkspacesController;
+  let workspacesUsecases: DeepMocked<WorkspacesUsecases>;
+
+  beforeEach(async () => {
+    workspacesUsecases = createMock<WorkspacesUsecases>();
+
+    workspacesController = new WorkspacesController(workspacesUsecases);
+  });
+
+  it('should be defined', () => {
+    expect(workspacesController).toBeDefined();
+  });
+
+  describe('PATCH /:workspaceId/teams/:teamId/members/role', () => {
+    it('When there is an error while updating user role, then the error is returned', async () => {
+      workspacesUsecases.changeUserRole.mockRejectedValueOnce(
+        new BadRequestException(),
+      );
+      await expect(
+        workspacesController.changeMemberRole('', '', {
+          userId: '',
+          role: WorkspaceRole.MEMBER,
+        }),
+      ).rejects.toThrow(BadRequestException);
+    });
+  });
+});

--- a/src/modules/workspaces/workspaces.controller.ts
+++ b/src/modules/workspaces/workspaces.controller.ts
@@ -23,6 +23,8 @@ import {
   WorkspaceRole,
 } from './guards/workspace-required-access.decorator';
 import { CreateWorkspaceInviteDto } from './dto/create-workspace-invite.dto';
+import { WorkspaceTeamAttributes } from './attributes/workspace-team.attributes';
+import { ChangeUserRoleDto } from './dto/change-user-role.dto';
 
 @ApiTags('Workspaces')
 @Controller('workspaces')
@@ -97,5 +99,20 @@ export class WorkspacesController {
   @WorkspaceRequiredAccess(AccessContext.TEAM, WorkspaceRole.MEMBER)
   async getTeamMembers() {
     throw new NotImplementedException();
+  }
+
+  @Patch('/:workspaceId/teams/:teamId/members/role')
+  @UseGuards(WorkspaceGuard)
+  @WorkspaceRequiredAccess(AccessContext.WORKSPACE, WorkspaceRole.OWNER)
+  async changeMemberRole(
+    @Param('workspaceId') workspaceId: WorkspaceAttributes['id'],
+    @Param('teamId') teamId: WorkspaceTeamAttributes['id'],
+    @Body() changeUserRoleBody: ChangeUserRoleDto,
+  ) {
+    return this.workspaceUseCases.changeUserRole(
+      workspaceId,
+      teamId,
+      changeUserRoleBody,
+    );
   }
 }

--- a/src/modules/workspaces/workspaces.controller.ts
+++ b/src/modules/workspaces/workspaces.controller.ts
@@ -101,17 +101,23 @@ export class WorkspacesController {
     throw new NotImplementedException();
   }
 
-  @Patch('/:workspaceId/teams/:teamId/members/role')
+  @Patch('/:workspaceId/teams/:teamId/members/:memberId/role')
   @UseGuards(WorkspaceGuard)
   @WorkspaceRequiredAccess(AccessContext.WORKSPACE, WorkspaceRole.OWNER)
   async changeMemberRole(
     @Param('workspaceId') workspaceId: WorkspaceAttributes['id'],
     @Param('teamId') teamId: WorkspaceTeamAttributes['id'],
+    @Param('memberId') userUuid: User['uuid'],
     @Body() changeUserRoleBody: ChangeUserRoleDto,
   ) {
+    if (!userUuid || !isUUID(userUuid)) {
+      throw new BadRequestException('Invalid User Uuid');
+    }
+
     return this.workspaceUseCases.changeUserRole(
       workspaceId,
       teamId,
+      userUuid,
       changeUserRoleBody,
     );
   }

--- a/src/modules/workspaces/workspaces.usecase.spec.ts
+++ b/src/modules/workspaces/workspaces.usecase.spec.ts
@@ -320,32 +320,30 @@ describe('WorkspacesUsecases', () => {
   });
 
   describe('changeUserRole', () => {
-    it('When team does not exist, then error is throw', async () => {
+    it('When team does not exist, then error is thrown', async () => {
       jest.spyOn(teamRepository, 'getTeamById').mockResolvedValue(null);
 
       await expect(
-        service.changeUserRole('workspaceId', 'teamId', {
-          userId: 'userId',
+        service.changeUserRole('workspaceId', 'teamId', 'userId', {
           role: WorkspaceRole.MEMBER,
         }),
       ).rejects.toThrow(NotFoundException);
     });
 
-    it('When user is not part of team, then error is throw', async () => {
+    it('When user is not part of team, then error is thrown', async () => {
       jest
         .spyOn(teamRepository, 'getTeamById')
         .mockResolvedValue(newWorkspaceTeam());
       jest.spyOn(teamRepository, 'getTeamUser').mockResolvedValue(null);
 
       await expect(
-        service.changeUserRole('workspaceId', 'teamId', {
-          userId: 'useriD',
+        service.changeUserRole('workspaceId', 'teamId', 'userId', {
           role: WorkspaceRole.MEMBER,
         }),
       ).rejects.toThrow(NotFoundException);
     });
 
-    it('When user does not exist, then error is throw', async () => {
+    it('When user does not exist, then error is thrown', async () => {
       jest
         .spyOn(teamRepository, 'getTeamById')
         .mockResolvedValue(newWorkspaceTeam());
@@ -361,14 +359,13 @@ describe('WorkspacesUsecases', () => {
       jest.spyOn(userRepository, 'findByUuid').mockResolvedValue(null);
 
       await expect(
-        service.changeUserRole('workspaceId', 'teamId', {
-          userId: 'userId',
+        service.changeUserRole('workspaceId', 'teamId', 'userId', {
           role: WorkspaceRole.MEMBER,
         }),
       ).rejects.toThrow(BadRequestException);
     });
 
-    it('When user is member is updated to manager, then team manager is updated correctly', async () => {
+    it('When a member of the team is upgrade to manager, then it works', async () => {
       const member = newUser();
       const team = newWorkspaceTeam();
 
@@ -384,8 +381,7 @@ describe('WorkspacesUsecases', () => {
       );
       jest.spyOn(userRepository, 'findByUuid').mockResolvedValue(member);
 
-      await service.changeUserRole('workspaceId', 'teamId', {
-        userId: 'userId',
+      await service.changeUserRole('workspaceId', 'teamId', 'userId', {
         role: WorkspaceRole.MANAGER,
       });
 
@@ -394,7 +390,7 @@ describe('WorkspacesUsecases', () => {
       });
     });
 
-    it('When user is manager is updated to member, then owner is assigned as manager', async () => {
+    it('When a team manager role is changed to member, then the owner is assigned as manager', async () => {
       const manager = newUser();
       const workspaceOwner = newUser();
       const team = newWorkspaceTeam({ manager: manager });
@@ -413,8 +409,7 @@ describe('WorkspacesUsecases', () => {
       jest.spyOn(userRepository, 'findByUuid').mockResolvedValue(manager);
       jest.spyOn(workspaceRepository, 'findById').mockResolvedValue(workspace);
 
-      await service.changeUserRole('workspaceId', 'teamId', {
-        userId: 'userId',
+      await service.changeUserRole('workspaceId', 'teamId', 'userId', {
         role: WorkspaceRole.MEMBER,
       });
 
@@ -442,8 +437,7 @@ describe('WorkspacesUsecases', () => {
       jest.spyOn(userRepository, 'findByUuid').mockResolvedValue(manager);
       jest.spyOn(workspaceRepository, 'findById').mockResolvedValue(workspace);
 
-      await service.changeUserRole('workspaceId', 'teamId', {
-        userId: 'userId',
+      await service.changeUserRole('workspaceId', 'teamId', 'userId', {
         role: WorkspaceRole.MANAGER,
       });
 
@@ -466,8 +460,7 @@ describe('WorkspacesUsecases', () => {
       );
       jest.spyOn(userRepository, 'findByUuid').mockResolvedValue(member);
 
-      await service.changeUserRole('workspaceId', 'teamId', {
-        userId: 'userId',
+      await service.changeUserRole('workspaceId', 'teamId', 'userId', {
         role: WorkspaceRole.MEMBER,
       });
 

--- a/src/modules/workspaces/workspaces.usecase.ts
+++ b/src/modules/workspaces/workspaces.usecase.ts
@@ -334,13 +334,14 @@ export class WorkspacesUsecases {
   async changeUserRole(
     workspaceId: WorkspaceAttributes['id'],
     teamId: WorkspaceTeamAttributes['id'],
+    userUuid: User['uuid'],
     changeUserRoleDto: ChangeUserRoleDto,
   ): Promise<void> {
-    const { role, userId } = changeUserRoleDto;
+    const { role } = changeUserRoleDto;
 
     const [team, teamUser] = await Promise.all([
       this.teamRepository.getTeamById(teamId),
-      this.teamRepository.getTeamUser(userId, teamId),
+      this.teamRepository.getTeamUser(userUuid, teamId),
     ]);
 
     if (!team) {

--- a/src/modules/workspaces/workspaces.usecase.ts
+++ b/src/modules/workspaces/workspaces.usecase.ts
@@ -24,6 +24,9 @@ import { CreateWorkspaceInviteDto } from './dto/create-workspace-invite.dto';
 import { MailerService } from '../../externals/mailer/mailer.service';
 import { ConfigService } from '@nestjs/config';
 import { Sign } from '../../middlewares/passport';
+import { ChangeUserRoleDto } from './dto/change-user-role.dto';
+import { WorkspaceTeamAttributes } from './attributes/workspace-team.attributes';
+import { WorkspaceRole } from './guards/workspace-required-access.decorator';
 
 @Injectable()
 export class WorkspacesUsecases {
@@ -326,6 +329,55 @@ export class WorkspacesUsecases {
 
   findById(workspaceId: string): Promise<Workspace | null> {
     return this.workspaceRepository.findById(workspaceId);
+  }
+
+  async changeUserRole(
+    workspaceId: WorkspaceAttributes['id'],
+    teamId: WorkspaceTeamAttributes['id'],
+    changeUserRoleDto: ChangeUserRoleDto,
+  ): Promise<void> {
+    const { role, userId } = changeUserRoleDto;
+
+    const [team, teamUser] = await Promise.all([
+      this.teamRepository.getTeamById(teamId),
+      this.teamRepository.getTeamUser(userId, teamId),
+    ]);
+
+    if (!team) {
+      throw new NotFoundException('Team not found.');
+    }
+
+    if (!teamUser) {
+      throw new NotFoundException('User not part of the team.');
+    }
+
+    const user = await this.userRepository.findByUuid(teamUser.memberId);
+
+    if (!user) {
+      throw new BadRequestException();
+    }
+
+    const isUserAlreadyManager = team.isUserManager(user);
+
+    let newManagerId: UserAttributes['uuid'];
+
+    if (role === WorkspaceRole.MEMBER && isUserAlreadyManager) {
+      const workspaceOwner =
+        await this.workspaceRepository.findById(workspaceId);
+      newManagerId = workspaceOwner.ownerId;
+    }
+
+    if (role === WorkspaceRole.MANAGER && !isUserAlreadyManager) {
+      newManagerId = user.uuid;
+    }
+
+    if (!newManagerId) {
+      return;
+    }
+
+    await this.teamRepository.updateById(team.id, {
+      managerId: newManagerId,
+    });
   }
 
   findUserInTeam(


### PR DESCRIPTION
This PR enables changing roles of users inside a workspace (teams). 

There are only two possible roles to be assigned in the workspace (excluding owner, which is non assignable):
- Manager of a team: it is able to manage the team users, remove them for the team, etc.
- Member: has access to the team but it is not able to manage users or settings of it.

If a manager is removed from his role, them the owner of the workspace becomes the manager of that team. Teams should always have manager.