### PR TITLE
feat: modified workspace creation flow

### DIFF
--- a/src/modules/gateway/dto/initialize-workspace.dto.ts
+++ b/src/modules/gateway/dto/initialize-workspace.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsNotEmpty, IsNumber } from 'class-validator';
+import { IsNotEmpty, IsNumber, IsOptional } from 'class-validator';
 
 export class InitializeWorkspaceDto {
   @ApiProperty({
@@ -8,6 +8,13 @@ export class InitializeWorkspaceDto {
   })
   @IsNotEmpty()
   ownerId: string;
+
+  @ApiProperty({
+    example: 'Address from billing',
+    description: 'Address of the workspace',
+  })
+  @IsOptional()
+  address?: string;
 
   @ApiProperty({
     example: '312321312',

--- a/src/modules/gateway/gateway.usecase.ts
+++ b/src/modules/gateway/gateway.usecase.ts
@@ -7,7 +7,10 @@ export class GatewayUseCases {
   constructor(private workspaceUseCases: WorkspacesUsecases) {}
 
   async initializeWorkspace(initializeWorkspaceDto: InitializeWorkspaceDto) {
-    const { ownerId, maxSpaceBytes } = initializeWorkspaceDto;
-    return this.workspaceUseCases.initiateWorkspace(ownerId, maxSpaceBytes);
+    const { ownerId, maxSpaceBytes, address } = initializeWorkspaceDto;
+
+    return this.workspaceUseCases.initiateWorkspace(ownerId, maxSpaceBytes, {
+      address,
+    });
   }
 }

--- a/src/modules/workspaces/dto/setup-workspace.dto.ts
+++ b/src/modules/workspaces/dto/setup-workspace.dto.ts
@@ -8,8 +8,8 @@ export class SetupWorkspaceDto {
     example: 'My workspace',
     description: 'Name of the workspace to be created',
   })
-  @IsNotEmpty()
-  name: Workspace['name'];
+  @IsOptional()
+  name?: Workspace['name'];
 
   @ApiProperty({
     example: 'Address',

--- a/src/modules/workspaces/workspaces.controller.spec.ts
+++ b/src/modules/workspaces/workspaces.controller.spec.ts
@@ -76,12 +76,16 @@ describe('Workspace Controller', () => {
         attributes: { deactivated: false },
       });
 
-      workspacesUsecases.getAvailableWorkspaces.mockResolvedValueOnce([
-        { workspace, workspaceUser },
-      ]);
+      workspacesUsecases.getAvailableWorkspaces.mockResolvedValueOnce({
+        availableWorkspaces: [{ workspace, workspaceUser }],
+        pendingWorkspaces: [],
+      });
       await expect(
         workspacesController.getAvailableWorkspaces(user),
-      ).resolves.toEqual([{ workspace, workspaceUser }]);
+      ).resolves.toEqual({
+        availableWorkspaces: [{ workspace, workspaceUser }],
+        pendingWorkspaces: [],
+      });
     });
   });
 

--- a/src/modules/workspaces/workspaces.usecase.ts
+++ b/src/modules/workspaces/workspaces.usecase.ts
@@ -46,6 +46,7 @@ export class WorkspacesUsecases {
   async initiateWorkspace(
     ownerId: UserAttributes['uuid'],
     maxSpaceBytes: number,
+    workspaceData: { address?: string },
   ) {
     const owner = await this.userRepository.findByUuid(ownerId);
 
@@ -87,7 +88,8 @@ export class WorkspacesUsecases {
     const newWorkspace = Workspace.build({
       id: workspaceId,
       ownerId: owner.uuid,
-      name: '',
+      name: 'My Workspace',
+      address: workspaceData?.address,
       defaultTeamId: newDefaultTeam.id,
       workspaceUserId: workspaceUser.uuid,
       setupCompleted: false,
@@ -173,17 +175,19 @@ export class WorkspacesUsecases {
       throw new InternalServerErrorException(finalMessage);
     }
 
+    const workspaceUpdatedInfo: Partial<WorkspaceAttributes> = {
+      name: setupWorkspaceDto.name ?? workspace.name,
+      setupCompleted: true,
+      address: setupWorkspaceDto.address ?? workspace.address,
+      description: setupWorkspaceDto.description ?? workspace.description,
+    };
+
     await this.workspaceRepository.updateBy(
       {
         ownerId: user.uuid,
         id: workspace.id,
       },
-      {
-        name: setupWorkspaceDto.name,
-        setupCompleted: true,
-        address: setupWorkspaceDto.address,
-        description: setupWorkspaceDto.description,
-      },
+      workspaceUpdatedInfo,
     );
   }
 
@@ -485,14 +489,18 @@ export class WorkspacesUsecases {
   }
 
   async getAvailableWorkspaces(user: User) {
-    const availablesWorkspaces =
-      await this.workspaceRepository.findUserAvailableWorkspaces(user.uuid);
+    const [availablesWorkspaces, ownerPendingWorkspaces] = await Promise.all([
+      await this.workspaceRepository.findUserAvailableWorkspaces(user.uuid),
+      await this.getWorkspacesPendingToBeSetup(user),
+    ]);
 
-    return availablesWorkspaces.filter(
-      (workspaceData) =>
-        workspaceData.workspace.isWorkspaceReady() &&
-        !workspaceData.workspaceUser.deactivated,
-    );
+    return {
+      availableWorkspaces: availablesWorkspaces.filter(
+        ({ workspace, workspaceUser }) =>
+          workspace.isWorkspaceReady() && !workspaceUser.deactivated,
+      ),
+      pendingWorkspaces: ownerPendingWorkspaces,
+    };
   }
 
   async getWorkspacesPendingToBeSetup(user: User) {


### PR DESCRIPTION
We need to modify the flow of the workspaces creation. Name and address are now going to be generated with the billing address from Stripe. 

This PR makes optional those fields in the setupWorkspace function. Now we only need the owner's encrypted mnemonic to set up their user on the first access to the workspaces and mark the workspace as ready.