### PR TITLE
[PB-1837]: feat/accept invitation to workspace

### DIFF
--- a/src/modules/user/user.module.ts
+++ b/src/modules/user/user.module.ts
@@ -44,6 +44,8 @@ import { AttemptChangeEmailModel } from './attempt-change-email.model';
 import { MailerService } from '../../externals/mailer/mailer.service';
 import { SecurityModule } from '../security/security.module';
 import { FeatureLimitModule } from '../feature-limit/feature-limit.module';
+import { WorkspacesModule } from '../workspaces/workspaces.module';
+import { SequelizeWorkspaceRepository } from '../workspaces/repositories/workspaces.repository';
 
 @Module({
   imports: [
@@ -69,6 +71,7 @@ import { FeatureLimitModule } from '../feature-limit/feature-limit.module';
     forwardRef(() => SharingModule),
     SecurityModule,
     forwardRef(() => FeatureLimitModule),
+    forwardRef(() => WorkspacesModule),
   ],
   controllers: [UserController],
   providers: [
@@ -79,6 +82,7 @@ import { FeatureLimitModule } from '../feature-limit/feature-limit.module';
     SequelizeKeyServerRepository,
     SequelizeUserReferralsRepository,
     SequelizeAttemptChangeEmailRepository,
+    SequelizeWorkspaceRepository,
     UserUseCases,
     CryptoService,
     BridgeService,

--- a/src/modules/user/user.usecase.spec.ts
+++ b/src/modules/user/user.usecase.spec.ts
@@ -270,7 +270,7 @@ describe('User use cases', () => {
   });
 
   describe('replacePreCreatedUserWorkspaceInvitations', () => {
-    it('When pre created user is replaced successfully, then update to new user uuid', async () => {
+    it('When pre created user is replaced successfully, then update invitations to new user uuid', async () => {
       const preCreatedUserUuid = 'pre-created-user-uuid';
       const newUserUuid = 'new-user-uuid';
       const privateKeyInBase64 = 'private-key';

--- a/src/modules/user/user.usecase.spec.ts
+++ b/src/modules/user/user.usecase.spec.ts
@@ -23,9 +23,15 @@ import { UserNotFoundException } from './exception/user-not-found.exception';
 import { AttemptChangeEmailNotFoundException } from './exception/attempt-change-email-not-found.exception';
 import { AttemptChangeEmailHasExpiredException } from './exception/attempt-change-email-has-expired.exception';
 import { AttemptChangeEmailAlreadyVerifiedException } from './exception/attempt-change-email-already-verified.exception';
-import { newMailLimit } from '../../../test/fixtures';
+import {
+  newMailLimit,
+  newUser,
+  newWorkspaceInvite,
+} from '../../../test/fixtures';
 import { MailTypes } from '../security/mail-limit/mailTypes';
 import { SequelizeMailLimitRepository } from '../security/mail-limit/mail-limit.repository';
+import { SequelizeWorkspaceRepository } from '../workspaces/repositories/workspaces.repository';
+import * as openpgpUtils from '../../lib/openpgp';
 
 jest.mock('../../middlewares/passport', () => {
   const originalModule = jest.requireActual('../../middlewares/passport');
@@ -50,6 +56,7 @@ describe('User use cases', () => {
   let attemptChangeEmailRepository: SequelizeAttemptChangeEmailRepository;
   let configService: ConfigService;
   let mailLimitRepository: SequelizeMailLimitRepository;
+  let workspaceRepository: SequelizeWorkspaceRepository;
 
   const user = User.build({
     id: 1,
@@ -108,6 +115,9 @@ describe('User use cases', () => {
     configService = moduleRef.get<ConfigService>(ConfigService);
     mailLimitRepository = moduleRef.get<SequelizeMailLimitRepository>(
       SequelizeMailLimitRepository,
+    );
+    workspaceRepository = moduleRef.get<SequelizeWorkspaceRepository>(
+      SequelizeWorkspaceRepository,
     );
   });
 
@@ -256,6 +266,68 @@ describe('User use cases', () => {
           expect(deleteFilesSpy).toBeCalledWith(user, files);
         });
       });
+    });
+  });
+
+  describe('replacePreCreatedUserWorkspaceInvitations', () => {
+    it('When pre created user is replaced successfully, then update to new user uuid', async () => {
+      const preCreatedUserUuid = 'pre-created-user-uuid';
+      const newUserUuid = 'new-user-uuid';
+      const privateKeyInBase64 = 'private-key';
+      const decryptedEncryptionKey = 'decrypted-key';
+      const newEncryptedKey = 'new-encrypted-key';
+      const newPublicKey = 'public-key';
+      const invitedUser = newUser();
+      const invitations = [
+        newWorkspaceInvite({
+          invitedUser: invitedUser.uuid,
+        }),
+        newWorkspaceInvite({
+          invitedUser: invitedUser.uuid,
+        }),
+      ];
+
+      jest
+        .spyOn(openpgpUtils, 'decryptMessageWithPrivateKey')
+        .mockResolvedValue(decryptedEncryptionKey);
+      jest
+        .spyOn(openpgpUtils, 'encryptMessageWithPublicKey')
+        .mockResolvedValue(newEncryptedKey);
+      jest
+        .spyOn(workspaceRepository, 'findInvitesBy')
+        .mockResolvedValue(invitations);
+
+      await userUseCases.replacePreCreatedUserWorkspaceInvitations(
+        preCreatedUserUuid,
+        newUserUuid,
+        privateKeyInBase64,
+        newPublicKey,
+      );
+
+      expect(
+        workspaceRepository.bulkUpdateInvitesKeysAndUsers,
+      ).toHaveBeenCalledWith(
+        invitations.map(() =>
+          expect.objectContaining({
+            invitedUser: expect.stringContaining(newUserUuid),
+          }),
+        ),
+      );
+    });
+
+    it('When no pre created user does not have invitations, then should not update', async () => {
+      jest.spyOn(workspaceRepository, 'findInvitesBy').mockResolvedValue([]);
+
+      await userUseCases.replacePreCreatedUserWorkspaceInvitations(
+        'pre-created-user-uuid',
+        'new-user-uuid',
+        'private-key',
+        'new-public-key',
+      );
+
+      expect(
+        workspaceRepository.bulkUpdateInvitesKeysAndUsers,
+      ).not.toHaveBeenCalled();
     });
   });
 

--- a/src/modules/workspaces/dto/accept-workspace-invite.dto.ts
+++ b/src/modules/workspaces/dto/accept-workspace-invite.dto.ts
@@ -1,0 +1,13 @@
+import { IsNotEmpty, IsUUID } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+import { WorkspaceInviteAttributes } from '../attributes/workspace-invite.attribute';
+
+export class AcceptWorkspaceInviteDto {
+  @ApiProperty({
+    example: '0f8fad5b-d9cb-469f-a165-70867728950e',
+    description: 'id of the invitation',
+  })
+  @IsUUID()
+  @IsNotEmpty()
+  inviteId: WorkspaceInviteAttributes['id'];
+}

--- a/src/modules/workspaces/repositories/workspaces.repository.spec.ts
+++ b/src/modules/workspaces/repositories/workspaces.repository.spec.ts
@@ -76,16 +76,23 @@ describe('SequelizeWorkspaceRepository', () => {
 
       await repository.bulkUpdateInvitesKeysAndUsers(invites);
 
-      invites.forEach((invite, index) => {
-        expect(workspaceInviteModel.update).toHaveBeenNthCalledWith(
-          index + 1,
-          {
-            invitedUser: invite.invitedUser,
-            encryptionKey: invite.encryptionKey,
-          },
-          { where: { id: invite.id } },
-        );
-      });
+      expect(workspaceInviteModel.update).toHaveBeenNthCalledWith(
+        1,
+        {
+          invitedUser: invites[0].invitedUser,
+          encryptionKey: invites[0].encryptionKey,
+        },
+        { where: { id: invites[0].id } },
+      );
+
+      expect(workspaceInviteModel.update).toHaveBeenNthCalledWith(
+        2,
+        {
+          invitedUser: invites[1].invitedUser,
+          encryptionKey: invites[1].encryptionKey,
+        },
+        { where: { id: invites[1].id } },
+      );
     });
   });
 

--- a/src/modules/workspaces/repositories/workspaces.repository.spec.ts
+++ b/src/modules/workspaces/repositories/workspaces.repository.spec.ts
@@ -12,6 +12,7 @@ import {
   newWorkspaceUser,
 } from '../../../../test/fixtures';
 import { Workspace } from '../domains/workspaces.domain';
+import { v4 } from 'uuid';
 
 describe('SequelizeWorkspaceRepository', () => {
   let repository: SequelizeWorkspaceRepository;
@@ -66,6 +67,25 @@ describe('SequelizeWorkspaceRepository', () => {
       jest.spyOn(workspaceInviteModel, 'count').mockResolvedValueOnce(5);
       const count = await repository.getWorkspaceInvitationsCount('1');
       expect(count).toEqual(5);
+    });
+  });
+
+  describe('bulkUpdateInvitesKeysAndUsers', () => {
+    it('When invites are being updated, then it should update each invite with the correct invitedUser and encryptionKey', async () => {
+      const invites = [newWorkspaceInvite(), newWorkspaceInvite()];
+
+      await repository.bulkUpdateInvitesKeysAndUsers(invites);
+
+      invites.forEach((invite, index) => {
+        expect(workspaceInviteModel.update).toHaveBeenNthCalledWith(
+          index + 1,
+          {
+            invitedUser: invite.invitedUser,
+            encryptionKey: invite.encryptionKey,
+          },
+          { where: { id: invite.id } },
+        );
+      });
     });
   });
 

--- a/src/modules/workspaces/repositories/workspaces.repository.ts
+++ b/src/modules/workspaces/repositories/workspaces.repository.ts
@@ -113,7 +113,9 @@ export class SequelizeWorkspaceRepository implements WorkspaceRepository {
     await Promise.all(updatePromises);
   }
 
-  async deleteInvite(where: Partial<WorkspaceInviteAttributes>): Promise<void> {
+  async deleteInviteBy(
+    where: Partial<WorkspaceInviteAttributes>,
+  ): Promise<void> {
     await this.modelWorkspaceInvite.destroy({ where });
   }
 

--- a/src/modules/workspaces/repositories/workspaces.repository.ts
+++ b/src/modules/workspaces/repositories/workspaces.repository.ts
@@ -86,6 +86,37 @@ export class SequelizeWorkspaceRepository implements WorkspaceRepository {
     return invite ? WorkspaceInvite.build(invite) : null;
   }
 
+  async findInvitesBy(
+    where: Partial<WorkspaceInvite>,
+  ): Promise<WorkspaceInvite[]> {
+    const invites = await this.modelWorkspaceInvite.findAll({ where });
+
+    return invites.map((invite) => WorkspaceInvite.build(invite));
+  }
+
+  async bulkUpdateInvitesKeysAndUsers(
+    invites: Partial<WorkspaceInvite>[],
+  ): Promise<void> {
+    const updatePromises = invites.map((invite) =>
+      this.modelWorkspaceInvite.update(
+        {
+          invitedUser: invite.invitedUser,
+          encryptionKey: invite.encryptionKey,
+        },
+        {
+          where: {
+            id: invite.id,
+          },
+        },
+      ),
+    );
+    await Promise.all(updatePromises);
+  }
+
+  async deleteInvite(where: Partial<WorkspaceInviteAttributes>): Promise<void> {
+    await this.modelWorkspaceInvite.destroy({ where });
+  }
+
   async getWorkspaceInvitationsCount(
     workspaceId: WorkspaceAttributes['id'],
   ): Promise<number> {

--- a/src/modules/workspaces/workspaces.controller.spec.ts
+++ b/src/modules/workspaces/workspaces.controller.spec.ts
@@ -6,6 +6,7 @@ import { WorkspaceRole } from './guards/workspace-required-access.decorator';
 import {
   newUser,
   newWorkspace,
+  newWorkspaceInvite,
   newWorkspaceUser,
 } from '../../../test/fixtures';
 import { v4 } from 'uuid';
@@ -114,6 +115,21 @@ describe('Workspace Controller', () => {
       await expect(
         workspacesController.getUserWorkspacesToBeSetup(owner),
       ).resolves.toEqual([workspace]);
+      describe('POST /invitations/accept', () => {
+        const user = newUser();
+        it('When workspace id is not a valid uuid, then it throws.', async () => {
+          const invite = newWorkspaceInvite({ invitedUser: user.uuid });
+
+          await workspacesController.acceptWorkspaceInvitation(user, {
+            inviteId: invite.id,
+          });
+
+          expect(workspacesUsecases.acceptWorkspaceInvite).toHaveBeenCalledWith(
+            user,
+            invite.id,
+          );
+        });
+      });
     });
   });
 });

--- a/src/modules/workspaces/workspaces.controller.spec.ts
+++ b/src/modules/workspaces/workspaces.controller.spec.ts
@@ -115,21 +115,22 @@ describe('Workspace Controller', () => {
       await expect(
         workspacesController.getUserWorkspacesToBeSetup(owner),
       ).resolves.toEqual([workspace]);
-      describe('POST /invitations/accept', () => {
-        const user = newUser();
-        it('When workspace id is not a valid uuid, then it throws.', async () => {
-          const invite = newWorkspaceInvite({ invitedUser: user.uuid });
+    });
+  });
 
-          await workspacesController.acceptWorkspaceInvitation(user, {
-            inviteId: invite.id,
-          });
+  describe('POST /invitations/accept', () => {
+    const user = newUser();
+    it('When workspace id is not a valid uuid, then it throws.', async () => {
+      const invite = newWorkspaceInvite({ invitedUser: user.uuid });
 
-          expect(workspacesUsecases.acceptWorkspaceInvite).toHaveBeenCalledWith(
-            user,
-            invite.id,
-          );
-        });
+      await workspacesController.acceptWorkspaceInvitation(user, {
+        inviteId: invite.id,
       });
+
+      expect(workspacesUsecases.acceptWorkspaceInvite).toHaveBeenCalledWith(
+        user,
+        invite.id,
+      );
     });
   });
 });

--- a/src/modules/workspaces/workspaces.controller.ts
+++ b/src/modules/workspaces/workspaces.controller.ts
@@ -32,6 +32,7 @@ import { CreateWorkspaceInviteDto } from './dto/create-workspace-invite.dto';
 import { WorkspaceTeamAttributes } from './attributes/workspace-team.attributes';
 import { ChangeUserRoleDto } from './dto/change-user-role.dto';
 import { SetupWorkspaceDto } from './dto/setup-workspace.dto';
+import { AcceptWorkspaceInviteDto } from './dto/accept-workspace-invite.dto';
 
 @ApiTags('Workspaces')
 @Controller('workspaces')
@@ -187,5 +188,21 @@ export class WorkspacesController {
       userUuid,
       changeUserRoleBody,
     );
+  }
+
+  @Post('/invitations/accept')
+  @ApiOperation({
+    summary: 'Accepts invitation to workspace',
+  })
+  @ApiOkResponse({
+    description: 'Workspace invitation accepted',
+  })
+  async acceptWorkspaceInvitation(
+    @UserDecorator() user: User,
+    @Body() acceptInvitationDto: AcceptWorkspaceInviteDto,
+  ) {
+    const { inviteId } = acceptInvitationDto;
+
+    return this.workspaceUseCases.acceptWorkspaceInvite(user, inviteId);
   }
 }

--- a/src/modules/workspaces/workspaces.controller.ts
+++ b/src/modules/workspaces/workspaces.controller.ts
@@ -191,6 +191,7 @@ export class WorkspacesController {
   }
 
   @Post('/invitations/accept')
+  @ApiBearerAuth()
   @ApiOperation({
     summary: 'Accepts invitation to workspace',
   })

--- a/src/modules/workspaces/workspaces.module.ts
+++ b/src/modules/workspaces/workspaces.module.ts
@@ -1,4 +1,4 @@
-import { Logger, Module } from '@nestjs/common';
+import { Logger, Module, forwardRef } from '@nestjs/common';
 import { SequelizeModule } from '@nestjs/sequelize';
 import { UserModule } from '../user/user.module';
 import { WorkspacesController } from './workspaces.controller';
@@ -25,7 +25,7 @@ import { MailerModule } from '../../externals/mailer/mailer.module';
       WorkspaceUserModel,
       WorkspaceInviteModel,
     ]),
