### PR TITLE
[PB-2144] feat: share files and folders with other members in the workspace

### DIFF
--- a/migrations/20240520034047-remove-sharing-shared-with-constraint.js
+++ b/migrations/20240520034047-remove-sharing-shared-with-constraint.js
@@ -1,0 +1,22 @@
+'use strict';
+
+module.exports = {
+  async up(queryInterface) {
+    await queryInterface.removeConstraint(
+      'sharings',
+      'sharings_shared_with_fkey',
+    );
+  },
+
+  async down(queryInterface) {
+    await queryInterface.addConstraint('sharings', {
+      type: 'FOREIGN KEY',
+      fields: ['shared_with'],
+      name: 'sharings_shared_with_fkey',
+      references: {
+        table: 'users',
+        field: 'uuid',
+      },
+    });
+  },
+};

--- a/migrations/20240520041258-add-shared-with-type-to-sharings.js
+++ b/migrations/20240520041258-add-shared-with-type-to-sharings.js
@@ -7,7 +7,7 @@ const newColumn = 'shared_with_type';
 module.exports = {
   async up(queryInterface, Sequelize) {
     await queryInterface.addColumn(tableName, newColumn, {
-      type: Sequelize.ENUM('individual', 'workspace_team', 'workspace_member'),
+      type: Sequelize.ENUM('individual', 'workspace_team'),
       defaultValue: 'individual',
       allowNull: false,
     });

--- a/migrations/20240520041258-add-shared-with-type-to-sharings.js
+++ b/migrations/20240520041258-add-shared-with-type-to-sharings.js
@@ -1,0 +1,19 @@
+'use strict';
+
+const tableName = 'sharings';
+const newColumn = 'shared_with_type';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.addColumn(tableName, newColumn, {
+      type: Sequelize.ENUM('individual', 'workspace_team', 'workspace_member'),
+      defaultValue: 'individual',
+      allowNull: false,
+    });
+  },
+
+  async down(queryInterface) {
+    await queryInterface.removeColumn(tableName, newColumn);
+  },
+};

