### PR TITLE
[_]: fix/sort-files-by-name-using-natural-order

### DIFF
--- a/migrations/20240515091404-create-custom-collation.js
+++ b/migrations/20240515091404-create-custom-collation.js
@@ -1,0 +1,16 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface) {
+    await queryInterface.sequelize.query(`
+      CREATE COLLATION IF NOT EXISTS custom_numeric (provider = icu, locale = 'en-u-kn-true');
+    `);
+  },
+
+  async down(queryInterface) {
+    await queryInterface.sequelize.query(`
+      DROP COLLATION IF EXISTS custom_numeric (provider = icu, locale = 'en-u-kn-true');
+    `);
+  },
+};

--- a/src/modules/file/file.repository.ts
+++ b/src/modules/file/file.repository.ts
@@ -225,7 +225,9 @@ export class SequelizeFileRepository implements FileRepository {
       structuredClone(order);
     const [, orderDirection] = order[plainNameIndex];
     newOrder[plainNameIndex] = Sequelize.literal(
-      `plain_name COLLATE "custom_numeric" ${orderDirection}`,
+      `plain_name COLLATE "custom_numeric" ${
+        orderDirection === 'ASC' ? 'ASC' : 'DESC'
+      }`,
     );
 
     return newOrder;

--- a/src/modules/folder/folder.controller.ts
+++ b/src/modules/folder/folder.controller.ts
@@ -274,7 +274,7 @@ export class FolderController {
       {
         parentUuid: folderUuid,
         deleted: false,
-        removed: false
+        removed: false,
       },
       {
         limit,

--- a/src/modules/folder/folder.controller.ts
+++ b/src/modules/folder/folder.controller.ts
@@ -190,6 +190,10 @@ export class FolderController {
       throw new BadRequestInvalidOffsetException();
     }
 
+    if (order && order !== 'ASC' && order !== 'DESC') {
+      throw new BadRequestException('Invalid order parameter');
+    }
+
     const files = await this.fileUseCases.getFiles(
       user.id,
       {


### PR DESCRIPTION
Changes: 
- Add a new custom collation `custom_numeric` (icu, locale = en-u-kn-true)
- Use the new collation to sort files by name in the well-known 'natural order'

With these changes, a files list ordered like this in ascendant order by name:
- Article 1
- Article 10
- Article 2

Is going to be ordered like this: 
- Article 1
- Article 2
- Article 10

