### PR TITLE
[_] feat: added extended base http exception

### DIFF
--- a/src/common/http-exception-filter-extended.exception.spec.ts
+++ b/src/common/http-exception-filter-extended.exception.spec.ts
@@ -1,0 +1,81 @@
+import { ArgumentsHost, HttpException, Logger } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { BaseExceptionFilter } from '@nestjs/core';
+import { newUser } from '../../test/fixtures';
+import { ExtendedHttpExceptionFilter } from './http-exception-filter-extended.exception';
+
+describe('ExtendedHttpExceptionFilter', () => {
+  let filter: ExtendedHttpExceptionFilter;
+  let loggerErrorSpy: jest.SpyInstance;
+  let baseExceptionFilterCatchSpy: jest.SpyInstance;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [ExtendedHttpExceptionFilter],
+    }).compile();
+
+    filter = module.get<ExtendedHttpExceptionFilter>(
+      ExtendedHttpExceptionFilter,
+    );
+    loggerErrorSpy = jest.spyOn(Logger.prototype, 'error').mockImplementation();
+    baseExceptionFilterCatchSpy = jest
+      .spyOn(BaseExceptionFilter.prototype, 'catch')
+      .mockImplementation();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const createMockArgumentsHost = (url: string, method: string, user: any) =>
+    ({
+      switchToHttp: jest.fn().mockReturnValue({
+        getRequest: jest.fn().mockReturnValue({
+          url,
+          method,
+          user,
+        }),
+        getResponse: jest.fn().mockReturnValue({
+          statusCode: 500,
+          headers: {},
+          getHeader: jest.fn(),
+          setHeader: jest.fn(),
+          isHeadersSent: false,
+        }),
+        getNext: jest.fn(),
+      }),
+      getArgs: jest.fn(),
+      getArgByIndex: jest.fn(),
+      switchToRpc: jest.fn(),
+      switchToWs: jest.fn(),
+      getType: jest.fn(),
+    }) as unknown as ArgumentsHost;
+
+  it('When non expected error are sent, then it should log details and call parent catch', () => {
+    const mockException = new Error('Unexpected error');
+    const user = newUser();
+    const mockHost = createMockArgumentsHost('/my-endpoint', 'GET', user);
+
+    filter.catch(mockException, mockHost);
+
+    expect(loggerErrorSpy).toHaveBeenCalled();
+    expect(baseExceptionFilterCatchSpy).toHaveBeenCalledWith(
+      mockException,
+      mockHost,
+    );
+  });
+
+  it('When expected exception is sent, then it should not log detailss and call parent catch', () => {
+    const mockException = new HttpException('This is an http error', 400);
+    const user = newUser();
+    const mockHost = createMockArgumentsHost('/my-endpoint', 'GET', user);
+
+    filter.catch(mockException, mockHost);
+
+    expect(loggerErrorSpy).not.toHaveBeenCalled();
+    expect(baseExceptionFilterCatchSpy).toHaveBeenCalledWith(
+      mockException,
+      mockHost,
+    );
+  });
+});

--- a/src/common/http-exception-filter-extended.exception.ts
+++ b/src/common/http-exception-filter-extended.exception.ts
@@ -1,0 +1,30 @@
+import { Catch, Logger, HttpException, ArgumentsHost } from '@nestjs/common';
+import { BaseExceptionFilter } from '@nestjs/core';
+
+@Catch()
+export class ExtendedHttpExceptionFilter extends BaseExceptionFilter {
+  private readonly logger = new Logger(ExtendedHttpExceptionFilter.name);
+
+  catch(exception: any, host: ArgumentsHost) {
+    const ctx = host.switchToHttp();
+
+    const request = ctx.getRequest();
+
+    if (!(exception instanceof HttpException)) {
+      const errorResponse = {
+        timestamp: new Date().toISOString(),
+        path: request.url,
+        method: request.method,
+        message: (exception as Error)?.message,
+        stack: (exception as Error)?.stack,
+        user: { email: request?.user?.email, uuid: request?.user?.uuid },
+      };
+
+      this.logger.error(
+        `[UNEXPECTED_ERROR] - Details: ${JSON.stringify(errorResponse)}`,
+      );
+    }
+
+    super.catch(exception, host);
+  }
+}

--- a/src/modules/workspaces/workspaces.controller.ts
+++ b/src/modules/workspaces/workspaces.controller.ts
@@ -12,6 +12,7 @@ import {
   UseGuards,
   UseInterceptors,
   InternalServerErrorException,
+  UseFilters,
 } from '@nestjs/common';
 import {
   ApiBearerAuth,
@@ -53,9 +54,11 @@ import { PaginationQueryDto } from './dto/pagination.dto';
 import { SortableFileAttributes } from '../file/file.domain';
 import { avatarStorageS3Config } from '../../externals/multer';
 import { WorkspaceInvitationsPagination } from './dto/workspace-invitations-pagination.dto';
+import { ExtendedHttpExceptionFilter } from '../../common/http-exception-filter-extended.exception';
 
 @ApiTags('Workspaces')
 @Controller('workspaces')
+@UseFilters(ExtendedHttpExceptionFilter)
 export class WorkspacesController {
   constructor(private workspaceUseCases: WorkspacesUsecases) {}
 


### PR DESCRIPTION
This PR introduces ExtendedHttpExceptionFilter, which extends NestJS's BaseExceptionFilter to improve error logging for unexpected errors. Http errors are not being logged as they are expected properly.

### Why?

When an unexpected error appears, we usually are not able to find logs easily due to Nestjs way of logging things (just the error message and the trace). Also, sometimes the errors are log in multiple lines and we are not able to see what's happening clearly. 

![image](https://github.com/internxt/drive-server-wip/assets/143480783/ef734c8c-7070-4a3c-a3c9-5446646d1fe9)


More info about this: https://docs.nestjs.com/exception-filters#inheritance