-    UserModule,
+    forwardRef(() => UserModule),
     BridgeModule,
     MailerModule,
   ],

--- a/src/modules/workspaces/workspaces.usecase.spec.ts
+++ b/src/modules/workspaces/workspaces.usecase.spec.ts
@@ -659,6 +659,7 @@ describe('WorkspacesUsecases', () => {
       const invite = newWorkspaceInvite({
         invitedUser: invitedUser.uuid,
         workspaceId: workspace.id,
+        attributes: { spaceLimit: BigInt(1000) },
       });
       jest.spyOn(workspaceRepository, 'findInvite').mockResolvedValue(invite);
       jest.spyOn(workspaceRepository, 'findOne').mockResolvedValue(workspace);
@@ -671,6 +672,7 @@ describe('WorkspacesUsecases', () => {
       expect(workspaceRepository.addUserToWorkspace).toHaveBeenCalledWith(
         expect.objectContaining({
           memberId: invite.invitedUser,
+          spaceLimit: invite.spaceLimit,
         }),
       );
     });

--- a/src/modules/workspaces/workspaces.usecase.spec.ts
+++ b/src/modules/workspaces/workspaces.usecase.spec.ts
@@ -608,6 +608,79 @@ describe('WorkspacesUsecases', () => {
     });
   });
 
