### PR TITLE
[_] feat: workspaces enable endpoints to retrieve invitations

### DIFF
--- a/src/modules/user/pre-created-users.repository.ts
+++ b/src/modules/user/pre-created-users.repository.ts
@@ -4,6 +4,7 @@ import { InjectModel } from '@nestjs/sequelize';
 import { PreCreatedUserModel } from './pre-created-users.model';
 import { PreCreatedUserAttributes } from './pre-created-users.attributes';
 import { PreCreatedUser } from './pre-created-user.domain';
+import { Op } from 'sequelize';
 
 @Injectable()
 export class SequelizePreCreatedUsersRepository {
@@ -15,6 +16,16 @@ export class SequelizePreCreatedUsersRepository {
   async findById(id: number): Promise<PreCreatedUser | null> {
     const user = await this.modelUser.findByPk(id);
     return user ? this.toDomain(user) : null;
+  }
+
+  async findByUuids(
+    uuids: PreCreatedUserAttributes['uuid'][],
+  ): Promise<PreCreatedUser[]> {
+    const preCreatedUsers = await this.modelUser.findAll({
+      where: { uuid: { [Op.in]: uuids } },
+    });
+
+    return preCreatedUsers.map((user) => this.toDomain(user));
   }
 
   async create(

--- a/src/modules/user/user.usecase.ts
+++ b/src/modules/user/user.usecase.ts
@@ -163,6 +163,13 @@ export class UserUseCases {
   findByUuids(uuids: User['uuid'][]): Promise<User[]> {
     return this.userRepository.findByUuids(uuids);
   }
+
+  findPreCreatedUsersByUuids(
+    uuids: PreCreatedUser['uuid'][],
+  ): Promise<PreCreatedUser[]> {
+    return this.preCreatedUserRepository.findByUuids(uuids);
+  }
+
   findById(id: User['id']): Promise<User | null> {
     return this.userRepository.findById(id);
   }

--- a/src/modules/workspaces/dto/workspace-invitations-pagination.dto.ts
+++ b/src/modules/workspaces/dto/workspace-invitations-pagination.dto.ts
@@ -1,0 +1,28 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import { IsInt, Min, Max } from 'class-validator';
+
+export class WorkspaceInvitationsPagination {
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(25)
+  @ApiProperty({
+    example: 1,
+    description: 'Number of items to request',
+    required: true,
+    type: Number,
+  })
+  limit: number;
+
+  @Type(() => Number)
+  @IsInt()
+  @Min(0)
+  @ApiProperty({
+    example: 0,
+    description: 'Number of items to skip',
+    required: true,
+    type: Number,
+  })
+  offset: number;
+}

--- a/src/modules/workspaces/repositories/workspaces.repository.ts
+++ b/src/modules/workspaces/repositories/workspaces.repository.ts
@@ -67,8 +67,14 @@ export class SequelizeWorkspaceRepository {
 
   async findInvitesBy(
     where: Partial<WorkspaceInvite>,
+    limit?: number,
+    offset?: number,
   ): Promise<WorkspaceInvite[]> {
-    const invites = await this.modelWorkspaceInvite.findAll({ where });
+    const invites = await this.modelWorkspaceInvite.findAll({
+      where,
+      limit,
+      offset,
+    });
 
     return invites.map((invite) => WorkspaceInvite.build(invite));
   }

--- a/src/modules/workspaces/workspaces.controller.spec.ts
+++ b/src/modules/workspaces/workspaces.controller.spec.ts
@@ -90,6 +90,71 @@ describe('Workspace Controller', () => {
     });
   });
 
+  describe('GET /:workspaceId/invitations', () => {
+    it('When workspace invites are requested, then it should return successfully', async () => {
+      const user = newUser();
+      const anotherUser = newUser();
+      const workspace = newWorkspace();
+
+      const invites = [
+        newWorkspaceInvite({ invitedUser: user.uuid }),
+        newWorkspaceInvite({ invitedUser: anotherUser.uuid }),
+      ];
+
+      workspacesUsecases.getWorkspacePendingInvitations.mockResolvedValueOnce([
+        {
+          ...invites[0],
+          user: { ...user },
+          isGuessInvite: false,
+        },
+        {
+          ...invites[1],
+          user: { ...anotherUser },
+          isGuessInvite: false,
+        },
+      ]);
+
+      await expect(
+        workspacesController.getWorkspacePendingInvitations(
+          { limit: 10, offset: 0 },
+          workspace.id,
+        ),
+      ).resolves.toEqual([
+        {
+          ...invites[0],
+          user: { ...user },
+          isGuessInvite: false,
+        },
+        {
+          ...invites[1],
+          user: { ...anotherUser },
+          isGuessInvite: false,
+        },
+      ]);
+    });
+  });
+
+  describe('GET /invitations', () => {
+    it('When user invites are requested, then it should return successfully', async () => {
+      const user = newUser();
+      const workspace = newWorkspace();
+      const invite = newWorkspaceInvite({
+        invitedUser: user.uuid,
+        workspaceId: workspace.id,
+      });
+      const limit = 10;
+      const offset = 0;
+
+      const invites = [{ ...invite, workspace: workspace.toJSON() }];
+
+      workspacesUsecases.getUserInvites.mockResolvedValueOnce(invites);
+
+      await expect(
+        workspacesController.getUserInvitations(user, { limit, offset }),
+      ).resolves.toEqual(invites);
+    });
+  });
+
   describe('PATCH /teams/:teamId', () => {
     it('When teamId is valid and update is successful, then resolve', async () => {
       await expect(

--- a/test/fixtures.spec.ts
+++ b/test/fixtures.spec.ts
@@ -511,4 +511,29 @@ describe('Testing fixtures tests', () => {
       expect(itemUser.context).toBe(customAttributes.context);
     });
   });
+
+  describe('PreCreatedUser fixture', () => {
+    it('When it generates a pre-created user, then the identifier should be a natural number', () => {
+      const user = fixtures.newPreCreatedUser();
+      expect(user.id).toBeGreaterThan(0);
+    });
+
+    it('When it generates a pre-created user, then the UUID should be random', () => {
+      const user = fixtures.newPreCreatedUser();
+      const otherUser = fixtures.newPreCreatedUser();
+
+      expect(user.uuid).not.toBe(otherUser.uuid);
+    });
+
+    it('When it generates a pre-created user, then the email should be random', () => {
+      const user = fixtures.newPreCreatedUser();
+      const otherUser = fixtures.newPreCreatedUser();
+      expect(user.email).not.toBe(otherUser.email);
+    });
+
+    it('When it generates a pre-created user, then the username should match the email', () => {
+      const user = fixtures.newPreCreatedUser();
+      expect(user.username).toBe(user.email);
+    });
+  });
 });

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -28,6 +28,7 @@ import {
 } from '../src/modules/workspaces/attributes/workspace-items-users.attributes';
 import { WorkspaceItemUser } from '../src/modules/workspaces/domains/workspace-item-user.domain';
 import { UserAttributes } from '../src/modules/user/user.attributes';
+import { PreCreatedUser } from '../src/modules/user/pre-created-user.domain';
 
 export const constants = {
   BUCKET_ID_LENGTH: 24,
@@ -186,6 +187,24 @@ export const newUser = (params?: {
     });
 
   return user;
+};
+
+export const newPreCreatedUser = (): PreCreatedUser => {
+  const randomEmail = randomDataGenerator.email();
+
+  return PreCreatedUser.build({
+    id: randomDataGenerator.natural(),
+    uuid: v4(),
+    email: randomEmail,
+    username: randomEmail,
+    password: '',
+    mnemonic: '',
+    hKey: '',
+    publicKey: '',
+    privateKey: '',
+    revocationKey: '',
+    encryptVersion: '03-aes',
+  });
 };
 
 export const publicUser = (): User => {


### PR DESCRIPTION
This PR exposes 2 new endpoints.

1. Get workspaces/invitations: retrieves current user invitations to any workspace.
2. Get workspaces/:workspaceId/invitations: retrieves pending invitations to the current workspace. Only the owner has access to this endpoint.