### PR TITLE
[_] chore: bigint variables are now handled with number

### DIFF
--- a/src/modules/workspaces/attributes/workspace-invite.attribute.ts
+++ b/src/modules/workspaces/attributes/workspace-invite.attribute.ts
@@ -4,7 +4,7 @@ export interface WorkspaceInviteAttributes {
   invitedUser: string;
   encryptionAlgorithm: string;
   encryptionKey: string;
-  spaceLimit: bigint;
+  spaceLimit: number;
   createdAt: Date;
   updatedAt: Date;
 }

--- a/src/modules/workspaces/attributes/workspace-users.attributes.ts
+++ b/src/modules/workspaces/attributes/workspace-users.attributes.ts
@@ -4,10 +4,10 @@ export interface WorkspaceUserAttributes {
   member?: any;
   key: string;
   workspaceId: string;
-  spaceLimit: bigint;
+  spaceLimit: number;
   rootFolderId?: string;
-  driveUsage: bigint;
-  backupsUsage: bigint;
+  driveUsage: number;
+  backupsUsage: number;
   deactivated: boolean;
   createdAt: Date;
   updatedAt: Date;

--- a/src/modules/workspaces/domains/workspace-invite.domain.ts
+++ b/src/modules/workspaces/domains/workspace-invite.domain.ts
@@ -6,7 +6,7 @@ export class WorkspaceInvite implements WorkspaceInviteAttributes {
   invitedUser: string;
   encryptionAlgorithm: string;
   encryptionKey: string;
-  spaceLimit: bigint;
+  spaceLimit: number;
   createdAt: Date;
   updatedAt: Date;
 
@@ -41,7 +41,7 @@ export class WorkspaceInvite implements WorkspaceInviteAttributes {
       invitedUser: this.invitedUser,
       encryptionAlgorithm: this.encryptionAlgorithm,
       encryptionKey: this.encryptionKey,
-      spaceLimit: this.spaceLimit.toString(),
+      spaceLimit: this.spaceLimit,
       createdAt: this.createdAt,
       updatedAt: this.updatedAt,
     };

--- a/src/modules/workspaces/domains/workspace-user.domain.ts
+++ b/src/modules/workspaces/domains/workspace-user.domain.ts
@@ -8,9 +8,9 @@ export class WorkspaceUser implements WorkspaceUserAttributes {
   key: string;
   workspaceId: string;
   rootFolderId?: string;
-  spaceLimit: bigint;
-  driveUsage: bigint;
-  backupsUsage: bigint;
+  spaceLimit: number;
+  driveUsage: number;
+  backupsUsage: number;
   deactivated: boolean;
   createdAt: Date;
   updatedAt: Date;
@@ -34,9 +34,9 @@ export class WorkspaceUser implements WorkspaceUserAttributes {
     this.setMember(member);
     this.key = key;
     this.workspaceId = workspaceId;
-    this.spaceLimit = BigInt(spaceLimit);
-    this.driveUsage = BigInt(driveUsage);
-    this.backupsUsage = BigInt(backupsUsage);
+    this.spaceLimit = spaceLimit;
+    this.driveUsage = driveUsage;
+    this.backupsUsage = backupsUsage;
     this.deactivated = deactivated;
     this.rootFolderId = rootFolderId;
     this.createdAt = createdAt;
@@ -51,19 +51,19 @@ export class WorkspaceUser implements WorkspaceUserAttributes {
     this.member = member;
   }
 
-  getUsedSpace(): bigint {
+  getUsedSpace(): number {
     return this.driveUsage + this.backupsUsage;
   }
 
-  getFreeSpace(): bigint {
+  getFreeSpace(): number {
     return this.spaceLimit - this.getUsedSpace();
   }
 
-  hasEnoughSpaceForFile(size: bigint): boolean {
+  hasEnoughSpaceForFile(size: number): boolean {
     return this.getFreeSpace() >= size;
   }
 
-  addDriveUsage(fileSize: bigint): void {
+  addDriveUsage(fileSize: number): void {
     this.driveUsage += fileSize;
   }
 
@@ -74,9 +74,9 @@ export class WorkspaceUser implements WorkspaceUserAttributes {
       key: this.key,
       workspaceId: this.workspaceId,
       rootFolderId: this.rootFolderId,
-      spaceLimit: this.spaceLimit.toString(),
-      driveUsage: this.driveUsage.toString(),
-      backupsUsage: this.backupsUsage.toString(),
+      spaceLimit: this.spaceLimit,
+      driveUsage: this.driveUsage,
+      backupsUsage: this.backupsUsage,
       deactivated: this.deactivated,
       member: this.member ? this.member.toJSON() : null,
       createdAt: this.createdAt,

--- a/src/modules/workspaces/dto/workspace-user-member.dto.ts
+++ b/src/modules/workspaces/dto/workspace-user-member.dto.ts
@@ -9,11 +9,11 @@ export interface WorkspaceUserMemberDto {
   member: UserToJsonDto;
   key: string;
   workspaceId: string;
-  spaceLimit: string;
-  driveUsage: string;
-  backupsUsage: string;
-  usedSpace: string;
-  freeSpace: string;
+  spaceLimit: number;
+  driveUsage: number;
+  backupsUsage: number;
+  usedSpace: number;
+  freeSpace: number;
   deactivated: boolean;
   createdAt: Date;
   updatedAt: Date;

--- a/src/modules/workspaces/models/workspace-invite.model.ts
+++ b/src/modules/workspaces/models/workspace-invite.model.ts
@@ -44,7 +44,7 @@ export class WorkspaceInviteModel
   encryptionKey: string;
 
   @Column({ type: DataType.BIGINT.UNSIGNED, allowNull: false })
-  spaceLimit: bigint;
+  spaceLimit: number;
 
   @Column({ allowNull: false, defaultValue: DataType.NOW })
   createdAt: Date;

--- a/src/modules/workspaces/models/workspace-users.model.ts
+++ b/src/modules/workspaces/models/workspace-users.model.ts
@@ -58,14 +58,14 @@ export class WorkspaceUserModel
   })
   workspace: WorkspaceModel;
 
-  @Column(DataType.BIGINT)
-  spaceLimit: bigint;
+  @Column(DataType.BIGINT.UNSIGNED)
+  spaceLimit: number;
 
-  @Column(DataType.BIGINT)
-  driveUsage: bigint;
+  @Column(DataType.BIGINT.UNSIGNED)
+  driveUsage: number;
 
-  @Column(DataType.BIGINT)
-  backupsUsage: bigint;
+  @Column(DataType.BIGINT.UNSIGNED)
+  backupsUsage: number;
 
   @Column(DataType.BOOLEAN)
   deactivated: boolean;

--- a/src/modules/workspaces/repositories/workspaces.repository.spec.ts
+++ b/src/modules/workspaces/repositories/workspaces.repository.spec.ts
@@ -131,7 +131,7 @@ describe('SequelizeWorkspaceRepository', () => {
       jest.spyOn(workspaceInviteModel, 'sum').mockResolvedValueOnce(null);
 
       const totalSpace = await repository.getSpaceLimitInInvitations('1');
-      expect(totalSpace).toStrictEqual(BigInt(0));
+      expect(totalSpace).toStrictEqual(0);
     });
   });
 
@@ -140,7 +140,7 @@ describe('SequelizeWorkspaceRepository', () => {
       jest.spyOn(workspaceUserModel, 'sum').mockResolvedValueOnce(10);
 
       const total = await repository.getTotalSpaceLimitInWorkspaceUsers('1');
-      expect(total).toStrictEqual(BigInt(10));
+      expect(total).toStrictEqual(10);
     });
   });
 

--- a/src/modules/workspaces/repositories/workspaces.repository.ts
+++ b/src/modules/workspaces/repositories/workspaces.repository.ts
@@ -169,21 +169,21 @@ export class SequelizeWorkspaceRepository {
   }
   async getSpaceLimitInInvitations(
     workspaceId: WorkspaceAttributes['id'],
-  ): Promise<bigint> {
+  ): Promise<number> {
     const totalSpaceLimit = await this.modelWorkspaceInvite.sum('spaceLimit', {
       where: { workspaceId: workspaceId },
     });
 
-    return BigInt(totalSpaceLimit || 0);
+    return totalSpaceLimit || 0;
   }
 
   async getTotalSpaceLimitInWorkspaceUsers(
     workspaceId: WorkspaceAttributes['id'],
-  ): Promise<bigint> {
+  ): Promise<number> {
     const total = await this.modelWorkspaceUser.sum('spaceLimit', {
       where: { workspaceId },
     });
-    return BigInt(total ?? 0);
+    return total ?? 0;
   }
 
   async createInvite(

--- a/src/modules/workspaces/workspaces.controller.spec.ts
+++ b/src/modules/workspaces/workspaces.controller.spec.ts
@@ -189,44 +189,44 @@ describe('Workspace Controller', () => {
         memberId: owner.uuid,
         member: owner,
         attributes: { deactivated: false },
-      }).toJSON();
+      });
       const userWorkspace1 = newWorkspaceUser({
         workspaceId: workspace.id,
         memberId: user1.uuid,
         member: user1,
         attributes: { deactivated: false },
-      }).toJSON();
+      });
       const userWorkspace2 = newWorkspaceUser({
         workspaceId: workspace.id,
         memberId: user2.uuid,
         member: user2,
         attributes: { deactivated: true },
-      }).toJSON();
+      });
 
       const mockResolvedValues = {
         activatedUsers: [
           {
-            ...ownerWorkspaceUser,
+            ...ownerWorkspaceUser.toJSON(),
             isOwner: true,
             isManager: true,
-            freeSpace: BigInt(150000).toString(),
-            usedSpace: BigInt(0).toString(),
+            freeSpace: ownerWorkspaceUser.getFreeSpace(),
+            usedSpace: ownerWorkspaceUser.getUsedSpace(),
           },
           {
-            ...userWorkspace1,
+            ...userWorkspace1.toJSON(),
             isOwner: false,
             isManager: false,
-            freeSpace: BigInt(15000).toString(),
-            usedSpace: BigInt(0).toString(),
+            freeSpace: userWorkspace1.getFreeSpace(),
+            usedSpace: userWorkspace1.getUsedSpace(),
           },
         ],
         disabledUsers: [
           {
-            ...userWorkspace2,
+            ...userWorkspace2.toJSON(),
             isOwner: false,
             isManager: false,
-            freeSpace: BigInt(13000).toString(),
-            usedSpace: BigInt(0).toString(),
+            freeSpace: userWorkspace2.getFreeSpace(),
+            usedSpace: userWorkspace2.getUsedSpace(),
           },
         ],
       };