--- a/src/modules/file/file.usecase.ts
+++ b/src/modules/file/file.usecase.ts
@@ -92,6 +92,7 @@ export class FileUseCases {
 
     const maybeAlreadyExistentFile = await this.fileRepository.findOneBy({
       name: newFileDto.name,
+      plainName: newFileDto.plainName,
       folderId: folder.id,
       type: newFileDto.type,
       userId: user.id,

--- a/src/modules/sharing/decorators/behalfUser.decorator.ts
+++ b/src/modules/sharing/decorators/behalfUser.decorator.ts
@@ -1,0 +1,9 @@
+import { createParamDecorator, ExecutionContext } from '@nestjs/common';
+
+export const BehalfUserDecorator = createParamDecorator(
+  async (_, ctx: ExecutionContext) => {
+    const req = ctx.switchToHttp().getRequest();
+
+    return req.behalfUser;
+  },
+);

--- a/src/modules/sharing/guards/sharing-permissions.decorator.ts
+++ b/src/modules/sharing/guards/sharing-permissions.decorator.ts
@@ -1,0 +1,11 @@
+import { SetMetadata } from '@nestjs/common';
+import { SharingActionName } from '../sharing.domain';
+
+export interface PermissionsOptions {
+  action: SharingActionName;
+}
+
+export const PermissionsMetadataName = 'permissionsData';
+
+export const RequiredSharingPermissions = (action: SharingActionName) =>
+  SetMetadata(PermissionsMetadataName, { action });

--- a/src/modules/sharing/guards/sharing-permissions.guard.spec.ts
+++ b/src/modules/sharing/guards/sharing-permissions.guard.spec.ts
@@ -27,9 +27,7 @@ import {
   newWorkspaceTeam,
   newWorkspaceTeamUser,
 } from '../../../../test/fixtures';
-import { WorkspaceTeam } from '../../workspaces/domains/workspace-team.domain';
 import { v4 } from 'uuid';
-import { Folder } from '../../folder/folder.domain';
 
 jest.mock('../../../lib/jwt');
 

--- a/src/modules/sharing/guards/sharing-permissions.guard.spec.ts
+++ b/src/modules/sharing/guards/sharing-permissions.guard.spec.ts
@@ -1,0 +1,194 @@
+import { DeepMocked, createMock } from '@golevelup/ts-jest';
+import {
+  ExecutionContext,
+  ForbiddenException,
+  NotFoundException,
+} from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { UserUseCases } from '../../user/user.usecase';
+import { SharingService } from '../../sharing/sharing.service';
+import { WorkspacesUsecases } from '../../workspaces/workspaces.usecase';
+import { SharingPermissionsGuard } from './sharing-permissions.guard';
+
+import { verifyWithDefaultSecret } from '../../../lib/jwt';
+import {
+  SharedWithType,
+  SharingActionName,
+} from '../../sharing/sharing.domain';
+import {
+  PermissionsMetadataName,
+  PermissionsOptions,
+} from './sharing-permissions.decorator';
+
+import {
+  newFolder,
+  newUser,
+  newWorkspace,
+  newWorkspaceTeam,
+} from '../../../../test/fixtures';
+
+jest.mock('../../../lib/jwt');
+
+const user = newUser();
+
+describe('SharingPermissionsGuard', () => {
+  let guard: SharingPermissionsGuard;
+  let reflector: DeepMocked<Reflector>;
+  let userUseCases: DeepMocked<UserUseCases>;
+  let sharingUseCases: DeepMocked<SharingService>;
+  let workspaceUseCases: DeepMocked<WorkspacesUsecases>;
+
+  beforeEach(async () => {
+    reflector = createMock<Reflector>();
+    userUseCases = createMock<UserUseCases>();
+    sharingUseCases = createMock<SharingService>();
+    workspaceUseCases = createMock<WorkspacesUsecases>();
+    guard = new SharingPermissionsGuard(
+      reflector,
+      userUseCases,
+      sharingUseCases,
+      workspaceUseCases,
+    );
+  });
+
+  it('Guard should be defined', () => {
+    expect(guard).toBeDefined();
+  });
+
+  it('When user is not part of the request, it should deny access', async () => {
+    const context = createMockExecutionContext({});
+
+    await expect(guard.canActivate(context)).resolves.toBe(false);
+  });
+
+  it('When resources token is invalid, it should throw', async () => {
+    mockMetadata(reflector, { action: SharingActionName.UploadFile });
+
+    const context = createMockExecutionContext({
+      user,
+      headers: { 'internxt-resources-token': 'invalid-token' },
+    });
+    (verifyWithDefaultSecret as jest.Mock).mockImplementation(
+      () => 'invalid-decoded',
+    );
+
+    await expect(guard.canActivate(context)).rejects.toThrow(
+      ForbiddenException,
+    );
+  });
+
+  it('When workspace and team permissions are valid, it should allow allow', async () => {
+    const workspace = newWorkspace();
+    const team = newWorkspaceTeam();
+    const folder = newFolder();
+    mockMetadata(reflector, { action: SharingActionName.UploadFile });
+
+    const context = createMockExecutionContext({
+      user,
+      headers: { 'internxt-resources-token': 'valid-token' },
+    });
+
+    (verifyWithDefaultSecret as jest.Mock).mockImplementation(() => ({
+      workspace: { workspaceId: workspace.id, teamId: team.id },
+      sharedRootFolderId: folder.uuid,
+      sharedWithType: SharedWithType.WorkspaceTeam,
+      owner: { uuid: user.uuid },
+    }));
+
+    jest
+      .spyOn(guard, 'isTeamMemberAbleToPerformAction')
+      .mockResolvedValue(true);
+    jest.spyOn(userUseCases, 'findByUuid').mockResolvedValue(user);
+
+    await expect(guard.canActivate(context)).resolves.toBe(true);
+  });
+
+  it('When user is not part of the team, it should deny access', async () => {
+    const workspace = newWorkspace();
+    const team = newWorkspaceTeam();
+    const folder = newFolder();
+    mockMetadata(reflector, { action: SharingActionName.UploadFile });
+
+    const context = createMockExecutionContext({
+      user,
+      headers: { 'internxt-resources-token': 'valid-token' },
+    });
+
+    (verifyWithDefaultSecret as jest.Mock).mockImplementation(() => ({
+      workspace: { workspaceId: workspace.id, teamId: team.id },
+      sharedRootFolderId: folder.uuid,
+      sharedWithType: SharedWithType.WorkspaceTeam,
+    }));
+
+    jest
+      .spyOn(guard, 'isTeamMemberAbleToPerformAction')
+      .mockResolvedValue(false);
+
+    await expect(guard.canActivate(context)).resolves.toBe(false);
+  });
+
+  it('When resource owner is not found, it should throw', async () => {
+    const workspace = newWorkspace();
+    const team = newWorkspaceTeam();
+    const folder = newFolder();
+    mockMetadata(reflector, { action: SharingActionName.UploadFile });
+
+    const context = createMockExecutionContext({
+      user,
+      headers: { 'internxt-resources-token': 'valid-token' },
+    });
+
+    (verifyWithDefaultSecret as jest.Mock).mockImplementation(() => ({
+      workspace: { workspaceId: workspace.id, teamId: team.id },
+      sharedRootFolderId: folder.uuid,
+      sharedWithType: SharedWithType.WorkspaceTeam,
+      owner: { uuid: user.uuid },
+    }));
+
+    jest
+      .spyOn(guard, 'isTeamMemberAbleToPerformAction')
+      .mockResolvedValue(true);
+    jest.spyOn(userUseCases, 'findByUuid').mockResolvedValue(null);
+
+    await expect(guard.canActivate(context)).rejects.toThrow(NotFoundException);
+  });
+
+  it('When user has individual permissions, it should allow access', async () => {
+    const folder = newFolder();
+    mockMetadata(reflector, { action: SharingActionName.UploadFile });
+
+    const context = createMockExecutionContext({
+      user,
+      headers: { 'internxt-resources-token': 'valid-token' },
+    });
+
+    (verifyWithDefaultSecret as jest.Mock).mockImplementation(() => ({
+      sharedRootFolderId: folder.uuid,
+      sharedWithType: SharedWithType.WorkspaceTeam,
+      owner: { uuid: user.uuid },
+    }));
+
+    jest.spyOn(guard, 'isUserAbleToPerfomAction').mockResolvedValue(true);
+
+    await expect(guard.canActivate(context)).resolves.toBe(true);
+  });
+});
+
+const createMockExecutionContext = (requestData: any): ExecutionContext => {
+  return {
+    getHandler: () => ({
+      name: 'endPointHandler',
+    }),
+    switchToHttp: () => ({
+      getRequest: () => requestData,
+    }),
+  } as unknown as ExecutionContext;
+};
+
+const mockMetadata = (reflector: Reflector, metadata: PermissionsOptions) => {
+  jest.spyOn(reflector, 'get').mockImplementation((key) => {
+    if (key === PermissionsMetadataName) {
+      return metadata;
+    }
+  });
+};

--- a/src/modules/sharing/guards/sharing-permissions.guard.ts
+++ b/src/modules/sharing/guards/sharing-permissions.guard.ts
@@ -121,7 +121,7 @@ export class SharingPermissionsGuard implements CanActivate {
       this.workspaceUseCases.findUserInTeam(requester.uuid, teamId),
     ]);
 
-    return userIsAllowedToPerfomAction && !!isUserPartOfTeam;
+    return userIsAllowedToPerfomAction && !!isUserPartOfTeam?.teamUser;
   }
 
   async isUserAbleToPerfomAction(

--- a/src/modules/sharing/guards/sharing-permissions.guard.ts
+++ b/src/modules/sharing/guards/sharing-permissions.guard.ts
@@ -103,7 +103,7 @@ export class SharingPermissionsGuard implements CanActivate {
     action: SharingActionName,
   ) {
     const [userIsAllowedToPerfomAction, isUserPartOfTeam] = await Promise.all([
-      this.sharingUseCases.canPerfomActionInWorkspace(
+      this.sharingUseCases.canPerfomAction(
         requester.uuid,
         sharedRootFolderId,
         action,

--- a/src/modules/sharing/guards/sharing-permissions.guard.ts
+++ b/src/modules/sharing/guards/sharing-permissions.guard.ts
@@ -108,4 +108,20 @@ export class SharingPermissionsGuard implements CanActivate {
 
     return userIsAllowedToPerfomAction;
   }
+
+  async isIndividualUserAbleToPerfomAction(
+    requester: User,
+    sharedRootFolderId: Folder['uuid'],
+    action: SharingActionName,
+  ) {
+    const userIsAllowedToPerfomAction =
+      await this.sharingUseCases.canUserPerformActionInSharing(
+        requester.uuid,
+        sharedRootFolderId,
+        action,
+        SharedWithType.Individual,
+      );
+
+    return userIsAllowedToPerfomAction;
+  }
 }

--- a/src/modules/sharing/guards/sharing-permissions.guard.ts
+++ b/src/modules/sharing/guards/sharing-permissions.guard.ts
@@ -1,0 +1,111 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  ForbiddenException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { User } from '../../user/user.domain';
+import { UserUseCases } from '../../user/user.usecase';
+import { FolderAttributes } from '../../folder/folder.attributes';
+import { verifyWithDefaultSecret } from '../../../lib/jwt';
+import { SharingService } from '../../sharing/sharing.service';
+import {
+  SharedWithType,
+  SharingActionName,
+} from '../../sharing/sharing.domain';
+import {
+  PermissionsMetadataName,
+  PermissionsOptions,
+} from './sharing-permissions.decorator';
+import { Workspace } from '../../workspaces/domains/workspaces.domain';
+import { WorkspaceTeam } from '../../workspaces/domains/workspace-team.domain';
+import { Folder } from '../../folder/folder.domain';
+
+@Injectable()
+export class SharingPermissionsGuard implements CanActivate {
+  constructor(
+    private reflector: Reflector,
+    private userUseCases: UserUseCases,
+    private sharingUseCases: SharingService,
+  ) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const permissionsOptions: PermissionsOptions = this.reflector.get(
+      PermissionsMetadataName,
+      context.getHandler(),
+    );
+    const { action } = permissionsOptions;
+
+    const request = context.switchToHttp().getRequest();
+    const requester = request?.user as User;
+
+    if (!requester) {
+      return false;
+    }
+
+    const resourcesToken = request.headers['internxt-resources-token'];
+
+    if (!resourcesToken || typeof resourcesToken !== 'string') {
+      return true;
+    }
+
+    const decoded = verifyWithDefaultSecret(resourcesToken) as
+      | {
+          owner?: {
+            uuid?: User['uuid'];
+          };
+          sharedRootFolderId?: FolderAttributes['uuid'];
+          sharedWithType: SharedWithType;
+          workspace?: {
+            workspaceId: Workspace['id'];
+            teamId: WorkspaceTeam['id'];
+          };
+        }
+      | string;
+
+    if (typeof decoded === 'string') {
+      throw new ForbiddenException('Invalid token');
+    }
+
+    const userIsAllowedToPerfomAction =
+      await this.isWorkspaceMemberAbleToPerformAction(
+        requester,
+        decoded.sharedRootFolderId,
+        action,
+      );
+
+    if (!userIsAllowedToPerfomAction) {
+      return false;
+    }
+
+    const resourceOwner = await this.userUseCases.findByUuid(
+      decoded.owner.uuid,
+    );
+
+    if (!resourceOwner) {
+      throw new NotFoundException('Resource owner not found');
+    }
+
+    request.behalfUser = resourceOwner;
+
+    return true;
+  }
+
+  async isWorkspaceMemberAbleToPerformAction(
+    requester: User,
+    sharedRootFolderId: Folder['uuid'],
+    action: SharingActionName,
+  ) {
+    const userIsAllowedToPerfomAction =
+      await this.sharingUseCases.canUserPerformActionInSharing(
+        requester.uuid,
+        sharedRootFolderId,
+        action,
+        SharedWithType.WorkspaceMember,
+      );
+
+    return userIsAllowedToPerfomAction;
+  }
+}

--- a/src/modules/sharing/models/index.ts
+++ b/src/modules/sharing/models/index.ts
@@ -137,11 +137,7 @@ export class SharingModel extends Model implements SharingAttributes {
   @AllowNull(false)
   @Default(SharedWithType.Individual)
   @Column(
-    DataType.ENUM(
-      SharedWithType.Individual,
-      SharedWithType.WorkspaceMember,
-      SharedWithType.WorkspaceTeam,
-    ),
+    DataType.ENUM(SharedWithType.Individual, SharedWithType.WorkspaceTeam),
   )
   sharedWithType: SharedWithType;
 

--- a/src/modules/sharing/models/index.ts
+++ b/src/modules/sharing/models/index.ts
@@ -3,7 +3,9 @@ import {
   BelongsTo,
   Column,
   DataType,
+  Default,
   ForeignKey,
+  HasMany,
   Model,
   PrimaryKey,
   Table,
@@ -11,13 +13,40 @@ import {
 import {
   PermissionAttributes,
   RoleAttributes,
+  SharedWithType,
   SharingAttributes,
   SharingInviteAttributes,
+  SharingActionName,
 } from '../sharing.domain';
 import { UserModel } from '../../user/user.model';
 import { FolderModel } from '../../folder/folder.model';
 import { FileModel } from '../../../modules/file/file.model';
 import { PreCreatedUserModel } from '../../../modules/user/pre-created-users.model';
+import { WorkspaceTeamModel } from '../../workspaces/models/workspace-team.model';
+import { SharingRolesModel } from './sharing-roles.model';
+
+@Table({
+  underscored: true,
+  timestamps: true,
+  tableName: 'roles',
+})
+export class RoleModel extends Model implements RoleAttributes {
+  @PrimaryKey
+  @Column({ type: DataType.UUID, defaultValue: DataType.UUIDV4 })
+  id: string;
+
+  @Column
+  name: string;
+
+  @HasMany(() => SharingRolesModel, 'roleId')
+  role: SharingRolesModel;
+
+  @Column
+  createdAt: Date;
+
+  @Column
+  updatedAt: Date;
+}
 
 @Table({
   underscored: true,
@@ -33,28 +62,14 @@ export class PermissionModel extends Model implements PermissionAttributes {
   @Column({ type: DataType.UUID })
   roleId: string;
 
-  @Column
-  name: string;
+  @BelongsTo(() => RoleModel, {
+    foreignKey: 'roleId',
+    targetKey: 'id',
+  })
+  role: RoleModel;
 
   @Column
-  createdAt: Date;
-
-  @Column
-  updatedAt: Date;
-}
-
-@Table({
-  underscored: true,
-  timestamps: true,
-  tableName: 'roles',
-})
-export class RoleModel extends Model implements RoleAttributes {
-  @PrimaryKey
-  @Column({ type: DataType.UUID, defaultValue: DataType.UUIDV4 })
-  id: string;
-
-  @Column
-  name: string;
+  name: SharingActionName;
 
   @Column
   createdAt: Date;
@@ -102,7 +117,6 @@ export class SharingModel extends Model implements SharingAttributes {
   })
   owner: UserModel;
 
-  @ForeignKey(() => UserModel)
   @Column(DataType.UUIDV4)
   sharedWith: SharingAttributes['sharedWith'];
 
@@ -112,6 +126,24 @@ export class SharingModel extends Model implements SharingAttributes {
     as: 'invited',
   })
   sharedWithUser: UserModel;
+
+  @BelongsTo(() => WorkspaceTeamModel, {
+    foreignKey: 'shared_with',
+    targetKey: 'id',
+    as: 'sharedWithTeam',
+  })
+  sharedWithTeam: WorkspaceTeamModel;
+
+  @AllowNull(false)
+  @Default(SharedWithType.Individual)
+  @Column(
+    DataType.ENUM(
+      SharedWithType.Individual,
+      SharedWithType.WorkspaceMember,
+      SharedWithType.WorkspaceTeam,
+    ),
+  )
+  sharedWithType: SharedWithType;
 
   @Column({ type: DataType.STRING, allowNull: true, defaultValue: null })
   encryptedCode: SharingAttributes['encryptedCode'];

--- a/src/modules/sharing/sharing.controller.spec.ts
+++ b/src/modules/sharing/sharing.controller.spec.ts
@@ -4,15 +4,20 @@ import { UuidDto } from '../../common/uuid.dto';
 import { createMock } from '@golevelup/ts-jest';
 import { Sharing } from './sharing.domain';
 import { newSharing } from '../../../test/fixtures';
+import { WorkspacesUsecases } from '../workspaces/workspaces.usecase';
 
 describe('SharingController', () => {
   let controller: SharingController;
   let sharingService: SharingService;
+  let workspaceUseCases: WorkspacesUsecases;
+
   let sharing: Sharing;
 
   beforeEach(async () => {
     sharingService = createMock<SharingService>();
-    controller = new SharingController(sharingService);
+    workspaceUseCases = createMock<WorkspacesUsecases>();
+
+    controller = new SharingController(sharingService, workspaceUseCases);
     sharing = newSharing({});
   });
 

--- a/src/modules/sharing/sharing.controller.spec.ts
+++ b/src/modules/sharing/sharing.controller.spec.ts
@@ -4,20 +4,17 @@ import { UuidDto } from '../../common/uuid.dto';
 import { createMock } from '@golevelup/ts-jest';
 import { Sharing } from './sharing.domain';
 import { newSharing } from '../../../test/fixtures';
-import { WorkspacesUsecases } from '../workspaces/workspaces.usecase';
 
 describe('SharingController', () => {
   let controller: SharingController;
   let sharingService: SharingService;
-  let workspaceUseCases: WorkspacesUsecases;
 
   let sharing: Sharing;
 
   beforeEach(async () => {
     sharingService = createMock<SharingService>();
-    workspaceUseCases = createMock<WorkspacesUsecases>();
 
-    controller = new SharingController(sharingService, workspaceUseCases);
+    controller = new SharingController(sharingService);
     sharing = newSharing({});
   });
 

--- a/src/modules/sharing/sharing.domain.ts
+++ b/src/modules/sharing/sharing.domain.ts
@@ -23,7 +23,6 @@ export enum SharingItemType {
 export enum SharedWithType {
   Individual = 'individual',
   WorkspaceTeam = 'workspace_team',
-  WorkspaceMember = 'workspace_member',
 }
 
 // This should match with the permissions table for the given user role.

--- a/src/modules/sharing/sharing.domain.ts
+++ b/src/modules/sharing/sharing.domain.ts
@@ -25,7 +25,6 @@ export enum SharedWithType {
   WorkspaceTeam = 'workspace_team',
 }
 
-// This should match with the permissions table for the given user role.
 export enum SharingActionName {
   UploadFile = 'UPLOAD_FILE',
   RenameItems = 'RENAME_ITEMS',

--- a/src/modules/sharing/sharing.module.ts
+++ b/src/modules/sharing/sharing.module.ts
@@ -22,6 +22,7 @@ import { PaymentsService } from '../../externals/payments/payments.service';
 import { AppSumoModule } from '../app-sumo/app-sumo.module';
 import { FeatureLimitModule } from '../feature-limit/feature-limit.module';
 import { HttpClientModule } from '../../externals/http/http.module';
+import { WorkspacesModule } from '../workspaces/workspaces.module';
 
 @Module({
   imports: [
@@ -35,6 +36,7 @@ import { HttpClientModule } from '../../externals/http/http.module';
     ]),
     forwardRef(() => FileModule),
     forwardRef(() => FolderModule),
+    forwardRef(() => WorkspacesModule),
     BridgeModule,
     AppSumoModule,
     forwardRef(() => UserModule),

--- a/src/modules/sharing/sharing.repository.spec.ts
+++ b/src/modules/sharing/sharing.repository.spec.ts
@@ -1,0 +1,106 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getModelToken } from '@nestjs/sequelize';
+import { createMock } from '@golevelup/ts-jest';
+import { SharingModel } from './models';
+import { Sharing } from './sharing.domain';
+import { SequelizeSharingRepository } from './sharing.repository';
+import { newFile, newSharing, newUser } from '../../../test/fixtures';
+import { User } from '../user/user.domain';
+import { v4 } from 'uuid';
+
+describe('SharingRepository', () => {
+  let repository: SequelizeSharingRepository;
+  let sharingModel: typeof SharingModel;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [SequelizeSharingRepository],
+    })
+      .useMocker(() => createMock())
+      .compile();
+
+    repository = module.get<SequelizeSharingRepository>(
+      SequelizeSharingRepository,
+    );
+    sharingModel = module.get<typeof SharingModel>(getModelToken(SharingModel));
+  });
+
+  describe('findFilesByOwnerAndSharedWithTeamInworkspace', () => {
+    it('When files are searched by owner and team in workspace, then it should return the shared files', async () => {
+      const teamId = v4();
+      const ownerId = v4();
+      const offset = 0;
+      const limit = 10;
+      const orderBy = [['name', 'ASC']] as any;
+      const sharing = newSharing();
+      const file = newFile();
+      const creator = newUser();
+
+      const mockSharing = {
+        get: jest.fn().mockReturnValue({
+          ...sharing,
+          file: {
+            ...file,
+            workspaceUser: {
+              creator,
+            },
+          },
+        }),
+      };
+
+      jest
+        .spyOn(sharingModel, 'findAll')
+        .mockResolvedValue([mockSharing] as any);
+
+      const result =
+        await repository.findFilesByOwnerAndSharedWithTeamInworkspace(
+          teamId,
+          ownerId,
+          offset,
+          limit,
+          orderBy,
+        );
+
+      expect(result[0]).toBeInstanceOf(Sharing);
+      expect(result[0].file.user).toBeInstanceOf(User);
+      expect(result[0].file).toMatchObject({ ...file, user: creator });
+    });
+  });
+
+  describe('findFoldersByOwnerAndSharedWithTeamInworkspace', () => {
+    it('When folders are searched by owner and team in workspace, then it should return the shared folders', async () => {
+      const teamId = v4();
+      const ownerId = v4();
+      const offset = 0;
+      const limit = 10;
+      const orderBy = [['name', 'ASC']] as any;
+
+      const mockSharing = {
+        get: jest.fn().mockReturnValue({
+          ...newSharing(),
+          folder: {
+            workspaceUser: {
+              creator: newUser(),
+            },
+          },
+        }),
+      };
+
+      jest
+        .spyOn(sharingModel, 'findAll')
+        .mockResolvedValue([mockSharing] as any);
+
+      const result =
+        await repository.findFoldersByOwnerAndSharedWithTeamInworkspace(
+          teamId,
+          ownerId,
+          offset,
+          limit,
+          orderBy,
+        );
+
+      expect(result[0]).toBeInstanceOf(Sharing);
+      expect(result[0].folder.user).toBeInstanceOf(User);
+    });
+  });
+});

--- a/src/modules/sharing/sharing.service.spec.ts
+++ b/src/modules/sharing/sharing.service.spec.ts
@@ -22,7 +22,7 @@ import { FolderUseCases } from '../folder/folder.usecase';
 import { FileUseCases } from '../file/file.usecase';
 import { UserUseCases } from '../user/user.usecase';
 import { SequelizeUserReferralsRepository } from '../user/user-referrals.repository';
-import { SharingType } from './sharing.domain';
+import { SharedWithType, SharingType } from './sharing.domain';
 import { FileStatus } from '../file/file.domain';
 import { SharingNotFoundException } from './exception/sharing-not-found.exception';
 
@@ -395,6 +395,7 @@ describe('Sharing Use Cases', () => {
         owner.uuid,
         itemIds,
         itemType,
+        SharedWithType.Individual,
       );
     });
   });

--- a/src/modules/sharing/sharing.service.spec.ts
+++ b/src/modules/sharing/sharing.service.spec.ts
@@ -636,7 +636,7 @@ describe('Sharing Use Cases', () => {
               sharingId: sharing.id,
               encryptionKey: sharing.encryptionKey,
               dateShared: sharing.createdAt,
-              sharedWithMe: user.uuid !== sharing.folder.user.uuid,
+              sharedWithMe: true,
             }),
           ]),
           files: [],

--- a/src/modules/sharing/sharing.service.spec.ts
+++ b/src/modules/sharing/sharing.service.spec.ts
@@ -11,6 +11,7 @@ import { v4 } from 'uuid';
 import {
   newFile,
   newFolder,
+  newPermission,
   newSharing,
   newSharingRole,
   newUser,
@@ -22,7 +23,11 @@ import { FolderUseCases } from '../folder/folder.usecase';
 import { FileUseCases } from '../file/file.usecase';
 import { UserUseCases } from '../user/user.usecase';
 import { SequelizeUserReferralsRepository } from '../user/user-referrals.repository';
-import { SharedWithType, SharingType } from './sharing.domain';
+import {
+  SharedWithType,
+  SharingActionName,
+  SharingType,
+} from './sharing.domain';
 import { FileStatus } from '../file/file.domain';
 import { SharingNotFoundException } from './exception/sharing-not-found.exception';
 
@@ -400,6 +405,300 @@ describe('Sharing Use Cases', () => {
     });
   });
 
+  describe('canPerfomAction', () => {
+    const sharedWith = v4();
+    const resourceId = v4();
+    const action = SharingActionName.UploadFile;
+    const sharedWithType = SharedWithType.Individual;
+
+    it('When the permission exists, then it should return true', async () => {
+      const permissions = [
+        newPermission(),
+        newPermission({ name: SharingActionName.UploadFile }),
+      ];
+      jest
+        .spyOn(sharingRepository, 'findPermissionsInSharing')
+        .mockResolvedValue(permissions);
+
+      const result = await sharingService.canPerfomAction(
+        sharedWith,
+        resourceId,
+        action,
+        sharedWithType,
+      );
+
+      expect(result).toBe(true);
+    });
+
+    it('When the permission does not match, then it should return false', async () => {
+      const permissions = [
+        newPermission({ name: SharingActionName.UploadFile }),
+      ];
+      jest
+        .spyOn(sharingRepository, 'findPermissionsInSharing')
+        .mockResolvedValue(permissions);
+
+      const result = await sharingService.canPerfomAction(
+        sharedWith,
+        resourceId,
+        SharingActionName.RenameItems,
+        sharedWithType,
+      );
+
+      expect(result).toBe(false);
+    });
+
+    it('When there are no permissions, then it should return false', async () => {
+      const permissions = [];
+      jest
+        .spyOn(sharingRepository, 'findPermissionsInSharing')
+        .mockResolvedValue(permissions);
+
+      const result = await sharingService.canPerfomAction(
+        sharedWith,
+        resourceId,
+        action,
+        sharedWithType,
+      );
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('createSharing', () => {
+    const sharing = newSharing();
+    const roleId = v4();
+
+    it('When creating a sharing, then it should return the created sharing', async () => {
+      const createdSharing = newSharing();
+
+      jest
+        .spyOn(sharingRepository, 'createSharing')
+        .mockResolvedValue(createdSharing);
+
+      const result = await sharingService.createSharing(sharing, roleId);
+
+      expect(result).toEqual(createdSharing);
+      expect(sharingRepository.createSharing).toHaveBeenCalledWith(sharing);
+      expect(sharingRepository.createSharingRole).toHaveBeenCalledWith({
+        roleId,
+        sharingId: createdSharing.id,
+        createdAt: expect.any(Date),
+        updatedAt: expect.any(Date),
+      });
+    });
+  });
+
+  describe('getSharedFilesInWorkspaces', () => {
+    const user = newUser();
+    const teamId = v4();
+    const offset = 0;
+    const limit = 10;
+    const order: [string, string][] = [['name', 'asc']];
+
+    it('When files are shared with the team, then it should return the files', async () => {
+      const sharing = newSharing();
+      sharing.file = newFile({ owner: newUser() });
+
+      const filesWithSharedInfo = [sharing];
+
+      jest
+        .spyOn(
+          sharingRepository,
+          'findFilesByOwnerAndSharedWithTeamInworkspace',
+        )
+        .mockResolvedValue(filesWithSharedInfo);
+
+      jest
+        .spyOn(fileUsecases, 'decrypFileName')
+        .mockReturnValue({ plainName: 'DecryptedFileName' });
+
+      jest.spyOn(usersUsecases, 'getAvatarUrl').mockResolvedValue('avatar-url');
+
+      const result = await sharingService.getSharedFilesInWorkspaces(
+        user,
+        teamId,
+        offset,
+        limit,
+        order,
+      );
+
+      expect(result).toEqual(
+        expect.objectContaining({
+          folders: [],
+          files: expect.arrayContaining([
+            expect.objectContaining({
+              plainName: sharing.file.plainName,
+              sharingId: sharing.id,
+              encryptionKey: sharing.encryptionKey,
+              dateShared: sharing.createdAt,
+            }),
+          ]),
+          credentials: {
+            networkPass: user.userId,
+            networkUser: user.bridgeUser,
+          },
+          token: '',
+          role: 'OWNER',
+        }),
+      );
+    });
+
+    it('When no files are shared with the team, then it should return nothing', async () => {
+      jest
+        .spyOn(
+          sharingRepository,
+          'findFilesByOwnerAndSharedWithTeamInworkspace',
+        )
+        .mockResolvedValue([]);
+
+      const result = await sharingService.getSharedFilesInWorkspaces(
+        user,
+        teamId,
+        offset,
+        limit,
+        order,
+      );
+
+      expect(result).toEqual({
+        folders: [],
+        files: [],
+        credentials: {
+          networkPass: user.userId,
+          networkUser: user.bridgeUser,
+        },
+        token: '',
+        role: 'OWNER',
+      });
+    });
+
+    it('When there is an error fetching shared files, then it should throw', async () => {
+      const error = new Error('Database error');
+
+      jest
+        .spyOn(
+          sharingRepository,
+          'findFilesByOwnerAndSharedWithTeamInworkspace',
+        )
+        .mockRejectedValue(error);
+
+      await expect(
+        sharingService.getSharedFilesInWorkspaces(
+          user,
+          teamId,
+          offset,
+          limit,
+          order,
+        ),
+      ).rejects.toThrow(error);
+    });
+  });
+
+  describe('getSharedFoldersInWorkspace', () => {
+    const user = newUser();
+    const teamId = v4();
+    const offset = 0;
+    const limit = 10;
+    const order: [string, string][] = [['name', 'asc']];
+
+    it('When folders are shared with the team, then it should return the folders', async () => {
+      const sharing = newSharing();
+      const folder = newFolder();
+      folder.user = newUser();
+      sharing.folder = folder;
+      const foldersWithSharedInfo = [sharing];
+
+      jest
+        .spyOn(
+          sharingRepository,
+          'findFoldersByOwnerAndSharedWithTeamInworkspace',
+        )
+        .mockResolvedValue(foldersWithSharedInfo);
+
+      jest
+        .spyOn(folderUseCases, 'decryptFolderName')
+        .mockReturnValue({ plainName: 'DecryptedFolderName' });
+
+      jest.spyOn(usersUsecases, 'getAvatarUrl').mockResolvedValue('avatar-url');
+
+      const result = await sharingService.getSharedFoldersInWorkspace(
+        user,
+        teamId,
+        offset,
+        limit,
+        order,
+      );
+
+      expect(result).toEqual(
+        expect.objectContaining({
+          folders: expect.arrayContaining([
+            expect.objectContaining({
+              sharingId: sharing.id,
+              encryptionKey: sharing.encryptionKey,
+              dateShared: sharing.createdAt,
+              sharedWithMe: user.uuid !== sharing.folder.user.uuid,
+            }),
+          ]),
+          files: [],
+          credentials: {
+            networkPass: user.userId,
+            networkUser: user.bridgeUser,
+          },
+          token: '',
+          role: 'OWNER',
+        }),
+      );
+    });
+
+    it('When no folders are shared with the team, then it should return an empty folders array', async () => {
+      jest
+        .spyOn(
+          sharingRepository,
+          'findFoldersByOwnerAndSharedWithTeamInworkspace',
+        )
+        .mockResolvedValue([]);
+
+      const result = await sharingService.getSharedFoldersInWorkspace(
+        user,
+        teamId,
+        offset,
+        limit,
+        order,
+      );
+
+      expect(result).toEqual({
+        folders: [],
+        files: [],
+        credentials: {
+          networkPass: user.userId,
+          networkUser: user.bridgeUser,
+        },
+        token: '',
+        role: 'OWNER',
+      });
+    });
+
+    it('When there is an error fetching shared folders, then it should throw an error', async () => {
+      const error = new Error('Database error');
+
+      jest
+        .spyOn(
+          sharingRepository,
+          'findFoldersByOwnerAndSharedWithTeamInworkspace',
+        )
+        .mockRejectedValue(error);
+
+      await expect(
+        sharingService.getSharedFoldersInWorkspace(
+          user,
+          teamId,
+          offset,
+          limit,
+          order,
+        ),
+      ).rejects.toThrow(error);
+    });
+  });
   describe('Access to public shared item info', () => {
     const owner = newUser();
     const otherUser = publicUser();

--- a/src/modules/sharing/sharing.service.ts
+++ b/src/modules/sharing/sharing.service.ts
@@ -2114,13 +2114,7 @@ export class SharingService {
       resourceId,
     );
 
-    for (const permission of permissions) {
-      if (permission.name === action) {
-        return true;
-      }
-    }
-
-    return false;
+    return permissions.some((p) => p.name === action);
   }
 
   async notifyUserSharingRoleUpdated(

--- a/src/modules/sharing/sharing.service.ts
+++ b/src/modules/sharing/sharing.service.ts
@@ -211,10 +211,19 @@ export class SharingService {
     private readonly userReferralsRepository: SequelizeUserReferralsRepository,
   ) {}
 
+  findSharingBy(where: Partial<Sharing>): Promise<Sharing | null> {
+    return this.sharingRepository.findOneSharingBy(where);
+  }
+
+  findSharingRoleBy(where: Partial<SharingRole>) {
+    return this.sharingRepository.findSharingRoleBy(where);
+  }
+
   async isItemBeingSharedAboveTheLimit(
     itemId: Sharing['itemId'],
     itemType: Sharing['itemType'],
     type: Sharing['type'],
+    sharedWithType = SharedWithType.Individual,
   ): Promise<boolean> {
     const [sharingsCountForThisItem, invitesCountForThisItem] =
       await Promise.all([
@@ -222,6 +231,7 @@ export class SharingService {
           itemId,
           itemType,
           type,
+          sharedWithType,
         }),
         this.sharingRepository.getInvitesCountBy({
           itemId,
@@ -865,6 +875,7 @@ export class SharingService {
       itemId: requestedFolderIsSharedRootFolder
         ? folderId
         : decoded.sharedRootFolderId,
+      sharedWithType: SharedWithType.Individual,
     });
 
     if (!sharing) {
@@ -907,6 +918,7 @@ export class SharingService {
       token: generateTokenWithPlainSecret(
         {
           sharedRootFolderId: sharing.itemId,
+          sharedWithType: SharedWithType.Individual,
           parentFolderId: parentFolder?.uuid || null,
           folder: {
             uuid: folder.uuid,
@@ -1027,6 +1039,7 @@ export class SharingService {
       itemId: requestedFolderIsSharedRootFolder
         ? folderId
         : decoded.sharedRootFolderId,
+      sharedWithType: SharedWithType.Individual,
     });
 
     if (!sharing) {
@@ -1066,6 +1079,7 @@ export class SharingService {
       token: generateTokenWithPlainSecret(
         {
           sharedRootFolderId: sharing.itemId,
+          sharedWithType: SharedWithType.Individual,
           parentFolderId: parentFolder?.uuid || null,
           folder: {
             uuid: folder.uuid,
@@ -1139,6 +1153,7 @@ export class SharingService {
         itemId: createInviteDto.itemId,
         itemType: createInviteDto.itemType,
         sharedWith: userJoining.uuid,
+        sharedWithType: SharedWithType.Individual,
       }),
     ]);
 
@@ -1161,7 +1176,9 @@ export class SharingService {
     const resourceIsOwnedByUser = item.isOwnedBy(user);
 
     if (!resourceIsOwnedByUser) {
-      throw new ForbiddenException();
+      throw new ForbiddenException(
+        'User does not have permission to share this item',
+      );
     }
 
     const expirationAt = new Date();
@@ -1328,6 +1345,7 @@ export class SharingService {
     itemType: Sharing['itemType'],
     itemId: Sharing['itemId'],
     type: Sharing['type'],
+    sharedWithType: SharedWithType = SharedWithType.Individual,
   ) {
     if (type === SharingType.Private) {
       await this.sharingRepository.deleteInvitesBy({
@@ -1340,6 +1358,7 @@ export class SharingService {
       itemId,
       itemType,
       type,
+      sharedWithType,
     });
   }
 
@@ -1442,6 +1461,7 @@ export class SharingService {
     user: User,
     itemId: Sharing['itemId'],
     itemType: Sharing['itemType'],
+    sharedWithType: SharedWithType = SharedWithType.Individual,
   ) {
     const sharing = await this.sharingRepository.findOneSharing({
       itemId,
@@ -1463,6 +1483,7 @@ export class SharingService {
     await this.sharingRepository.deleteSharingsBy({
       itemId,
       itemType,
+      sharedWithType,
     });
   }
 
@@ -1470,12 +1491,14 @@ export class SharingService {
     user: User,
     itemIds: Sharing['itemId'][],
     itemType: Sharing['itemType'],
+    sharedWithType: SharedWithType = SharedWithType.Individual,
   ) {
     await this.sharingRepository.bulkDeleteInvites(itemIds, itemType);
     await this.sharingRepository.bulkDeleteSharings(
       user.uuid,
       itemIds,
       itemType,
+      sharedWithType,
     );
   }
 
@@ -1736,6 +1759,114 @@ export class SharingService {
           encryptionKey: fileWithSharedInfo.encryptionKey,
           dateShared: fileWithSharedInfo.createdAt,
           sharedWithMe: user.uuid !== fileWithSharedInfo.file.user.uuid,
+          user: {
+            ...fileWithSharedInfo.file.user,
+            avatar: avatar
+              ? await this.usersUsecases.getAvatarUrl(avatar)
+              : null,
+          },
+          credentials: {
+            networkPass: fileWithSharedInfo.file.user.userId,
+            networkUser: fileWithSharedInfo.file.user.bridgeUser,
+          },
+        };
+      }),
+    )) as FileWithSharedInfo[];
+
+    return {
+      folders: [],
+      files: files,
+      credentials: {
+        networkPass: user.userId,
+        networkUser: user.bridgeUser,
+      },
+      token: '',
+      role: 'OWNER',
+    };
+  }
+
+  async getSharedFoldersInWorkspace(
+    user: User,
+    teamId: Sharing['sharedWith'],
+    offset: number,
+    limit: number,
+    order: [string, string][],
+  ): Promise<GetItemsReponse> {
+    const foldersWithSharedInfo =
+      await this.sharingRepository.findFoldersByOwnerAndSharedWithTeamInworkspace(
+        teamId,
+        user.uuid,
+        offset,
+        limit,
+        order,
+      );
+
+    const folders = (await Promise.all(
+      foldersWithSharedInfo.map(async (folderWithSharedInfo) => {
+        const avatar = folderWithSharedInfo.folder.user.avatar;
+        return {
+          ...folderWithSharedInfo.folder,
+          plainName:
+            folderWithSharedInfo.folder.plainName ||
+            this.folderUsecases.decryptFolderName(folderWithSharedInfo.folder)
+              .plainName,
+          sharingId: folderWithSharedInfo.id,
+          encryptionKey: folderWithSharedInfo.encryptionKey,
+          dateShared: folderWithSharedInfo.createdAt,
+          sharedWithMe: user.uuid !== folderWithSharedInfo.folder.user.uuid,
+          user: {
+            ...folderWithSharedInfo.folder.user,
+            avatar: avatar
+              ? await this.usersUsecases.getAvatarUrl(avatar)
+              : null,
+          },
+          credentials: {
+            networkPass: folderWithSharedInfo.folder.user.userId,
+            networkUser: folderWithSharedInfo.folder.user.bridgeUser,
+          },
+        };
+      }),
+    )) as FolderWithSharedInfo[];
+
+    return {
+      folders: folders,
+      files: [],
+      credentials: {
+        networkPass: user.userId,
+        networkUser: user.bridgeUser,
+      },
+      token: '',
+      role: 'OWNER',
+    };
+  }
+
+  async getSharedFilesInWorkspaces(
+    user: User,
+    teamId: Sharing['sharedWith'],
+    offset: number,
+    limit: number,
+    order: [string, string][],
+  ): Promise<GetItemsReponse> {
+    const filesWithSharedInfo =
+      await this.sharingRepository.findFilesByOwnerAndSharedWithTeamInworkspace(
+        teamId,
+        user.uuid,
+        offset,
+        limit,
+        order,
+      );
+
+    const files = (await Promise.all(
+      filesWithSharedInfo.map(async (fileWithSharedInfo) => {
+        const avatar = fileWithSharedInfo.file.user.avatar;
+        return {
+          ...fileWithSharedInfo.file,
+          plainName:
+            fileWithSharedInfo.file.plainName ||
+            this.fileUsecases.decrypFileName(fileWithSharedInfo.file).plainName,
+          sharingId: fileWithSharedInfo.id,
+          encryptionKey: fileWithSharedInfo.encryptionKey,
+          dateShared: fileWithSharedInfo.createdAt,
           user: {
             ...fileWithSharedInfo.file.user,
             avatar: avatar
@@ -2067,6 +2198,7 @@ export class SharingService {
         itemType,
         type: SharingType.Public,
         ownerId: user.uuid,
+        sharedWithType: SharedWithType.Individual,
       });
     }
   }
@@ -2075,6 +2207,7 @@ export class SharingService {
     user: User,
     itemId: Sharing['itemId'],
     itemType: Sharing['itemType'],
+    sharedWithType = SharedWithType.Individual,
   ): Promise<Sharing> {
     const [publicSharing, privateSharing] = await Promise.all([
       this.sharingRepository.findOneByOwnerOrSharedWithItem(
@@ -2088,6 +2221,7 @@ export class SharingService {
         itemId,
         itemType,
         SharingType.Private,
+        sharedWithType,
       ),
     ]);
 
@@ -2114,5 +2248,21 @@ export class SharingService {
     }
 
     return this.folderUsecases.getFolderSizeByUuid(sharing.itemId);
+  }
+
+  async createSharing(
+    sharing: Sharing,
+    roleId: SharingRole['roleId'],
+  ): Promise<Sharing> {
+    const createdSharing = await this.sharingRepository.createSharing(sharing);
+
+    await this.sharingRepository.createSharingRole({
+      roleId,
+      sharingId: createdSharing.id,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    return createdSharing;
   }
 }

--- a/src/modules/sharing/sharing.service.ts
+++ b/src/modules/sharing/sharing.service.ts
@@ -1803,7 +1803,7 @@ export class SharingService {
 
     const folders = (await Promise.all(
       foldersWithSharedInfo.map(async (folderWithSharedInfo) => {
-        const avatar = folderWithSharedInfo.folder.user.avatar;
+        const avatar = folderWithSharedInfo.folder?.user?.avatar;
         return {
           ...folderWithSharedInfo.folder,
           plainName:
@@ -1854,7 +1854,7 @@ export class SharingService {
 
     const files = (await Promise.all(
       filesWithSharedInfo.map(async (fileWithSharedInfo) => {
-        const avatar = fileWithSharedInfo.file.user.avatar;
+        const avatar = fileWithSharedInfo.file?.user?.avatar;
         return {
           ...fileWithSharedInfo.file,
           plainName:
@@ -2102,7 +2102,7 @@ export class SharingService {
     }
   }
 
-  async canPerfomActionInWorkspace(
+  async canPerfomAction(
     sharedWith: Sharing['sharedWith'],
     resourceId: Sharing['itemId'],
     action: SharingActionName,

--- a/src/modules/sharing/sharing.service.ts
+++ b/src/modules/sharing/sharing.service.ts
@@ -1820,10 +1820,6 @@ export class SharingService {
               ? await this.usersUsecases.getAvatarUrl(avatar)
               : null,
           },
-          credentials: {
-            networkPass: folderWithSharedInfo.folder.user.userId,
-            networkUser: folderWithSharedInfo.folder.user.bridgeUser,
-          },
         };
       }),
     )) as FolderWithSharedInfo[];
@@ -1872,10 +1868,6 @@ export class SharingService {
             avatar: avatar
               ? await this.usersUsecases.getAvatarUrl(avatar)
               : null,
-          },
-          credentials: {
-            networkPass: fileWithSharedInfo.file.user.userId,
-            networkUser: fileWithSharedInfo.file.user.bridgeUser,
           },
         };
       }),
@@ -2110,18 +2102,17 @@ export class SharingService {
     }
   }
 
-  async canUserPerformActionInSharing(
+  async canPerfomActionInWorkspace(
     sharedWith: Sharing['sharedWith'],
     resourceId: Sharing['itemId'],
     action: SharingActionName,
     sharedWithType = SharedWithType.Individual,
   ) {
-    const permissions =
-      await this.sharingRepository.findUserPermissionsInSharing(
-        sharedWith,
-        sharedWithType,
-        resourceId,
-      );
+    const permissions = await this.sharingRepository.findPermissionsInSharing(
+      sharedWith,
+      sharedWithType,
+      resourceId,
+    );
 
     for (const permission of permissions) {
       if (permission.name === action) {

--- a/src/modules/sharing/sharing.service.ts
+++ b/src/modules/sharing/sharing.service.ts
@@ -13,7 +13,9 @@ import { v4, validate as validateUuid } from 'uuid';
 import {
   Item,
   Role,
+  SharedWithType,
   Sharing,
+  SharingActionName,
   SharingAttributes,
   SharingInvite,
   SharingRole,
@@ -1975,6 +1977,28 @@ export class SharingService {
           // no op
         });
     }
+  }
+
+  async canUserPerformActionInSharing(
+    sharedWith: Sharing['sharedWith'],
+    resourceId: Sharing['itemId'],
+    action: SharingActionName,
+    sharedWithType = SharedWithType.Individual,
+  ) {
+    const permissions =
+      await this.sharingRepository.findUserPermissionsInSharing(
+        sharedWith,
+        sharedWithType,
+        resourceId,
+      );
+
+    for (const permission of permissions) {
+      if (permission.name === action) {
+        return true;
+      }
+    }
+
+    return false;
   }
 
   async notifyUserSharingRoleUpdated(

--- a/src/modules/user/user.usecase.ts
+++ b/src/modules/user/user.usecase.ts
@@ -170,6 +170,10 @@ export class UserUseCases {
     return this.preCreatedUserRepository.findByUuids(uuids);
   }
 
+  findByUuid(uuid: User['uuid']): Promise<User> {
+    return this.userRepository.findByUuid(uuid);
+  }
+
   findById(id: User['id']): Promise<User | null> {
     return this.userRepository.findById(id);
   }

--- a/src/modules/workspaces/dto/get-items-inside-shared-folder.dto.ts
+++ b/src/modules/workspaces/dto/get-items-inside-shared-folder.dto.ts
@@ -1,0 +1,42 @@
+import { IsOptional, IsString, IsInt, Min, Max } from 'class-validator';
+import { Type } from 'class-transformer';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { OrderBy } from '../../../common/order.type';
+
+export class getItemsInsideSharedFolderDtoQuery {
+  @ApiPropertyOptional({
+    description: 'Order by',
+    example: 'name:asc',
+  })
+  @IsOptional()
+  @IsString()
+  orderBy?: OrderBy;
+
+  @ApiPropertyOptional({
+    description: 'Token',
+  })
+  @IsOptional()
+  @IsString()
+  token?: string;
+
+  @ApiPropertyOptional({
+    description: 'Page number',
+    default: 0,
+  })
+  @IsOptional()
+  @IsInt()
+  @Min(0)
+  @Type(() => Number)
+  page?: number = 0;
+
+  @ApiPropertyOptional({
+    description: 'Items per page',
+    default: 50,
+  })
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  @Max(50)
+  @Type(() => Number)
+  perPage?: number = 50;
+}

--- a/src/modules/workspaces/dto/get-items-inside-shared-folder.dto.ts
+++ b/src/modules/workspaces/dto/get-items-inside-shared-folder.dto.ts
@@ -3,7 +3,7 @@ import { Type } from 'class-transformer';
 import { ApiPropertyOptional } from '@nestjs/swagger';
 import { OrderBy } from '../../../common/order.type';
 
-export class getItemsInsideSharedFolderDtoQuery {
+export class GetItemsInsideSharedFolderDtoQuery {
   @ApiPropertyOptional({
     description: 'Order by',
     example: 'name:asc',

--- a/src/modules/workspaces/dto/share-item-with-member.dto.ts
+++ b/src/modules/workspaces/dto/share-item-with-member.dto.ts
@@ -1,0 +1,35 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty } from 'class-validator';
+import { WorkspaceItemUser } from '../domains/workspace-item-user.domain';
+import { User } from '../../user/user.domain';
+
+export class ShareItemWithMemberDto {
+  @ApiProperty({
+    example: 'uuid',
+    description: 'The uuid of the item to share',
+  })
+  @IsNotEmpty()
+  itemId: WorkspaceItemUser['itemId'];
+
+  @ApiProperty({
+    example: 'file | folder',
+    description: 'The type of the resource to share',
+  })
+  @IsNotEmpty()
+  itemType: WorkspaceItemUser['itemType'];
+
+  @ApiProperty({
+    example: '84f47d08-dc7c-43dc-b27c-bec4edaa9598',
+    description:
+      "Workspace's member id (user uuid) you want to share this file with",
+  })
+  @IsNotEmpty()
+  sharedWith: User['uuid'];
+
+  @ApiProperty({
+    example: '84f47d08-dc7c-43dc-b27c-bec4edaa9598',
+    description: 'Role of the team regarding the item.',
+  })
+  @IsNotEmpty()
+  roleId: string;
+}

--- a/src/modules/workspaces/dto/share-item-with-team.dto.ts
+++ b/src/modules/workspaces/dto/share-item-with-team.dto.ts
@@ -1,9 +1,9 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { IsNotEmpty } from 'class-validator';
 import { WorkspaceItemUser } from '../domains/workspace-item-user.domain';
-import { User } from '../../user/user.domain';
+import { WorkspaceTeam } from '../domains/workspace-team.domain';
 
-export class ShareItemWithMemberDto {
+export class ShareItemWithTeamDto {
   @ApiProperty({
     example: 'uuid',
     description: 'The uuid of the item to share',
@@ -20,11 +20,10 @@ export class ShareItemWithMemberDto {
 
   @ApiProperty({
     example: '84f47d08-dc7c-43dc-b27c-bec4edaa9598',
-    description:
-      "Workspace's member id (user uuid) you want to share this file with",
+    description: "Workspace's team id you want to share this file with",
   })
   @IsNotEmpty()
-  sharedWith: User['uuid'];
+  sharedWith: WorkspaceTeam['id'];
 
   @ApiProperty({
     example: '84f47d08-dc7c-43dc-b27c-bec4edaa9598',

--- a/src/modules/workspaces/repositories/workspaces.repository.ts
+++ b/src/modules/workspaces/repositories/workspaces.repository.ts
@@ -285,8 +285,8 @@ export class SequelizeWorkspaceRepository {
     userUuid: string,
     workspaceId: string,
   ): Promise<{
-    workspace: Workspace | null;
-    workspaceUser: WorkspaceUser | null;
+    workspace?: Workspace | null;
+    workspaceUser?: WorkspaceUser | null;
   }> {
     const workspace = await this.modelWorkspace.findOne({
       where: { id: workspaceId },

--- a/src/modules/workspaces/workspaces.controller.spec.ts
+++ b/src/modules/workspaces/workspaces.controller.spec.ts
@@ -13,6 +13,8 @@ import {
 import { v4 } from 'uuid';
 import { WorkspaceUserMemberDto } from './dto/workspace-user-member.dto';
 import { SharingService } from '../sharing/sharing.service';
+import { CreateWorkspaceFolderDto } from './dto/create-workspace-folder.dto';
+import { WorkspaceItemType } from './attributes/workspace-items-users.attributes';
 
 describe('Workspace Controller', () => {
   let workspacesController: WorkspacesController;
@@ -482,6 +484,115 @@ describe('Workspace Controller', () => {
       await expect(
         workspacesController.deleteAvatar(workspace.id),
       ).resolves.toBeTruthy();
+    });
+  });
+
+  describe('GET /:workspaceId/teams/:teamId/shared/files', () => {
+    it('When shared files are requested, then it should call the service with the respective arguments', async () => {
+      const user = newUser();
+      const teamId = v4();
+      const orderBy = 'createdAt:ASC';
+      const page = 1;
+      const perPage = 50;
+      const order = [['createdAt', 'ASC']];
+
+      await workspacesController.getSharedFiles(
+        teamId,
+        user,
+        orderBy,
+        page,
+        perPage,
+      );
+
+      expect(sharingUseCases.getSharedFilesInWorkspaces).toHaveBeenCalledWith(
+        user,
+        teamId,
+        page,
+        perPage,
+        order,
+      );
+    });
+  });
+
+  describe('GET /:workspaceId/teams/:teamId/shared/folders', () => {
+    it('When shared folders are requested, then it should call the service with the respective arguments', async () => {
+      const user = newUser();
+      const teamId = v4();
+      const orderBy = 'createdAt:ASC';
+      const page = 1;
+      const perPage = 50;
+      const order = [['createdAt', 'ASC']];
+
+      await workspacesController.getSharedFolders(
+        teamId,
+        user,
+        orderBy,
+        page,
+        perPage,
+      );
+
+      expect(sharingUseCases.getSharedFoldersInWorkspace).toHaveBeenCalledWith(
+        user,
+        teamId,
+        page,
+        perPage,
+        order,
+      );
+    });
+  });
+
+  describe('GET /:workspaceId/teams/:teamId/shared/:sharedFolderId/files', () => {
+    it('When files inside a shared folder are requested, then it should call the service with the respective arguments', async () => {
+      const user = newUser();
+      const workspaceId = v4();
+      const teamId = v4();
+      const sharedFolderId = v4();
+      const orderBy = 'createdAt:ASC';
+      const token = 'token';
+      const page = 1;
+      const perPage = 50;
+      const order = [['createdAt', 'ASC']];
+
+      await workspacesController.getFilesInsideSharedFolder(
+        workspaceId,
+        teamId,
+        user,
+        sharedFolderId,
+        { token, page, perPage, orderBy },
+      );
+
+      expect(workspacesUsecases.getItemsInSharedFolder).toHaveBeenCalledWith(
+        workspaceId,
+        teamId,
+        user,
+        sharedFolderId,
+        WorkspaceItemType.File,
+        token,
+        { page, perPage, order },
+      );
+    });
+  });
+
+  describe('POST /:workspaceId/folders', () => {
+    it('When a folder is created successfully, then it should call the service with the respective arguments', async () => {
+      const user = newUser();
+      const workspaceId = v4();
+      const createFolderDto: CreateWorkspaceFolderDto = {
+        name: 'New Folder',
+        parentFolderUuid: v4(),
+      };
+
+      await workspacesController.createFolder(
+        workspaceId,
+        user,
+        createFolderDto,
+      );
+
+      expect(workspacesUsecases.createFolder).toHaveBeenCalledWith(
+        user,
+        workspaceId,
+        createFolderDto,
+      );
     });
   });
 });

--- a/src/modules/workspaces/workspaces.controller.spec.ts
+++ b/src/modules/workspaces/workspaces.controller.spec.ts
@@ -12,15 +12,21 @@ import {
 } from '../../../test/fixtures';
 import { v4 } from 'uuid';
 import { WorkspaceUserMemberDto } from './dto/workspace-user-member.dto';
+import { SharingService } from '../sharing/sharing.service';
 
 describe('Workspace Controller', () => {
   let workspacesController: WorkspacesController;
   let workspacesUsecases: DeepMocked<WorkspacesUsecases>;
+  let sharingUseCases: DeepMocked<SharingService>;
 
   beforeEach(async () => {
     workspacesUsecases = createMock<WorkspacesUsecases>();
+    sharingUseCases = createMock<SharingService>();
 
-    workspacesController = new WorkspacesController(workspacesUsecases);
+    workspacesController = new WorkspacesController(
+      workspacesUsecases,
+      sharingUseCases,
+    );
   });
 
   it('should be defined', () => {

--- a/src/modules/workspaces/workspaces.controller.ts
+++ b/src/modules/workspaces/workspaces.controller.ts
@@ -65,6 +65,7 @@ import { SharingPermissionsGuard } from '../sharing/guards/sharing-permissions.g
 import { RequiredSharingPermissions } from '../sharing/guards/sharing-permissions.decorator';
 import { SharingActionName } from '../sharing/sharing.domain';
 import { BehalfUserDecorator } from '../sharing/decorators/behalfUser.decorator';
+import { WorkspaceItemType } from './attributes/workspace-items-users.attributes';
 
 @ApiTags('Workspaces')
 @Controller('workspaces')
@@ -542,10 +543,11 @@ export class WorkspacesController {
       ? [orderBy.split(':') as [string, string]]
       : undefined;
 
-    return this.workspaceUseCases.getFoldersInSharedFolder(
+    return this.workspaceUseCases.getItemsInSharedFolder(
       workspaceId,
       user,
       sharedFolderId,
+      WorkspaceItemType.Folder,
       token,
       { page, perPage, order },
     );
@@ -571,10 +573,11 @@ export class WorkspacesController {
       ? [orderBy.split(':') as [string, string]]
       : undefined;
 
-    return this.workspaceUseCases.getFilesInSharedFolder(
+    return this.workspaceUseCases.getItemsInSharedFolder(
       workspaceId,
       user,
       sharedFolderId,
+      WorkspaceItemType.File,
       token,
       { page, perPage, order },
     );

--- a/src/modules/workspaces/workspaces.controller.ts
+++ b/src/modules/workspaces/workspaces.controller.ts
@@ -66,7 +66,7 @@ import { BehalfUserDecorator } from '../sharing/decorators/behalfUser.decorator'
 import { WorkspaceItemType } from './attributes/workspace-items-users.attributes';
 import { SharingService } from '../sharing/sharing.service';
 import { WorkspaceTeam } from './domains/workspace-team.domain';
-import { getItemsInsideSharedFolderDtoQuery } from './dto/get-items-inside-shared-folder.dto';
+import { GetItemsInsideSharedFolderDtoQuery } from './dto/get-items-inside-shared-folder.dto';
 import { WorkspaceUserAttributes } from './attributes/workspace-users.attributes';
 import { ChangeUserAssignedSpaceDto } from './dto/change-user-assigned-space.dto';
 
@@ -656,7 +656,7 @@ export class WorkspacesController {
     teamId: WorkspaceTeam['id'],
     @UserDecorator() user: User,
     @Param('sharedFolderId', ValidateUUIDPipe) sharedFolderId: Folder['uuid'],
-    @Query() queryDto: getItemsInsideSharedFolderDtoQuery,
+    @Query() queryDto: GetItemsInsideSharedFolderDtoQuery,
   ) {
     const { orderBy, token, page, perPage } = queryDto;
 
@@ -688,7 +688,7 @@ export class WorkspacesController {
     teamId: WorkspaceTeam['id'],
     @UserDecorator() user: User,
     @Param('sharedFolderId', ValidateUUIDPipe) sharedFolderId: Folder['uuid'],
-    @Query() queryDto: getItemsInsideSharedFolderDtoQuery,
+    @Query() queryDto: GetItemsInsideSharedFolderDtoQuery,
   ) {
     const { orderBy, token, page, perPage } = queryDto;
 

--- a/src/modules/workspaces/workspaces.controller.ts
+++ b/src/modules/workspaces/workspaces.controller.ts
@@ -3,7 +3,6 @@ import {
   Body,
   Controller,
   Delete,
-  ForbiddenException,
   Get,
   Param,
   Patch,
@@ -66,6 +65,7 @@ import { SharingActionName } from '../sharing/sharing.domain';
 import { BehalfUserDecorator } from '../sharing/decorators/behalfUser.decorator';
 import { WorkspaceItemType } from './attributes/workspace-items-users.attributes';
 import { SharingService } from '../sharing/sharing.service';
+import { WorkspaceTeam } from './domains/workspace-team.domain';
 
 @ApiTags('Workspaces')
 @Controller('workspaces')
@@ -525,7 +525,7 @@ export class WorkspacesController {
 
   @Get(':workspaceId/:teamId/shared/files')
   @ApiOperation({
-    summary: 'Get shared files',
+    summary: 'Get shared files with a team',
   })
   @UseGuards(WorkspaceGuard)
   @WorkspaceRequiredAccess(AccessContext.TEAM, WorkspaceRole.MEMBER)
@@ -552,7 +552,7 @@ export class WorkspacesController {
 
   @Get(':workspaceId/:teamId/shared/folders')
   @ApiOperation({
-    summary: 'Get shared folders',
+    summary: 'Get shared folders with a team',
   })
   @UseGuards(WorkspaceGuard)
   @WorkspaceRequiredAccess(AccessContext.TEAM, WorkspaceRole.MEMBER)
@@ -577,7 +577,7 @@ export class WorkspacesController {
     );
   }
 
-  @Get(':workspaceId/shared/:sharedFolderId/folders')
+  @Get(':workspaceId/:teamId/shared/:sharedFolderId/folders')
   @ApiOperation({
     summary: 'Get all folders inside a shared folder',
   })
@@ -586,6 +586,8 @@ export class WorkspacesController {
   async getFoldersInsideSharedFolder(
     @Param('workspaceId', ValidateUUIDPipe)
     workspaceId: WorkspaceAttributes['id'],
+    @Param('teamId', ValidateUUIDPipe)
+    teamId: WorkspaceTeam['id'],
     @UserDecorator() user: User,
     @Param('sharedFolderId', ValidateUUIDPipe) sharedFolderId: Folder['uuid'],
     @Query('orderBy') orderBy: OrderBy,
@@ -599,6 +601,7 @@ export class WorkspacesController {
 
     return this.workspaceUseCases.getItemsInSharedFolder(
       workspaceId,
+      teamId,
       user,
       sharedFolderId,
       WorkspaceItemType.Folder,
@@ -607,7 +610,7 @@ export class WorkspacesController {
     );
   }
 
-  @Get(':workspaceId/shared/:sharedFolderId/files')
+  @Get(':workspaceId/:teamId/shared/:sharedFolderId/files')
   @ApiOperation({
     summary: 'Get files inside a shared folder',
   })
@@ -616,6 +619,8 @@ export class WorkspacesController {
   async getFilesInsideSharedFolder(
     @Param('workspaceId', ValidateUUIDPipe)
     workspaceId: WorkspaceAttributes['id'],
+    @Param('teamId', ValidateUUIDPipe)
+    teamId: WorkspaceTeam['id'],
     @UserDecorator() user: User,
     @Param('sharedFolderId', ValidateUUIDPipe) sharedFolderId: Folder['uuid'],
     @Query('orderBy') orderBy: OrderBy,
@@ -629,6 +634,7 @@ export class WorkspacesController {
 
     return this.workspaceUseCases.getItemsInSharedFolder(
       workspaceId,
+      teamId,
       user,
       sharedFolderId,
       WorkspaceItemType.File,

--- a/src/modules/workspaces/workspaces.controller.ts
+++ b/src/modules/workspaces/workspaces.controller.ts
@@ -66,6 +66,7 @@ import { BehalfUserDecorator } from '../sharing/decorators/behalfUser.decorator'
 import { WorkspaceItemType } from './attributes/workspace-items-users.attributes';
 import { SharingService } from '../sharing/sharing.service';
 import { WorkspaceTeam } from './domains/workspace-team.domain';
+import { getItemsInsideSharedFolderDtoQuery } from './dto/get-items-inside-shared-folder.dto';
 
 @ApiTags('Workspaces')
 @Controller('workspaces')
@@ -523,7 +524,7 @@ export class WorkspacesController {
     );
   }
 
-  @Get(':workspaceId/:teamId/shared/files')
+  @Get(':workspaceId/teams/:teamId/shared/files')
   @ApiOperation({
     summary: 'Get shared files with a team',
   })
@@ -550,7 +551,7 @@ export class WorkspacesController {
     );
   }
 
-  @Get(':workspaceId/:teamId/shared/folders')
+  @Get(':workspaceId/teams/:teamId/shared/folders')
   @ApiOperation({
     summary: 'Get shared folders with a team',
   })
@@ -577,7 +578,7 @@ export class WorkspacesController {
     );
   }
 
-  @Get(':workspaceId/:teamId/shared/:sharedFolderId/folders')
+  @Get(':workspaceId/teams/:teamId/shared/:sharedFolderId/folders')
   @ApiOperation({
     summary: 'Get all folders inside a shared folder',
   })
@@ -590,11 +591,10 @@ export class WorkspacesController {
     teamId: WorkspaceTeam['id'],
     @UserDecorator() user: User,
     @Param('sharedFolderId', ValidateUUIDPipe) sharedFolderId: Folder['uuid'],
-    @Query('orderBy') orderBy: OrderBy,
-    @Query('token') token: string,
-    @Query('page') page = 0,
-    @Query('perPage') perPage = 50,
+    @Query() queryDto: getItemsInsideSharedFolderDtoQuery,
   ) {
+    const { orderBy, token, page, perPage } = queryDto;
+
     const order = orderBy
       ? [orderBy.split(':') as [string, string]]
       : undefined;
@@ -610,7 +610,7 @@ export class WorkspacesController {
     );
   }
 
-  @Get(':workspaceId/:teamId/shared/:sharedFolderId/files')
+  @Get(':workspaceId/teams/:teamId/shared/:sharedFolderId/files')
   @ApiOperation({
     summary: 'Get files inside a shared folder',
   })
@@ -623,11 +623,10 @@ export class WorkspacesController {
     teamId: WorkspaceTeam['id'],
     @UserDecorator() user: User,
     @Param('sharedFolderId', ValidateUUIDPipe) sharedFolderId: Folder['uuid'],
-    @Query('orderBy') orderBy: OrderBy,
-    @Query('token') token: string,
-    @Query('page') page = 0,
-    @Query('perPage') perPage = 50,
+    @Query() queryDto: getItemsInsideSharedFolderDtoQuery,
   ) {
+    const { orderBy, token, page, perPage } = queryDto;
+
     const order = orderBy
       ? [orderBy.split(':') as [string, string]]
       : undefined;

--- a/src/modules/workspaces/workspaces.module.ts
+++ b/src/modules/workspaces/workspaces.module.ts
@@ -17,6 +17,7 @@ import { MailerModule } from '../../externals/mailer/mailer.module';
 import { AvatarService } from '../../externals/avatar/avatar.service';
 import { FolderModule } from '../folder/folder.module';
 import { FileModule } from '../file/file.module';
+import { SharingModule } from '../sharing/sharing.module';
 
 @Module({
   imports: [
@@ -31,6 +32,7 @@ import { FileModule } from '../file/file.module';
     forwardRef(() => UserModule),
     forwardRef(() => FolderModule),
     forwardRef(() => FileModule),
+    forwardRef(() => SharingModule),
     BridgeModule,
     MailerModule,
   ],

--- a/src/modules/workspaces/workspaces.usecase.spec.ts
+++ b/src/modules/workspaces/workspaces.usecase.spec.ts
@@ -1966,7 +1966,7 @@ describe('WorkspacesUsecases', () => {
     });
   });
 
-  describe('shareItemWithMember', () => {
+  describe('shareItemWithTeam', () => {
     const user = newUser();
     const workspaceId = 'some-workspace-id';
     const item = newWorkspaceItemUser();
@@ -1978,12 +1978,12 @@ describe('WorkspacesUsecases', () => {
       roleId: 'string',
     };
 
-    it('When item is invalid, then it should throw BadRequestException', async () => {
+    it('When item is invalid, then it should throw', async () => {
       jest.spyOn(workspaceRepository, 'getItemBy').mockResolvedValue(null);
 
       await expect(
-        service.shareItemWithMember(user, workspaceId, shareWithMemberDto),
-      ).rejects.toThrow(BadRequestException);
+        service.shareItemWithTeam(user, workspaceId, shareWithMemberDto),
+      ).rejects.toThrow(NotFoundException);
     });
 
     it('When item is not owned by user, then it should throw ForbiddenException', async () => {
@@ -1992,11 +1992,11 @@ describe('WorkspacesUsecases', () => {
       jest.spyOn(workspaceRepository, 'getItemBy').mockResolvedValue(item);
 
       await expect(
-        service.shareItemWithMember(user, workspaceId, shareWithMemberDto),
+        service.shareItemWithTeam(user, workspaceId, shareWithMemberDto),
       ).rejects.toThrow(ForbiddenException);
     });
 
-    it('When member is not part of workspace, then it should throw BadRequestException', async () => {
+    it('When member is not part of workspace, then it should throw', async () => {
       const item = newWorkspaceItemUser();
 
       jest.spyOn(workspaceRepository, 'getItemBy').mockResolvedValue(item);
@@ -2005,8 +2005,8 @@ describe('WorkspacesUsecases', () => {
         .mockResolvedValue(null);
 
       await expect(
-        service.shareItemWithMember(user, workspaceId, shareWithMemberDto),
-      ).rejects.toThrow(BadRequestException);
+        service.shareItemWithTeam(user, workspaceId, shareWithMemberDto),
+      ).rejects.toThrow(ForbiddenException);
     });
 
     /*     it('When item is already shared with member, then it should throw BadRequestException', async () => {

--- a/src/modules/workspaces/workspaces.usecase.ts
+++ b/src/modules/workspaces/workspaces.usecase.ts
@@ -808,7 +808,7 @@ export class WorkspacesUsecases {
     folderUuid: Folder['uuid'],
     itemsType: WorkspaceItemType,
     token: string | null,
-    options?: { page: number; perPage: number; order: [string, string][] },
+    options?: { page: number; perPage: number; order: string[][] },
   ) {
     const getFolderContentByCreatedBy = async (
       createdBy: User['uuid'],
@@ -1737,44 +1737,6 @@ export class WorkspacesUsecases {
     itemType: WorkspaceItemUser['itemType'],
   ) {
     return this.workspaceRepository.getItemBy({ createdBy, itemId, itemType });
-  }
-
-  async findWorkspaceResourceOwnerByWorkspaceItem(
-    requester: User,
-    itemId: WorkspaceItemUser['itemId'],
-    itemType: WorkspaceItemUser['itemType'],
-    workspaceId: Workspace['id'],
-  ): Promise<User> {
-    const { workspaceUser: memberInWorkspace, workspace } =
-      await this.findUserAndWorkspace(requester.uuid, workspaceId);
-
-    if (!memberInWorkspace || !workspace) {
-      throw new ForbiddenException(
-        'This user is not part of workspace or workspace not valid',
-      );
-    }
-
-    const itemInWorkspace = await this.findWorkspaceItemByUser(
-      requester.uuid,
-      itemId,
-      itemType,
-    );
-
-    if (!itemInWorkspace.isOwnedBy(requester)) {
-      throw new ForbiddenException(
-        'This user is not part of workspace or workspace not valid',
-      );
-    }
-
-    const workspaceResourcesOwner = await this.userUsecases.findByUuid(
-      workspace.workspaceUserId,
-    );
-
-    if (!workspaceResourcesOwner) {
-      throw new NotFoundException('Resource owner not found');
-    }
-
-    return workspaceResourcesOwner;
   }
 
   findById(workspaceId: string): Promise<Workspace | null> {

--- a/src/modules/workspaces/workspaces.usecase.ts
+++ b/src/modules/workspaces/workspaces.usecase.ts
@@ -773,6 +773,10 @@ export class WorkspacesUsecases {
       this.workspaceRepository.findById(workspaceId),
     ]);
 
+    if (!workspace) {
+      throw new BadRequestException('Workspace is not valid!');
+    }
+
     if (existentSharing) {
       throw new ConflictException(
         'This item is already shared with this team!',

--- a/test/fixtures.spec.ts
+++ b/test/fixtures.spec.ts
@@ -9,6 +9,7 @@ import {
   WorkspaceItemType,
 } from '../src/modules/workspaces/attributes/workspace-items-users.attributes';
 import * as fixtures from './fixtures';
+import { SharingActionName } from '../src/modules/sharing/sharing.domain';
 
 describe('Testing fixtures tests', () => {
   describe("User's fixture", () => {
@@ -270,6 +271,34 @@ describe('Testing fixtures tests', () => {
 
       expect(limit.type).toEqual(LimitTypes.Boolean);
       expect(limit.value).toEqual('0');
+    });
+  });
+
+  describe('Permission fixture', () => {
+    it('When it generates a new permission, then the identifier should be random', () => {
+      const permission = fixtures.newPermission();
+      const otherPermission = fixtures.newPermission();
+
+      expect(permission.id).toBeTruthy();
+      expect(otherPermission.id).not.toBe(permission.id);
+    });
+
+    it('When it generates a permission and a name is provided, then that name should be set', () => {
+      const actionName: SharingActionName = SharingActionName.UploadFile;
+      const permission = fixtures.newPermission({
+        name: actionName,
+      });
+
+      expect(permission.name).toEqual(actionName);
+    });
+
+    it('When it generates a permission and a roleId is provided, then that roleId should be set', () => {
+      const roleId = v4();
+      const permission = fixtures.newPermission({
+        roleId,
+      });
+
+      expect(permission.roleId).toEqual(roleId);
     });
   });
 

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -4,7 +4,9 @@ import { generateKeyPairSync } from 'crypto';
 import { Folder } from '../src/modules/folder/folder.domain';
 import { User } from '../src/modules/user/user.domain';
 import {
+  Permission,
   Sharing,
+  SharingActionName,
   SharingRole,
   SharingType,
 } from '../src/modules/sharing/sharing.domain';
@@ -226,13 +228,13 @@ export const newSharing = (bindTo?: {
   encryptedPassword?: string;
 }): Sharing => {
   return Sharing.build({
-    type: bindTo.sharingType ? bindTo.sharingType : SharingType.Private,
+    type: bindTo?.sharingType ? bindTo.sharingType : SharingType.Private,
     id: v4(),
     itemId: bindTo?.item?.uuid || v4(),
     itemType: (bindTo?.item instanceof File ? 'file' : 'folder') || 'folder',
     ownerId: bindTo?.owner?.uuid || v4(),
     sharedWith: bindTo?.sharedWith?.uuid || v4(),
-    encryptedPassword: bindTo.encryptedPassword || null,
+    encryptedPassword: bindTo?.encryptedPassword || null,
     createdAt: randomDataGenerator.date(),
     updatedAt: randomDataGenerator.date(),
     encryptionAlgorithm: 'test',
@@ -317,6 +319,18 @@ export const newWorkspace = (params?: {
     });
 
   return workspace;
+};
+
+export const newPermission = (bindTo?: {
+  id?: string;
+  roleId?: string;
+  name?: SharingActionName;
+}): Permission => {
+  return Permission.build({
+    id: bindTo?.id ?? v4(),
+    roleId: bindTo?.roleId ?? v4(),
+    name: bindTo?.name ?? SharingActionName.UploadFile,
+  });
 };
 
 export const newWorkspaceTeam = (params?: {


### PR DESCRIPTION
### Description

This PR allow users in the workspace to share files and folders with other members in the workspace.

1. **Migration Scripts:**
   - Removed `sharings` constraint.
   - Added `sharedWithType` column (enum).

2. **Domain Modifications:**
   - Updated Sharing domain with `sharedWithType`.
   - Added `SharingActionName` to permissions domain.

3. **Repository Changes:**
   - Implemented `findPermissions` for sharings.
   - Added `canUserPerformActionInSharing` use case.

5. **Guards and Decorators:**
   - Created `SharingPermissionsGuard` for checking permissions in shared items.
   - Added `BehalfUserDecorator` to retrieve behalfUser from requests.

6. **Controller Updates:**
   - Applied `SharingPermissionsGuard` to `createFile` endpoint.
   - Added `shareItemWithMember`, `getFoldersInsideSharedFolder`, and `getFilesInsideSharedFolder` endpoints to WorkspaceController.

7. **Miscelaneous Adjustments:**
   - Moved RoleModel to resolve TypeScript relation issues.