### PR TITLE
[PB: 2077] Allow owner to edit and add an avatar to workspace

### DIFF
--- a/migrations/20240510110825-add-avatar-field-into-workspaces-table.js
+++ b/migrations/20240510110825-add-avatar-field-into-workspaces-table.js
@@ -1,0 +1,18 @@
+'use strict';
+
+const tableName = 'workspaces';
+const newColumn = 'avatar';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.addColumn(tableName, newColumn, {
+      type: Sequelize.STRING,
+      allowNull: true,
+    });
+  },
+
+  async down(queryInterface) {
+    await queryInterface.removeColumn(tableName, newColumn);
+  },
+};

--- a/package.json
+++ b/package.json
@@ -98,6 +98,7 @@
     "@types/hapi__joi": "^17.1.13",
     "@types/jest": "29.5.8",
     "@types/jsonwebtoken": "9.0.2",
+    "@types/multer": "^1.4.11",
     "@types/node": "^20.9.0",
     "@types/sequelize": "^4.28.18",
     "@types/supertest": "^2.0.16",

--- a/src/externals/avatar/avatar.service.ts
+++ b/src/externals/avatar/avatar.service.ts
@@ -1,13 +1,21 @@
 import { Injectable } from '@nestjs/common';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
-import { GetObjectCommand, S3 } from '@aws-sdk/client-s3';
-
+import {
+  GetObjectCommand,
+  ObjectCannedACL,
+  S3Client,
+  PutObjectCommand,
+  DeleteObjectCommand,
+} from '@aws-sdk/client-s3';
+import { Express } from 'express';
 import { User } from '../../modules/user/user.domain';