--- a/src/modules/workspaces/workspaces.usecase.spec.ts
+++ b/src/modules/workspaces/workspaces.usecase.spec.ts
@@ -100,7 +100,7 @@ describe('WorkspacesUsecases', () => {
       await expect(
         service.inviteUserToWorkspace(user, 'workspace-id', {
           invitedUser: 'test@example.com',
-          spaceLimit: BigInt(1024),
+          spaceLimit: 1024,
           encryptionKey: 'Dasdsadas',
           encryptionAlgorithm: 'dadads',
         }),
@@ -117,7 +117,7 @@ describe('WorkspacesUsecases', () => {
       await expect(
         service.inviteUserToWorkspace(user, 'workspace-id', {
           invitedUser: 'test@example.com',
-          spaceLimit: BigInt(1024),
+          spaceLimit: 1024,
           encryptionKey: 'Dasdsadas',
           encryptionAlgorithm: 'dadads',
         }),
@@ -142,7 +142,7 @@ describe('WorkspacesUsecases', () => {
       jest.spyOn(userRepository, 'findByUuid').mockResolvedValueOnce(user);
       jest
         .spyOn(service, 'getAssignableSpaceInWorkspace')
-        .mockResolvedValueOnce(BigInt(6000000));
+        .mockResolvedValueOnce(6000000);
       jest.spyOn(configService, 'get').mockResolvedValueOnce('secret' as never);
       jest
         .spyOn(mailerService, 'sendWorkspaceUserExternalInvitation')
@@ -151,7 +151,7 @@ describe('WorkspacesUsecases', () => {
       await expect(
         service.inviteUserToWorkspace(user, 'workspace-id', {
           invitedUser: 'test@example.com',
-          spaceLimit: BigInt(1024),
+          spaceLimit: 1024,
           encryptionKey: '',
           encryptionAlgorithm: '',
         }),
@@ -181,7 +181,7 @@ describe('WorkspacesUsecases', () => {
       jest.spyOn(userRepository, 'findByUuid').mockResolvedValueOnce(user);
       jest
         .spyOn(service, 'getAssignableSpaceInWorkspace')
-        .mockResolvedValueOnce(BigInt(6000000));
+        .mockResolvedValueOnce(6000000);
       jest
         .spyOn(mailerService, 'sendWorkspaceUserInvitation')
         .mockResolvedValueOnce(undefined);
@@ -190,7 +190,7 @@ describe('WorkspacesUsecases', () => {
       await expect(
         service.inviteUserToWorkspace(user, 'workspace-id', {
           invitedUser: 'test@example.com',
-          spaceLimit: BigInt(1024),
+          spaceLimit: 1024,
           encryptionKey: '',
           encryptionAlgorithm: '',
         }),
@@ -218,7 +218,7 @@ describe('WorkspacesUsecases', () => {
       await expect(
         service.inviteUserToWorkspace(user, workspace.id, {
           invitedUser: 'test@example.com',
-          spaceLimit: BigInt(1024),
+          spaceLimit: 1024,
           encryptionKey: 'encryptionKey',
           encryptionAlgorithm: 'RSA',
         }),
@@ -243,7 +243,7 @@ describe('WorkspacesUsecases', () => {
       await expect(
         service.inviteUserToWorkspace(user, workspace.id, {
           invitedUser: invitedUser.email,
-          spaceLimit: BigInt(1024),
+          spaceLimit: 1024,
           encryptionKey: 'encryptionKey',
           encryptionAlgorithm: 'RSA',
         }),
@@ -274,7 +274,7 @@ describe('WorkspacesUsecases', () => {
       await expect(
         service.inviteUserToWorkspace(user, workspace.id, {
           invitedUser: invitedUserEmail,
-          spaceLimit: BigInt(1024),
+          spaceLimit: 1024,
           encryptionKey: 'encryptionKey',
           encryptionAlgorithm: 'RSA',
         }),
@@ -299,13 +299,13 @@ describe('WorkspacesUsecases', () => {
       jest.spyOn(service, 'isWorkspaceFull').mockResolvedValueOnce(false);
       jest
         .spyOn(service, 'getAssignableSpaceInWorkspace')
-        .mockResolvedValueOnce(BigInt(spaceLeft));
+        .mockResolvedValueOnce(spaceLeft);
       jest.spyOn(workspaceRepository, 'findInvite').mockResolvedValueOnce(null);
 
       await expect(
         service.inviteUserToWorkspace(user, workspace.id, {
           invitedUser: invitedUserEmail,
-          spaceLimit: BigInt(spaceLeft + 1),
+          spaceLimit: spaceLeft + 1,
           encryptionKey: 'encryptionKey',
           encryptionAlgorithm: 'RSA',
         }),
@@ -720,7 +720,7 @@ describe('WorkspacesUsecases', () => {
       const invite = newWorkspaceInvite({
         invitedUser: invitedUser.uuid,
         workspaceId: workspace.id,
-        attributes: { spaceLimit: BigInt(1000) },
+        attributes: { spaceLimit: 1000 },
       });
       jest.spyOn(workspaceRepository, 'findInvite').mockResolvedValue(invite);
       jest.spyOn(workspaceRepository, 'findOne').mockResolvedValue(workspace);
@@ -1071,16 +1071,16 @@ describe('WorkspacesUsecases', () => {
       jest.spyOn(networkService, 'getLimit').mockResolvedValue(1000000);
       jest
         .spyOn(workspaceRepository, 'getTotalSpaceLimitInWorkspaceUsers')
-        .mockResolvedValue(BigInt(500000));
+        .mockResolvedValue(500000);
       jest
         .spyOn(workspaceRepository, 'getSpaceLimitInInvitations')
-        .mockResolvedValue(BigInt(200000));
+        .mockResolvedValue(200000);
 
       const assignableSpace = await service.getAssignableSpaceInWorkspace(
         workspace,
         workspaceDefaultUser,
       );
-      expect(assignableSpace).toBe(BigInt(300000));
+      expect(assignableSpace).toBe(300000);
     });
   });
 
@@ -1212,8 +1212,8 @@ describe('WorkspacesUsecases', () => {
             ...workspaceUser.toJSON(),
             isOwner: false,
             isManager: false,
-            freeSpace: workspaceUser.getFreeSpace().toString(),
-            usedSpace: workspaceUser.getUsedSpace().toString(),
+            freeSpace: workspaceUser.getFreeSpace(),
+            usedSpace: workspaceUser.getUsedSpace(),
           },
         ],
         disabledUsers: [],
@@ -1267,15 +1267,15 @@ describe('WorkspacesUsecases', () => {
             ...workspaceUser1.toJSON(),
             isOwner: false,
             isManager: true,
-            freeSpace: workspaceUser1.getFreeSpace().toString(),
-            usedSpace: workspaceUser1.getUsedSpace().toString(),
+            freeSpace: workspaceUser1.getFreeSpace(),
+            usedSpace: workspaceUser1.getUsedSpace(),
           },
           {
             ...workspaceUser2.toJSON(),
             isOwner: false,
             isManager: false,
-            freeSpace: workspaceUser2.getFreeSpace().toString(),
-            usedSpace: workspaceUser2.getUsedSpace().toString(),
+            freeSpace: workspaceUser2.getFreeSpace(),
+            usedSpace: workspaceUser2.getUsedSpace(),
           },
         ],
         disabledUsers: [],
@@ -1392,7 +1392,7 @@ describe('WorkspacesUsecases', () => {
     it('When users do not have space, then it should throw', async () => {
       const user = newUser();
       const workspaceUserWithNoSpace = newWorkspaceUser({
-        attributes: { spaceLimit: BigInt(1024), driveUsage: BigInt(1024) },
+        attributes: { spaceLimit: 1024, driveUsage: 1024 },
       });
 
       jest
@@ -1406,9 +1406,9 @@ describe('WorkspacesUsecases', () => {
 
     it('When file size is bigger than free space, then it should throw', async () => {
       const user = newUser();
-      const size = BigInt(2000);
+      const size = 2000;
       const workspaceUserWithNoSpace = newWorkspaceUser({
-        attributes: { spaceLimit: BigInt(1024), driveUsage: BigInt(1024) },
+        attributes: { spaceLimit: 1024, driveUsage: 1024 },
       });
 
       jest
@@ -1416,15 +1416,18 @@ describe('WorkspacesUsecases', () => {
         .mockResolvedValueOnce(workspaceUserWithNoSpace);
 
       await expect(
-        service.createFile(user, workspace.id, { ...createFileDto, size }),
+        service.createFile(user, workspace.id, {
+          ...createFileDto,
+          size: BigInt(size),
+        }),
       ).rejects.toThrow(BadRequestException);
     });
 
     it('When parent folder is not valid, then it should throw', async () => {
       const user = newUser();
-      const size = BigInt(2000);
+      const size = 2000;
       const workspaceUser = newWorkspaceUser({
-        attributes: { spaceLimit: BigInt(2048), driveUsage: BigInt(1024) },
+        attributes: { spaceLimit: 2048, driveUsage: 1024 },
       });
 
       jest
@@ -1433,15 +1436,18 @@ describe('WorkspacesUsecases', () => {
       jest.spyOn(workspaceRepository, 'getItemBy').mockResolvedValue(null);
 
       await expect(
-        service.createFile(user, workspace.id, { ...createFileDto, size }),
+        service.createFile(user, workspace.id, {
+          ...createFileDto,
+          size: BigInt(size),
+        }),
       ).rejects.toThrow(BadRequestException);
     });
 
     it('When user does not own the parent folder, then it should throw', async () => {
       const user = newUser();
-      const fileSize = BigInt(1000);
+      const fileSize = 1000;
       const workspaceUser = newWorkspaceUser({
-        attributes: { spaceLimit: fileSize + BigInt(1) },
+        attributes: { spaceLimit: fileSize + 1 },
       });
       const folderItem = newWorkspaceItemUser();
 
@@ -1455,20 +1461,20 @@ describe('WorkspacesUsecases', () => {
       await expect(
         service.createFile(user, workspace.id, {
           ...createFileDto,
-          size: fileSize,
+          size: BigInt(fileSize),
         }),
       ).rejects.toThrow(ForbiddenException);
     });
 
     it('When parent folder is the workspace root folder, then it should throw', async () => {
       const user = newUser();
-      const fileSize = BigInt(2000);
+      const fileSize = 2000;
       const workspace = newWorkspace({
         attributes: { rootFolderId: createFileDto.folderUuid },
       });
       const workspaceUser = newWorkspaceUser({
         attributes: {
-          spaceLimit: fileSize + BigInt(1),
+          spaceLimit: fileSize + 1,
           rootFolderId: createFileDto.folderUuid,
         },
         workspaceId: workspace.id,
@@ -1487,18 +1493,18 @@ describe('WorkspacesUsecases', () => {
       await expect(
         service.createFile(user, workspace.id, {
           ...createFileDto,
-          size: fileSize,
+          size: BigInt(fileSize),
         }),
       ).rejects.toThrow(ForbiddenException);
     });
 
     it('When workspace user has enough space and parent folder is valid, then it should create file successfully', async () => {
       const user = newUser();
-      const fileSize = BigInt(2000);
+      const fileSize = 2000;
       const workspace = newWorkspace();
       const workspaceUser = newWorkspaceUser({
         attributes: {
-          spaceLimit: fileSize + BigInt(1),
+          spaceLimit: fileSize + 1,
           rootFolderId: createFileDto.folderUuid,
         },
         workspaceId: workspace.id,
@@ -1526,7 +1532,7 @@ describe('WorkspacesUsecases', () => {
 
       const result = await service.createFile(user, workspace.id, {
         ...createFileDto,
-        size: fileSize,
+        size: BigInt(fileSize),
       });
 
       expect(result).toEqual({ ...createdFile, item: createdItemFile });

--- a/src/modules/workspaces/workspaces.usecase.ts
+++ b/src/modules/workspaces/workspaces.usecase.ts
@@ -182,9 +182,9 @@ export class WorkspacesUsecases {
           id: v4(),
           workspaceId: workspace.id,
           memberId: user.uuid,
-          spaceLimit: BigInt(0),
-          driveUsage: BigInt(0),
-          backupsUsage: BigInt(0),
+          spaceLimit: 0,
+          driveUsage: 0,
+          backupsUsage: 0,
           key: setupWorkspaceDto.encryptedMnemonic,
           rootFolderId: rootFolder.uuid,
           deactivated: false,
@@ -346,7 +346,7 @@ export class WorkspacesUsecases {
       invitedUser: userJoining.uuid,
       encryptionAlgorithm: createInviteDto.encryptionAlgorithm,
       encryptionKey: createInviteDto.encryptionKey,
-      spaceLimit: BigInt(createInviteDto.spaceLimit),
+      spaceLimit: createInviteDto.spaceLimit,
       createdAt: new Date(),
       updatedAt: new Date(),
     });
@@ -415,7 +415,7 @@ export class WorkspacesUsecases {
       workspaceId,
     });
 
-    if (!workspaceUser.hasEnoughSpaceForFile(createFileDto.size)) {
+    if (!workspaceUser.hasEnoughSpaceForFile(Number(createFileDto.size))) {
       throw new BadRequestException('You have not enough space for this file');
     }
 
@@ -457,7 +457,7 @@ export class WorkspacesUsecases {
       updatedAt: new Date(),
     });
 
-    workspaceUser.addDriveUsage(BigInt(createdFile.size));
+    workspaceUser.addDriveUsage(Number(createdFile.size));
 
     await this.workspaceRepository.updateWorkspaceUser(
       workspaceUser.id,
@@ -649,9 +649,9 @@ export class WorkspacesUsecases {
         workspaceId: invite.workspaceId,
         memberId: invite.invitedUser,
         spaceLimit: invite.spaceLimit,
-        driveUsage: BigInt(0),
+        driveUsage: 0,
         rootFolderId: rootFolder.uuid,
-        backupsUsage: BigInt(0),
+        backupsUsage: 0,
         key: invite.encryptionKey,
         deactivated: false,
         createdAt: new Date(),
@@ -746,7 +746,7 @@ export class WorkspacesUsecases {
   async getAssignableSpaceInWorkspace(
     workspace: Workspace,
     workpaceDefaultUser: User,
-  ): Promise<bigint> {
+  ): Promise<number> {
     const [
       spaceLimit,
       totalSpaceLimitAssigned,
@@ -761,9 +761,7 @@ export class WorkspacesUsecases {
     ]);
 
     const spaceLeft =
-      BigInt(spaceLimit) -
-      totalSpaceLimitAssigned -
-      totalSpaceAssignedInInvitations;
+      spaceLimit - totalSpaceLimitAssigned - totalSpaceAssignedInInvitations;
 
     return spaceLeft;
   }
@@ -914,8 +912,8 @@ export class WorkspacesUsecases {
         return {
           isOwner,
           isManager,
-          usedSpace: workspaceUser.getUsedSpace().toString(),
-          freeSpace: workspaceUser.getFreeSpace().toString(),
+          usedSpace: workspaceUser.getUsedSpace(),
+          freeSpace: workspaceUser.getFreeSpace(),
           ...workspaceUser.toJSON(),
         };
       }),

--- a/test/fixtures.spec.ts
+++ b/test/fixtures.spec.ts
@@ -375,18 +375,14 @@ describe('Testing fixtures tests', () => {
 
     it('When it generates a workspace user, then driveUsage and backupsUsage should not exceed spaceLimit', () => {
       const user = fixtures.newWorkspaceUser();
-      expect(Number(user.driveUsage)).toBeLessThanOrEqual(
-        BigInt(user.spaceLimit),
-      );
-      expect(BigInt(user.backupsUsage)).toBeLessThanOrEqual(
-        BigInt(user.spaceLimit),
-      );
+      expect(Number(user.driveUsage)).toBeLessThanOrEqual(user.spaceLimit);
+      expect(user.backupsUsage).toBeLessThanOrEqual(user.spaceLimit);
     });
 
     it('When it generates a workspace user with custom attributes, then those attributes are set correctly', () => {
       const customAttributes = {
         deactivated: true,
-        spaceLimit: BigInt(500),
+        spaceLimit: 500,
       };
       const user = fixtures.newWorkspaceUser({ attributes: customAttributes });
 
@@ -419,7 +415,7 @@ describe('Testing fixtures tests', () => {
     it('When it generates a workspace invite with custom attributes, then those attributes are set correctly', () => {
       const customAttributes = {
         encryptionAlgorithm: 'AES-256',
-        spaceLimit: BigInt(2048),
+        spaceLimit: 2048,
       };
       const invite = fixtures.newWorkspaceInvite({
         attributes: customAttributes,

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -379,9 +379,9 @@ export const newWorkspaceUser = (params?: {
     member: params?.member,
     key: randomDataGenerator.string({ length: 32 }),
     workspaceId: params?.workspaceId || v4(),
-    spaceLimit: BigInt(spaceLimit),
-    driveUsage: BigInt(0),
-    backupsUsage: BigInt(0),
+    spaceLimit: spaceLimit,
+    driveUsage: 0,
+    backupsUsage: 0,
     deactivated: randomDataGenerator.bool(),
     createdAt: randomCreatedAt,
     updatedAt: new Date(randomDataGenerator.date({ min: randomCreatedAt })),
@@ -408,9 +408,7 @@ export const newWorkspaceInvite = (params?: {
     invitedUser: params?.invitedUser || randomDataGenerator.email(),
     encryptionAlgorithm: 'AES-256',
     encryptionKey: randomDataGenerator.string({ length: 32 }),
-    spaceLimit: BigInt(
-      randomDataGenerator.natural({ min: 1024, max: 1048576 }),
-    ),
+    spaceLimit: randomDataGenerator.natural({ min: 1024, max: 1048576 }),
     createdAt: defaultCreatedAt,
     updatedAt: new Date(randomDataGenerator.date({ min: defaultCreatedAt })),
   });


### PR DESCRIPTION
BigInts are not well-supported by JSON.stringify(), which is used by NestJS and Jest in many situations. This causes more problems than benefits, and using BigInts is unnecessary in our case.

Initially, using BigInts seemed like a good idea due to their support for numbers greater than the MAX_SAFE_INTEGER. However, the MAX_SAFE_INTEGER is sufficiently large for our use case.

MAX_SAFE_INTEGER = 9,007,199,254,740,991

If we consider this number as bytes, it is approximately 8,192 TB, which is more than adequate for our needs.