+  describe('acceptWorkspaceInvite', () => {
+    const invitedUser = newUser();
+
+    it('When invite is not found, then fail', async () => {
+      jest.spyOn(workspaceRepository, 'findInvite').mockResolvedValue(null);
+      await expect(
+        service.acceptWorkspaceInvite(invitedUser, 'anyUuid'),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('When invite does not point to a valid workspace, then fail', async () => {
+      const invite = newWorkspaceInvite({ invitedUser: invitedUser.uuid });
+
+      jest.spyOn(workspaceRepository, 'findInvite').mockResolvedValue(invite);
+      jest.spyOn(workspaceRepository, 'findOne').mockResolvedValue(null);
+
+      await expect(
+        service.acceptWorkspaceInvite(invitedUser, 'anyUuid'),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    /*     it('When invite is valid, then add user to workspace with respective space limit', async () => {
+      const workspace = newWorkspace();
+      const invite = newWorkspaceInvite({
+        invitedUser: invitedUser.uuid,
+        workspaceId: workspace.id,
+      });
+      jest.spyOn(workspaceRepository, 'findInvite').mockResolvedValue(invite);
+      jest.spyOn(workspaceRepository, 'findOne').mockResolvedValue(workspace);
+
+      await service.acceptWorkspaceInvite(invitedUser, 'anyUuid');
+
+      expect(workspaceRepository.addUserToWorkspace).toHaveBeenCalledWith(
+        expect.objectContaining({
+          memberId: invite.invitedUser,
+          workspaceId: invite.id,
+          spaceLimit: invite.spaceLimit,
+        }),
+      );
+    }); */
+
+    /*     it('When invite is valid, then add user to default team', async () => {
+      const workspace = newWorkspace();
+      const invite = newWorkspaceInvite({
+        invitedUser: invitedUser.uuid,
+        workspaceId: workspace.id,
+      });
+      jest.spyOn(workspaceRepository, 'findInvite').mockResolvedValue(invite);
+      jest.spyOn(workspaceRepository, 'findOne').mockResolvedValue(workspace);
+
+      await service.acceptWorkspaceInvite(invitedUser, 'anyUuid');
+
+      expect(workspaceRepository.addUserToTeam).toHaveBeenCalledWith(
+        workspace.defaultTeamId,
+        invitedUser.uuid,
+      );
+    }); */
+
+    it('When invite is accepted, then it should be deleted aftewards', async () => {
+      const workspace = newWorkspace();
+      const invite = newWorkspaceInvite({
+        invitedUser: invitedUser.uuid,
+        workspaceId: workspace.id,
+      });
+      jest.spyOn(workspaceRepository, 'findInvite').mockResolvedValue(invite);
+      jest.spyOn(workspaceRepository, 'findOne').mockResolvedValue(workspace);
+
+      await service.acceptWorkspaceInvite(invitedUser, 'anyUuid');
+
+      expect(workspaceRepository.deleteInvite).toHaveBeenCalledWith(invite);
+    });
+  });
+
   describe('changeUserRole', () => {
     it('When team does not exist, then error is thrown', async () => {
       jest.spyOn(teamRepository, 'getTeamById').mockResolvedValue(null);


### PR DESCRIPTION
This PR adds pre-created user replacement using the same logic we implemented previously for sharings and adds an endpoint to accept workspace invitations.

### When pre-created user keys get replaced?

- When a user registers via normal flow with the invited email.
- When a user registers via a special flow (view) set for external invited users.

### How do users get replaced?

We use the same process as sharings (which is working OK), when the user registers and a new pair of keys are created, we use the default password we set previously to decrypt the private key of the pre-created user and use the new pair of keys to encrypt again the respective encryptionKeys.

### Why did I not add a field to accept the workspace invitation to the pre-created users' registration as we do in sharing?

We had problems with that previously! Sometimes the invitation is not accepted after we update the keys and the userUuid of the invitation! Please reach out to me for a further explanation.

#### Suggestion for this!!

Due to the user uuid in the invitation not being returned correctly if we try to fetch the invitation immediately after it has been updated (it comes with the pre-created user uuid instead of the registered user uuid despite it has been changed a few milliseconds ago). 

We could ask the frontend team to request the accept invite endpoint, this should give the database enough time to process the update of the invitation.