### PR TITLE
[PB-1843, PB-1840] feat: added deactivate user and member details endpoint

### DIFF
--- a/src/modules/workspaces/repositories/team.repository.spec.ts
+++ b/src/modules/workspaces/repositories/team.repository.spec.ts
@@ -157,12 +157,15 @@ describe('SequelizeWorkspaceTeamRepository', () => {
   });
 
   describe('getTeamAndMemberByWorkspaceAndMemberId', () => {
+    const workspaceId = 'cc0b0b43-30cb-47cc-8461-7fda2caad132';
+    const memberId = '79a88429-b45a-4ae7-90f1-c351b6882670';
+
     it('When members are not found, then return empty array', async () => {
       jest.spyOn(workspaceTeamUserModel, 'findAll').mockResolvedValueOnce([]);
 
       const result = await repository.getTeamAndMemberByWorkspaceAndMemberId(
-        'workspaceiD',
-        'memberId',
+        workspaceId,
+        memberId,
       );
 
       expect(result).toEqual([]);
@@ -184,8 +187,8 @@ describe('SequelizeWorkspaceTeamRepository', () => {
       ] as any);
 
       const result = await repository.getTeamAndMemberByWorkspaceAndMemberId(
-        'workspaceiD',
-        'memberId',
+        workspaceId,
+        memberId,
       );
 
       expect(result).toEqual([

--- a/src/modules/workspaces/repositories/team.repository.spec.ts
+++ b/src/modules/workspaces/repositories/team.repository.spec.ts
@@ -2,6 +2,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { createMock } from '@golevelup/ts-jest';
 import { getModelToken } from '@nestjs/sequelize';
 import {
+  newUser,
   newWorkspace,
   newWorkspaceTeam,
   newWorkspaceTeamUser,
@@ -157,15 +158,15 @@ describe('SequelizeWorkspaceTeamRepository', () => {
   });
 
   describe('getTeamAndMemberByWorkspaceAndMemberId', () => {
-    const workspaceId = 'cc0b0b43-30cb-47cc-8461-7fda2caad132';
-    const memberId = '79a88429-b45a-4ae7-90f1-c351b6882670';
+    const workspace = newWorkspace();
+    const member = newUser();
 
     it('When members are not found, then return empty array', async () => {
       jest.spyOn(workspaceTeamUserModel, 'findAll').mockResolvedValueOnce([]);
 
       const result = await repository.getTeamAndMemberByWorkspaceAndMemberId(
-        workspaceId,
-        memberId,
+        workspace.id,
+        member.uuid,
       );
 
       expect(result).toEqual([]);
@@ -187,8 +188,8 @@ describe('SequelizeWorkspaceTeamRepository', () => {
       ] as any);
 
       const result = await repository.getTeamAndMemberByWorkspaceAndMemberId(
-        workspaceId,
-        memberId,
+        workspace.id,
+        member.uuid,
       );
 
       expect(result).toEqual([

--- a/src/modules/workspaces/repositories/team.repository.ts
+++ b/src/modules/workspaces/repositories/team.repository.ts
@@ -10,6 +10,7 @@ import { WorkspaceTeam } from '../domains/workspace-team.domain';
 import { WorkspaceTeamAttributes } from '../attributes/workspace-team.attributes';
 import { UserAttributes } from '../../user/user.attributes';
 import { WorkspaceTeamUser } from '../domains/workspace-team-user.domain';
+import { WorkspaceTeamUserAttributes } from '../attributes/workspace-team-users.attributes';
 
 @Injectable()
 export class SequelizeWorkspaceTeamRepository {
@@ -35,11 +36,13 @@ export class SequelizeWorkspaceTeamRepository {
 
   async getTeamMembers(teamId: WorkspaceTeamAttributes['id']) {
     const result = await this.teamUserModel.findAll({
-      where: { id: teamId },
-      include: { model: UserModel, as: 'member' },
+      where: { teamId },
+      include: { model: UserModel, required: true },
     });
 
-    return result.map((teamUser) => User.build({ ...teamUser.member }));
+    return result.map((teamUser) =>
+      User.build({ ...teamUser.member.get({ plain: true }) }),
+    );
   }
 
   async getTeamMembersCount(teamId: WorkspaceTeamAttributes['id']) {
@@ -94,6 +97,30 @@ export class SequelizeWorkspaceTeamRepository {
     const raw = await this.teamModel.findOne({ where: { id: teamId } });
 
     return raw ? this.toDomain(raw) : null;
+  }
+
+  async getTeamAndMemberByWorkspaceAndMemberId(
+    workspaceId: WorkspaceAttributes['id'],
+    memberId: WorkspaceTeamUserAttributes['memberId'],
+  ): Promise<
+    {
+      team: WorkspaceTeam;
+      teamUser: WorkspaceTeamUser;
+    }[]
+  > {
+    const memberTeamsAndData = await this.teamUserModel.findAll({
+      where: { memberId },
+      include: {
+        model: this.teamModel,
+        required: true,
+        where: { workspaceId },
+      },
+    });
+
+    return memberTeamsAndData.map((teamUser) => ({
+      team: this.toDomain(teamUser.team),
+      teamUser: this.teamUserToDomain(teamUser),
+    }));
   }
 
   async removeMemberFromTeam(

--- a/src/modules/workspaces/repositories/workspaces.repository.spec.ts
+++ b/src/modules/workspaces/repositories/workspaces.repository.spec.ts
@@ -8,6 +8,8 @@ import { createMock } from '@golevelup/ts-jest';
 import { WorkspaceInvite } from '../domains/workspace-invite.domain';
 import { WorkspaceUser } from '../domains/workspace-user.domain';
 import {
+  newUser,
+  newWorkspace,
   newWorkspaceInvite,
   newWorkspaceUser,
 } from '../../../../test/fixtures';
@@ -141,6 +143,19 @@ describe('SequelizeWorkspaceRepository', () => {
 
       const total = await repository.getTotalSpaceLimitInWorkspaceUsers('1');
       expect(total).toStrictEqual(BigInt(10));
+    });
+  });
+
+  describe('deactivateWorkspaceUser', () => {
+    it('When the total is calculated, the respective space should be returned', async () => {
+      const member = newUser();
+      const workspace = newWorkspace();
+
+      await repository.deactivateWorkspaceUser(member.uuid, workspace.id);
+      expect(workspaceUserModel.update).toHaveBeenCalledWith(
+        { deactivated: true },
+        { where: { memberId: member.uuid, workspaceId: workspace.id } },
+      );
     });
   });
 

--- a/src/modules/workspaces/repositories/workspaces.repository.spec.ts
+++ b/src/modules/workspaces/repositories/workspaces.repository.spec.ts
@@ -147,7 +147,7 @@ describe('SequelizeWorkspaceRepository', () => {
   });
 
   describe('deactivateWorkspaceUser', () => {
-    it('When the total is calculated, the respective space should be returned', async () => {
+    it('When the user is deactivated, then the respective user should be deleted', async () => {
       const member = newUser();
       const workspace = newWorkspace();
 

--- a/src/modules/workspaces/repositories/workspaces.repository.ts
+++ b/src/modules/workspaces/repositories/workspaces.repository.ts
@@ -224,6 +224,16 @@ export class SequelizeWorkspaceRepository implements WorkspaceRepository {
     };
   }
 
+  async deactivateWorkspaceUser(
+    memberId: string,
+    workspaceId: string,
+  ): Promise<void> {
+    await this.modelWorkspaceUser.update(
+      { deactivated: true },
+      { where: { memberId, workspaceId } },
+    );
+  }
+
   async findUserAvailableWorkspaces(userUuid: string) {
     const userWorkspaces = await this.modelWorkspaceUser.findAll({
       where: { memberId: userUuid },

--- a/src/modules/workspaces/workspaces.controller.ts
+++ b/src/modules/workspaces/workspaces.controller.ts
@@ -357,7 +357,7 @@ export class WorkspacesController {
   @ApiParam({ name: 'workspaceId', type: String, required: true })
   @ApiParam({ name: 'memberId', type: String, required: true })
   @ApiOkResponse({
-    description: 'Details of workpace member',
+    description: 'Details of the workspace members',
   })
   @UseGuards(WorkspaceGuard)
   @WorkspaceRequiredAccess(AccessContext.WORKSPACE, WorkspaceRole.MEMBER)

--- a/src/modules/workspaces/workspaces.controller.ts
+++ b/src/modules/workspaces/workspaces.controller.ts
@@ -109,7 +109,7 @@ export class WorkspacesController {
     description: 'Members of the team',
   })
   @UseGuards(WorkspaceGuard)
-  @WorkspaceRequiredAccess(AccessContext.WORKSPACE, WorkspaceRole.MEMBER)
+  @WorkspaceRequiredAccess(AccessContext.TEAM, WorkspaceRole.MEMBER)
   async getTeamMembers(
     @Param('teamId', ValidateUUIDPipe) teamId: WorkspaceTeamAttributes['id'],
   ) {
@@ -346,6 +346,53 @@ export class WorkspacesController {
       teamId,
       userUuid,
       changeUserRoleBody,
+    );
+  }
+
+  @Get(':workspaceId/members/:memberId')
+  @ApiBearerAuth()
+  @ApiOperation({
+    summary: 'Gets workspace member details',
+  })
+  @ApiParam({ name: 'workspaceId', type: String, required: true })
+  @ApiParam({ name: 'memberId', type: String, required: true })
+  @ApiOkResponse({
+    description: 'Details of workpace member',
+  })
+  @UseGuards(WorkspaceGuard)
+  @WorkspaceRequiredAccess(AccessContext.WORKSPACE, WorkspaceRole.MEMBER)
+  async getWorkspaceMemberDetails(
+    @Param('memberId', ValidateUUIDPipe)
+    memberId: WorkspaceTeamAttributes['id'],
+    @Param('workspaceId', ValidateUUIDPipe)
+    workspaceId: WorkspaceAttributes['id'],
+  ) {
+    return this.workspaceUseCases.getMemberDetails(workspaceId, memberId);
+  }
+
+  @Patch(':workspaceId/members/:memberId/deactivate')
+  @ApiBearerAuth()
+  @ApiOperation({
+    summary: 'Deactivate user from workspace',
+  })
+  @ApiParam({ name: 'workspaceId', type: String, required: true })
+  @ApiParam({ name: 'memberId', type: String, required: true })
+  @ApiOkResponse({
+    description: 'User successfully deactivated',
+  })
+  @UseGuards(WorkspaceGuard)
+  @WorkspaceRequiredAccess(AccessContext.WORKSPACE, WorkspaceRole.OWNER)
+  async deactivateWorkspaceMember(
+    @Param('memberId', ValidateUUIDPipe)
+    memberId: WorkspaceTeamAttributes['id'],
+    @Param('workspaceId', ValidateUUIDPipe)
+    workspaceId: WorkspaceAttributes['id'],
+    @UserDecorator() user: User,
+  ) {
+    return this.workspaceUseCases.deactivateWorkspaceUser(
+      user,
+      memberId,
+      workspaceId,
     );
   }
 }

--- a/src/modules/workspaces/workspaces.usecase.spec.ts
+++ b/src/modules/workspaces/workspaces.usecase.spec.ts
@@ -1353,7 +1353,7 @@ describe('WorkspacesUsecases', () => {
   describe('getTeamMembers', () => {
     it('When members are found, then it should return members data', async () => {
       const member1 = newUser({
-        attributes: { avatar: '693d930a-b497-43a2-825d-bd43a45b44b7' },
+        attributes: { avatar: v4() },
       });
       const member2 = newUser();
       const avatarUrl = 'avatarUrl';

--- a/src/modules/workspaces/workspaces.usecase.spec.ts
+++ b/src/modules/workspaces/workspaces.usecase.spec.ts
@@ -25,6 +25,7 @@ import { BridgeService } from '../../externals/bridge/bridge.service';
 import { SequelizeWorkspaceTeamRepository } from './repositories/team.repository';
 import { WorkspaceRole } from './guards/workspace-required-access.decorator';
 import { WorkspaceTeamUser } from './domains/workspace-team-user.domain';
+import { v4 } from 'uuid';
 
 jest.mock('../../middlewares/passport', () => {
   const originalModule = jest.requireActual('../../middlewares/passport');
@@ -1352,6 +1353,47 @@ describe('WorkspacesUsecases', () => {
         },
         teams: [{ ...team, isManager: team.isUserManager(managerUser) }],
       });
+    });
+  });
+
+  describe('getTeamMembers', () => {
+    it('When members are found, then it should return members data', async () => {
+      const member1 = newUser();
+      const member2 = newUser();
+      const avatarUrl = 'avatarUrl';
+      jest
+        .spyOn(teamRepository, 'getTeamMembers')
+        .mockResolvedValue([member1, member2]);
+      jest.spyOn(userUsecases, 'getAvatarUrl').mockResolvedValue(avatarUrl);
+
+      const result = await service.getTeamMembers(v4());
+
+      expect(result).toEqual([
+        {
+          name: member1.name,
+          lastname: member1.lastname,
+          email: member1.email,
+          id: member1.id,
+          uuid: member1.uuid,
+          avatar: avatarUrl,
+        },
+        {
+          name: member2.name,
+          lastname: member2.lastname,
+          email: member2.email,
+          id: member2.id,
+          uuid: member2.uuid,
+          avatar: avatarUrl,
+        },
+      ]);
+    });
+
+    it('When members are not found, then it should return empty', async () => {
+      jest.spyOn(teamRepository, 'getTeamMembers').mockResolvedValue([]);
+
+      const result = await service.getTeamMembers(v4());
+
+      expect(result).toEqual([]);
     });
   });
 

--- a/src/modules/workspaces/workspaces.usecase.spec.ts
+++ b/src/modules/workspaces/workspaces.usecase.spec.ts
@@ -1355,6 +1355,67 @@ describe('WorkspacesUsecases', () => {
     });
   });
 
+  describe('deactivateWorkspaceUser', () => {
+    it('When user is not part of workspace, then it should throw', async () => {
+      const workspace = newWorkspace();
+
+      jest
+        .spyOn(workspaceRepository, 'findWorkspaceAndUser')
+        .mockResolvedValue({ workspace, workspaceUser: null });
+
+      await expect(
+        service.deactivateWorkspaceUser(newUser(), 'workspaceId', 'memberId'),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('When workspace is not valid, then it should throw', async () => {
+      jest
+        .spyOn(workspaceRepository, 'findWorkspaceAndUser')
+        .mockResolvedValue({ workspace: null, workspaceUser: null });
+
+      await expect(
+        service.deactivateWorkspaceUser(newUser(), 'workspaceId', 'memberId'),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('When user is owner of workspace, then it should throw', async () => {
+      const owner = newUser();
+      const workspace = newWorkspace({ owner });
+      const workspaceUser = newWorkspaceUser({
+        workspaceId: workspace.id,
+        memberId: owner.uuid,
+      });
+
+      jest
+        .spyOn(workspaceRepository, 'findWorkspaceAndUser')
+        .mockResolvedValue({ workspace, workspaceUser });
+
+      await expect(
+        service.deactivateWorkspaceUser(owner, 'workspaceId', 'memberId'),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('When user is valid, then it is deactivated', async () => {
+      const member = newUser();
+      const workspace = newWorkspace();
+      const workspaceUser = newWorkspaceUser({
+        workspaceId: workspace.id,
+        memberId: member.uuid,
+      });
+
+      jest
+        .spyOn(workspaceRepository, 'findWorkspaceAndUser')
+        .mockResolvedValue({ workspace, workspaceUser });
+
+      await service.deactivateWorkspaceUser(member, 'workspaceId', 'memberId');
+
+      expect(workspaceRepository.deactivateWorkspaceUser).toHaveBeenCalledWith(
+        member.uuid,
+        workspace.id,
+      );
+    });
+  });
+
   describe('teams', () => {
     describe('createTeam', () => {
       it('When workspace is not found, then fail', async () => {

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -21,6 +21,7 @@ import { WorkspaceTeam } from '../src/modules/workspaces/domains/workspace-team.
 import { WorkspaceTeamUser } from '../src/modules/workspaces/domains/workspace-team-user.domain';
 import { WorkspaceUser } from '../src/modules/workspaces/domains/workspace-user.domain';
 import { WorkspaceInvite } from '../src/modules/workspaces/domains/workspace-invite.domain';
+import { UserAttributes } from '../src/modules/user/user.attributes';
 
 export const constants = {
   BUCKET_ID_LENGTH: 24,
@@ -138,10 +139,12 @@ export const newFile = (params?: NewFilesParams): File => {
   return file;
 };
 
-export const newUser = (): User => {
+export const newUser = (params?: {
+  attributes?: Partial<UserAttributes>;
+}): User => {
   const randomEmail = randomDataGenerator.email();
 
-  return User.build({
+  const user = User.build({
     id: randomDataGenerator.natural(),
     userId: '',
     name: 'John',
@@ -170,6 +173,13 @@ export const newUser = (): User => {
     avatar: null,
     lastPasswordChangedAt: new Date(),
   });
+
+  params?.attributes &&
+    Object.keys(params.attributes).forEach((key) => {
+      user[key] = params.attributes[key];
+    });
+
+  return user;
 };
 
 export const publicUser = (): User => {


### PR DESCRIPTION
This PR allows workspace users to get other members details and workspace owners to deactivate other users in the workspace.

It also fixes the endpoint to get the members of a team.