### PR TITLE
[PB-2049]: feat/added get available and pending to be setup workspaces endpoints

### DIFF
--- a/src/modules/workspaces/workspaces.controller.ts
+++ b/src/modules/workspaces/workspaces.controller.ts
@@ -38,6 +38,28 @@ import { SetupWorkspaceDto } from './dto/setup-workspace.dto';
 export class WorkspacesController {
   constructor(private workspaceUseCases: WorkspacesUsecases) {}
 
+  @Get('/')
+  @ApiOperation({
+    summary: 'Get available workspaces for the user',
+  })
+  @ApiOkResponse({
+    description: 'Available workspaces and workspaceUser',
+  })
+  async getAvailableWorkspaces(@UserDecorator() user: User) {
+    return this.workspaceUseCases.getAvailableWorkspaces(user);
+  }
+
+  @Get('/pending-setup')
+  @ApiOperation({
+    summary: 'Get owner workspaces ready to be setup',
+  })
+  @ApiOkResponse({
+    description: 'Workspaces pending to be setup',
+  })
+  async getUserWorkspacesToBeSetup(@UserDecorator() user: User) {
+    return this.workspaceUseCases.getWorkspacesPendingToBeSetup(user);
+  }
+
   @Patch('/:workspaceId/setup')
   @ApiOperation({
     summary: 'Set up workspace that has been initialized',

--- a/src/modules/workspaces/workspaces.controller.ts
+++ b/src/modules/workspaces/workspaces.controller.ts
@@ -53,6 +53,7 @@ export class WorkspacesController {
   @ApiOperation({
     summary: 'Get owner workspaces ready to be setup',
   })
+  @ApiBearerAuth()
   @ApiOkResponse({
     description: 'Workspaces pending to be setup',
   })

--- a/src/modules/workspaces/workspaces.usecase.spec.ts
+++ b/src/modules/workspaces/workspaces.usecase.spec.ts
@@ -553,21 +553,23 @@ describe('WorkspacesUsecases', () => {
   describe('getWorkspacesPendingToBeSetup', () => {
     it('When trying to get workspaces ready to be setup, then only workspaces that the user created should be retrieved', async () => {
       const owner = newUser();
-      const workspace = newWorkspace({
+      const setupWorkspace = newWorkspace({
         owner,
         attributes: { setupCompleted: false },
       });
 
       jest
         .spyOn(workspaceRepository, 'findAllBy')
-        .mockResolvedValue([workspace]);
+        .mockResolvedValue([setupWorkspace]);
 
-      await service.getWorkspacesPendingToBeSetup(owner);
+      const availableWorkspaces =
+        await service.getWorkspacesPendingToBeSetup(owner);
 
       expect(workspaceRepository.findAllBy).toHaveBeenCalledWith({
         ownerId: owner.uuid,
         setupCompleted: false,
       });
+      expect(availableWorkspaces).toEqual([setupWorkspace]);
     });
   });
 

--- a/src/modules/workspaces/workspaces.usecase.ts
+++ b/src/modules/workspaces/workspaces.usecase.ts
@@ -405,6 +405,26 @@ export class WorkspacesUsecases {
     return this.teamRepository.createTeam(newTeam);
   }
 
+  async getAvailableWorkspaces(user: User) {
+    const availablesWorkspaces =
+      await this.workspaceRepository.findUserAvailableWorkspaces(user.uuid);
+
+    return availablesWorkspaces.filter(
+      (workspaceData) =>
+        workspaceData.workspace.isWorkspaceReady() &&
+        !workspaceData.workspaceUser.deactivated,
+    );
+  }
+
+  async getWorkspacesPendingToBeSetup(user: User) {
+    const workspacesToBeSetup = await this.workspaceRepository.findAllBy({
+      ownerId: user.uuid,
+      setupCompleted: false,
+    });
+
+    return workspacesToBeSetup;
+  }
+
   async getWorkspaceTeams(user: User, workspaceId: WorkspaceAttributes['id']) {
     const workspace = await this.workspaceRepository.findOne({
       ownerId: user.uuid,


### PR DESCRIPTION
We need to show users their available workspaces so they can switch between them. We also need to show the current user's pending (to be setup) workspaces. 

This PR intends to add those two endpoints.

- Get available workspaces endpoint: retrieves the already setup workspaces the user belongs to, this endpoint is useful for owners and members of the workspace. 
- Get workspaces pending to be set up: retrieves the current user (thus, the owner of them) workspaces that are yet to be setup. 