+import { Workspace } from '../../modules/workspaces/domains/workspaces.domain';
+import { v4 } from 'uuid';
 
 @Injectable()
 export class AvatarService {
-  async getDownloadUrl(avatar: User['avatar']): Promise<string> {
-    const s3 = new S3({
+  AvatarS3Instance(): S3Client {
+    return new S3Client({
       endpoint: process.env.AVATAR_ENDPOINT,
       region: process.env.AVATAR_REGION,
       credentials: {
@@ -16,12 +24,17 @@ export class AvatarService {
       },
       forcePathStyle: process.env.AVATAR_FORCE_PATH_STYLE === 'true',
     });
+  }
 
+  async getDownloadUrl(
+    avatarKey: User['avatar'] | Workspace['avatar'],
+  ): Promise<string> {
+    const s3Client = this.AvatarS3Instance();
     const url = await getSignedUrl(
-      s3,
+      s3Client,
       new GetObjectCommand({
         Bucket: process.env.AVATAR_BUCKET,
-        Key: avatar,
+        Key: avatarKey,
       }),
       {
         expiresIn: 24 * 3600,
@@ -34,5 +47,32 @@ export class AvatarService {
     } else {
       return url;
     }
+  }
+
+  async uploadAvatar(file: Express.Multer.File): Promise<string> {
+    const s3Client = this.AvatarS3Instance();
+    const bucket = process.env.AVATAR_BUCKET;
+    const keyObject = v4();
+
+    const putObjectInput = {
+      Bucket: bucket,
+      Key: keyObject,
+      Body: file.buffer,
+      ACL: ObjectCannedACL.public_read,
+      ContentType: file.mimetype,
+    };
+
+    const putObjectCommand = new PutObjectCommand(putObjectInput);
+    await s3Client.send(putObjectCommand);
+    return keyObject;
+  }
+
+  async deleteAvatar(avatarKey: User['avatar'] | Workspace['avatar']) {
+    const s3Client = this.AvatarS3Instance();
+    const deleteObjectCommand = new DeleteObjectCommand({
+      Bucket: process.env.AVATAR_BUCKET,
+      Key: avatarKey,
+    });
+    await s3Client.send(deleteObjectCommand);
   }
 }

--- a/src/modules/workspaces/attributes/workspace.attributes.ts
+++ b/src/modules/workspaces/attributes/workspace.attributes.ts
@@ -4,6 +4,7 @@ export interface WorkspaceAttributes {
   address?: string;
   name: string;
   description?: string;
+  avatar: string;
   defaultTeamId: string;
   workspaceUserId: string;
   setupCompleted: boolean;

--- a/src/modules/workspaces/domains/workspaces.domain.ts
+++ b/src/modules/workspaces/domains/workspaces.domain.ts
@@ -8,6 +8,7 @@ export class Workspace implements WorkspaceAttributes {
   address?: string;
   name: string;
   description?: string;
+  avatar: string;
   defaultTeamId: string;
   workspaceUserId: string;
   setupCompleted: boolean;
@@ -23,6 +24,7 @@ export class Workspace implements WorkspaceAttributes {
     defaultTeamId,
     workspaceUserId,
     setupCompleted,
+    avatar,
     createdAt,
     updatedAt,
   }: WorkspaceAttributes) {
@@ -30,6 +32,7 @@ export class Workspace implements WorkspaceAttributes {
     this.ownerId = ownerId;
     this.address = address;
     this.name = name;
+    this.avatar = avatar;
     this.description = description;
     this.defaultTeamId = defaultTeamId;
     this.workspaceUserId = workspaceUserId;
@@ -62,6 +65,7 @@ export class Workspace implements WorkspaceAttributes {
       name: this.name,
       description: this.description,
       defaultTeamId: this.defaultTeamId,
+      avatar: this.avatar,
       workspaceUserId: this.workspaceUserId,
       createdAt: this.createdAt,
       updatedAt: this.updatedAt,

--- a/src/modules/workspaces/models/workspace.model.ts
+++ b/src/modules/workspaces/models/workspace.model.ts
@@ -7,6 +7,7 @@ import {
   ForeignKey,
   BelongsTo,
   HasMany,
+  AllowNull,
 } from 'sequelize-typescript';
 import { UserModel } from '../../user/user.model';
 import { WorkspaceUserModel } from './workspace-users.model';
@@ -45,6 +46,10 @@ export class WorkspaceModel extends Model implements WorkspaceAttributes {
 
   @Column(DataType.BOOLEAN)
   setupCompleted: boolean;
+
+  @AllowNull
+  @Column(DataType.STRING)
+  avatar: string;
 
   @ForeignKey(() => WorkspaceTeamModel)
   @Column(DataType.UUID)

--- a/src/modules/workspaces/workspaces.controller.ts
+++ b/src/modules/workspaces/workspaces.controller.ts
@@ -3,11 +3,16 @@ import {
   Body,
   Controller,
   Delete,
+  FileTypeValidator,
   Get,
+  MaxFileSizeValidator,
   Param,
+  ParseFilePipe,
   Patch,
   Post,
+  UploadedFile,
   UseGuards,
+  UseInterceptors,
 } from '@nestjs/common';
 import {
   ApiBearerAuth,
@@ -37,6 +42,8 @@ import { SetupWorkspaceDto } from './dto/setup-workspace.dto';
 import { AcceptWorkspaceInviteDto } from './dto/accept-workspace-invite.dto';
 import { ValidateUUIDPipe } from './pipes/validate-uuid.pipe';
 import { WorkspaceInviteAttributes } from './attributes/workspace-invite.attribute';
+import { FileInterceptor } from '@nestjs/platform-express';
+import { Express } from 'express';
 
 @ApiTags('Workspaces')
 @Controller('workspaces')
@@ -235,6 +242,46 @@ export class WorkspacesController {
       workspaceId,
       setupWorkspaceDto,
     );
+  }
+
+  @Post('/:workspaceId/avatar')
+  @ApiBearerAuth()
+  @ApiParam({ name: 'workspaceId', type: String, required: true })
+  @ApiOkResponse({
+    description: 'Avatar added to the workspace',
+  })
+  @WorkspaceRequiredAccess(AccessContext.WORKSPACE, WorkspaceRole.OWNER)
+  @UseGuards(WorkspaceGuard)
+  @UseInterceptors(FileInterceptor('file'))
+  async uploadAvatar(
+    @UploadedFile(
+      new ParseFilePipe({
+        validators: [
+          new MaxFileSizeValidator({ maxSize: 1000 * 1000 * 5 }),
+          new FileTypeValidator({ fileType: 'image/*' }),
+        ],
+      }),
+    )
+    file: Express.Multer.File,
+    @Param('workspaceId', ValidateUUIDPipe)
+    workspaceId: WorkspaceAttributes['id'],
+  ) {
+    return this.workspaceUseCases.upsertAvatar(workspaceId, file);
+  }
+
+  @Delete('/:workspaceId/avatar')
+  @ApiBearerAuth()
+  @ApiParam({ name: 'workspaceId', type: String, required: true })
+  @ApiOkResponse({
+    description: 'Avatar deleted from the workspace',
+  })
+  @WorkspaceRequiredAccess(AccessContext.WORKSPACE, WorkspaceRole.OWNER)
+  @UseGuards(WorkspaceGuard)
+  async deleteAvatar(
+    @Param('workspaceId', ValidateUUIDPipe)
+    workspaceId: WorkspaceAttributes['id'],
+  ) {
+    return this.workspaceUseCases.deleteAvatar(workspaceId);
   }
 
   @Get('/:workspaceId/members')

--- a/src/modules/workspaces/workspaces.module.ts
+++ b/src/modules/workspaces/workspaces.module.ts
@@ -14,6 +14,7 @@ import { WorkspaceTeamUserModel } from './models/workspace-team-users.model';
 import { WorkspaceGuard } from './guards/workspaces.guard';
 import { WorkspaceInviteModel } from './models/workspace-invite.model';
 import { MailerModule } from '../../externals/mailer/mailer.module';
+import { AvatarService } from '../../externals/avatar/avatar.service';
 
 @Module({
   imports: [
@@ -36,6 +37,7 @@ import { MailerModule } from '../../externals/mailer/mailer.module';
     SequelizeWorkspaceTeamRepository,
     SequelizeWorkspaceRepository,
     WorkspaceGuard,
+    AvatarService,
   ],
   exports: [WorkspacesUsecases, SequelizeModule],
 })

--- a/src/modules/workspaces/workspaces.usecase.ts
+++ b/src/modules/workspaces/workspaces.usecase.ts
@@ -31,6 +31,8 @@ import { WorkspaceRole } from './guards/workspace-required-access.decorator';
 import { SetupWorkspaceDto } from './dto/setup-workspace.dto';
 import { WorkspaceUser } from './domains/workspace-user.domain';
 import { WorkspaceUserMemberDto } from './dto/workspace-user-member.dto';
+import { AvatarService } from '../../externals/avatar/avatar.service';
+import { Express } from 'express';
 
 @Injectable()
 export class WorkspacesUsecases {
@@ -42,6 +44,7 @@ export class WorkspacesUsecases {
     private userUsecases: UserUseCases,
     private configService: ConfigService,
     private mailerService: MailerService,
+    private readonly avatarService: AvatarService,
   ) {}
 
   async initiateWorkspace(
@@ -91,6 +94,7 @@ export class WorkspacesUsecases {
       ownerId: owner.uuid,
       name: 'My Workspace',
       address: workspaceData?.address,
+      avatar: null,
       defaultTeamId: newDefaultTeam.id,
       workspaceUserId: workspaceUser.uuid,
       setupCompleted: false,
@@ -543,11 +547,25 @@ export class WorkspacesUsecases {
       await this.getWorkspacesPendingToBeSetup(user),
     ]);
 
+    const workspacesFiltered = availablesWorkspaces.filter(
+      ({ workspace, workspaceUser }) =>
+        workspace.isWorkspaceReady() && !workspaceUser.deactivated,
+    );
+
+    const workspacesWithAvatar = await Promise.all(
+      workspacesFiltered.map(async (item) => ({
+        workspaceUser: item.workspaceUser,
+        workspace: {
+          ...item.workspace,
+          avatar: item.workspace?.avatar
+            ? await this.getAvatarUrl(item.workspace.avatar)
+            : null,
+        },
+      })),
+    );
+
     return {
-      availableWorkspaces: availablesWorkspaces.filter(
-        ({ workspace, workspaceUser }) =>
-          workspace.isWorkspaceReady() && !workspaceUser.deactivated,
-      ),
+      availableWorkspaces: workspacesWithAvatar,
       pendingWorkspaces: ownerPendingWorkspaces,
     };
   }
@@ -833,5 +851,77 @@ export class WorkspacesUsecases {
     teamUser: WorkspaceTeamUser | null;
   }> {
     return this.teamRepository.getTeamUserAndTeamByTeamId(userUuid, teamId);
+  }
+
+  async getAvatarUrl(avatarKey: Workspace['avatar']): Promise<string> {
+    return await this.avatarService.getDownloadUrl(avatarKey);
+  }
+
+  async upsertAvatar(
+    workspaceId: Workspace['id'],
+    file: Express.Multer.File,
+  ): Promise<Error | { avatar: string }> {
+    const workspace = await this.workspaceRepository.findOne({
+      id: workspaceId,
+    });
+
+    if (!workspace) {
+      throw new BadRequestException('Not valid workspace');
+    }
+
+    if (workspace.avatar) {
+      try {
+        await this.avatarService.deleteAvatar(workspace.avatar);
+      } catch (err) {
+        Logger.error(
+          `[WORKSPACE/SET_AVATAR]Deleting the avatar in workspaceId: ${
+            workspace.id
+          } has failed. Error: ${(err as Error).message}`,
+        );
+        throw new Error('Deleting avatar to workspace has failed');
+      }
+    }
+
+    try {
+      const s3AvatarKey = await this.avatarService.uploadAvatar(file);
+      await this.workspaceRepository.updateById(workspace.id, {
+        avatar: s3AvatarKey,
+      });
+      const avatarUrl = await this.getAvatarUrl(s3AvatarKey);
+      return { avatar: avatarUrl };
+    } catch (err) {
+      Logger.error(
+        `[WORKSPACE/SET_AVATAR]Adding the avatar in workspaceId: ${
+          workspace.id
+        } has failed. Error: ${(err as Error).message}`,
+      );
+      throw new Error('Adding avatar to workspace has failed');
+    }
+  }
+
+  async deleteAvatar(workspaceId: Workspace['id']): Promise<Error | void> {
+    const workspace = await this.workspaceRepository.findOne({
+      id: workspaceId,
+    });
+
+    if (!workspace) {
+      throw new BadRequestException('Not valid workspace');
+    }
+
+    if (workspace.avatar) {
+      try {
+        await this.avatarService.deleteAvatar(workspace.avatar);
+        await this.workspaceRepository.updateById(workspace.id, {
+          avatar: null,
+        });
+      } catch (err) {
+        Logger.error(
+          `[WORKSPACE/DELETE_AVATAR]Deleting the avatar in workspaceId: ${
+            workspace.id
+          } has failed. Error: ${(err as Error).message}`,
+        );
+        throw new Error('Deleting avatar to workspace has failed');
+      }
+    }
   }
 }

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -254,12 +254,14 @@ export const newFeatureLimit = (bindTo?: {
 export const newWorkspace = (params?: {
   attributes?: Partial<Workspace>;
   owner?: User;
+  avatar?: Workspace['avatar'];
 }): Workspace => {
   const randomCreatedAt = randomDataGenerator.date();
 
   const workspace = Workspace.build({
     id: v4(),
     ownerId: params?.owner?.uuid || v4(),
+    avatar: params?.avatar || null,
     address: randomDataGenerator.address(),
     name: randomDataGenerator.company(),
     description: randomDataGenerator.sentence(),

--- a/yarn.lock
+++ b/yarn.lock
@@ -2699,6 +2699,13 @@
   resolved "https://registry.yarnpkg.com/@types/ms/-/ms-0.7.31.tgz#31b7ca6407128a3d2bbc27fe2d21b345397f6197"
   integrity sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA==
 
+"@types/multer@^1.4.11":
+  version "1.4.11"
+  resolved "https://registry.yarnpkg.com/@types/multer/-/multer-1.4.11.tgz#c70792670513b4af1159a2b60bf48cc932af55c5"
+  integrity sha512-svK240gr6LVWvv3YGyhLlA+6LRRWA4mnGIU7RcNmgjBYFl6665wcXrRfxGp5tEPVHUNm5FMcmq7too9bxCwX/w==
+  dependencies:
+    "@types/express" "*"
+
 "@types/node@*":
   version "17.0.40"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.40.tgz#76ee88ae03650de8064a6cf75b8d95f9f4a16090"


### PR DESCRIPTION
### Ticket
- https://inxt.atlassian.net/browse/PB-2077

### Update
- Migration to add `avatar` field in workspace
- Update `AvatarService` to configure `Put` & `Delete` options
- Endpoint to `Upload` and `Edit` avatar in workspace
```
URL: /workspaces/:id/avatar
Method: POST
Authorization: Bearer {token}
Body: {
    "file": FILE // Form-data
}
```
- Endpoint to `Delete` avatar in workspace
```
URL: /workspaces/:id/avatar
Method: PUT
Authorization: Bearer {token}
```