### PR TITLE
feat: calculate member usage in workspace

### DIFF
--- a/migrations/20240610121257-add-last-size-sync-column.js
+++ b/migrations/20240610121257-add-last-size-sync-column.js
@@ -1,0 +1,18 @@
+'use strict';
+
+const tableName = 'workspace_users';
+const newColumn = 'last_usage_sync_at';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.addColumn(tableName, newColumn, {
+      type: Sequelize.DATE,
+      allowNull: true,
+    });
+  },
+
+  async down(queryInterface) {
+    await queryInterface.removeColumn(tableName, newColumn);
+  },
+};

--- a/src/modules/file/file.repository.spec.ts
+++ b/src/modules/file/file.repository.spec.ts
@@ -1,0 +1,96 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getModelToken } from '@nestjs/sequelize';
+import { createMock } from '@golevelup/ts-jest';
+import { newUser, newWorkspace } from '../../../test/fixtures';
+import { FileStatus } from './file.domain';
+import { FileModel } from './file.model';
+import { FileRepository, SequelizeFileRepository } from './file.repository';
+import { Op } from 'sequelize';
+
+describe('FileRepository', () => {
+  let repository: FileRepository;
+  let fileModel: typeof FileModel;
+
+  const user = newUser();
+  const workspace = newWorkspace();
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [SequelizeFileRepository],
+    })
+      .useMocker(() => createMock())
+      .compile();
+
+    repository = module.get<FileRepository>(SequelizeFileRepository);
+    fileModel = module.get<typeof FileModel>(getModelToken(FileModel));
+  });
+
+  describe('getSumSizeOfFilesByStatuses', () => {
+    it('When called with specific statuses and options, then it should fetch file sizes', async () => {
+      const statuses = [FileStatus.EXISTS, FileStatus.TRASHED];
+      const options = {
+        limit: 100,
+        offset: 0,
+        createdFrom: new Date('2023-01-01'),
+      };
+      const fileSizes = [{ size: '100' }, { size: '200' }];
+
+      jest.spyOn(fileModel, 'findAll').mockResolvedValueOnce(fileSizes as any);
+
+      const result = await repository.getSumSizeOfFilesByStatuses(
+        user.uuid,
+        workspace.id,
+        statuses,
+        options,
+      );
+
+      expect(fileModel.findAll).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            [Op.or]: expect.arrayContaining([
+              { status: statuses[0] },
+              { status: statuses[1] },
+            ]),
+          }),
+          include: expect.objectContaining({
+            where: expect.objectContaining({
+              createdBy: user.uuid,
+              workspaceId: workspace.id,
+              created_at: { [Op.gte]: options.createdFrom },
+            }),
+          }),
+        }),
+      );
+      expect(result).toEqual(fileSizes);
+    });
+
+    it('When files removed from a specific date are fetch, then it should include the date in the query', async () => {
+      const statuses = [FileStatus.DELETED];
+      const options = {
+        limit: 100,
+        offset: 0,
+        removedFrom: new Date('2023-01-01'),
+      };
+      const fileSizes = [{ size: '100' }, { size: '200' }];
+
+      jest.spyOn(fileModel, 'findAll').mockResolvedValueOnce(fileSizes as any);
+
+      const result = await repository.getSumSizeOfFilesByStatuses(
+        user.uuid,
+        workspace.id,
+        statuses,
+        options,
+      );
+
+      expect(fileModel.findAll).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            [Op.or]: expect.arrayContaining([{ status: statuses[0] }]),
+            removed_at: { [Op.gte]: options.removedFrom },
+          }),
+        }),
+      );
+      expect(result).toEqual(fileSizes);
+    });
+  });
+});

--- a/src/modules/file/file.usecase.spec.ts
+++ b/src/modules/file/file.usecase.spec.ts
@@ -777,4 +777,64 @@ describe('FileUseCases', () => {
       expect(result).toEqual(updatedFile);
     });
   });
+
+  describe('getTrashedAndExistentFilesSizeSum', () => {
+    const createdBy = v4();
+    const workspaceId = v4();
+    const options = { limit: 10, offset: 10 };
+
+    it('When order is provided, then it should fetch files size with the given order', async () => {
+      const expectedResponse = [{ size: '1000' }, { size: '2000' }];
+
+      jest
+        .spyOn(fileRepository, 'getSumSizeOfTrashedAndExistentFiles')
+        .mockResolvedValue(expectedResponse);
+
+      const result = await service.getTrashedAndExistentFilesSizeSum(
+        createdBy,
+        workspaceId,
+        {
+          ...options,
+          order: [['name', 'ASC']],
+        },
+      );
+
+      expect(
+        fileRepository.getSumSizeOfTrashedAndExistentFiles,
+      ).toHaveBeenCalledWith(
+        createdBy,
+        workspaceId,
+        options.limit,
+        options.offset,
+        [['name', 'ASC']],
+      );
+      expect(result).toEqual(expectedResponse);
+    });
+
+    it('When order is not provided, then it should fetch files size with the default order', async () => {
+      const expectedResponse = [{ size: '3000' }];
+      const defaultOrder = [['uuid', 'ASC']];
+
+      jest
+        .spyOn(fileRepository, 'getSumSizeOfTrashedAndExistentFiles')
+        .mockResolvedValue(expectedResponse);
+
+      const result = await service.getTrashedAndExistentFilesSizeSum(
+        createdBy,
+        workspaceId,
+        { limit: options.limit, offset: options.offset },
+      );
+
+      expect(
+        fileRepository.getSumSizeOfTrashedAndExistentFiles,
+      ).toHaveBeenCalledWith(
+        createdBy,
+        workspaceId,
+        options.limit,
+        options.offset,
+        defaultOrder,
+      );
+      expect(result).toEqual(expectedResponse);
+    });
+  });
 });

--- a/src/modules/file/file.usecase.ts
+++ b/src/modules/file/file.usecase.ts
@@ -313,6 +313,26 @@ export class FileUseCases {
     );
   }
 
+  async getTrashedAndExistentFilesSizeSum(
+    createdBy: UserAttributes['uuid'],
+    workspaceId: WorkspaceAttributes['id'],
+    options: {
+      limit: number;
+      offset: number;
+      order?: Array<[keyof File, string]>;
+    },
+  ) {
+    const fetchOrder = options?.order ?? [['uuid', 'ASC']];
+
+    return this.fileRepository.getSumSizeOfTrashedAndExistentFiles(
+      createdBy,
+      workspaceId,
+      options.limit,
+      options.offset,
+      fetchOrder,
+    );
+  }
+
   async getFilesInWorkspace(
     createdBy: UserAttributes['uuid'],
     workspaceId: WorkspaceAttributes['id'],

--- a/src/modules/file/file.usecase.ts
+++ b/src/modules/file/file.usecase.ts
@@ -313,23 +313,31 @@ export class FileUseCases {
     );
   }
 
-  async getTrashedAndExistentFilesSizeSum(
+  async getWorkspaceFilesSizeSumByStatuses(
     createdBy: UserAttributes['uuid'],
     workspaceId: WorkspaceAttributes['id'],
+    statuses: FileStatus[],
     options: {
       limit: number;
       offset: number;
       order?: Array<[keyof File, string]>;
+      createdFrom?: Date;
+      removedFrom?: Date;
     },
   ) {
     const fetchOrder = options?.order ?? [['uuid', 'ASC']];
 
-    return this.fileRepository.getSumSizeOfTrashedAndExistentFiles(
+    return this.fileRepository.getSumSizeOfFilesByStatuses(
       createdBy,
       workspaceId,
-      options.limit,
-      options.offset,
-      fetchOrder,
+      statuses,
+      {
+        limit: options.limit,
+        offset: options.offset,
+        order: fetchOrder,
+        createdFrom: options?.createdFrom,
+        removedFrom: options?.removedFrom,
+      },
     );
   }
 

--- a/src/modules/workspaces/attributes/workspace-users.attributes.ts
+++ b/src/modules/workspaces/attributes/workspace-users.attributes.ts
@@ -9,6 +9,7 @@ export interface WorkspaceUserAttributes {
   driveUsage: number;
   backupsUsage: number;
   deactivated: boolean;
+  lastUsageSyncAt?: Date;
   createdAt: Date;
   updatedAt: Date;
 }

--- a/src/modules/workspaces/domains/workspace-user.domain.ts
+++ b/src/modules/workspaces/domains/workspace-user.domain.ts
@@ -12,6 +12,7 @@ export class WorkspaceUser implements WorkspaceUserAttributes {
   driveUsage: number;
   backupsUsage: number;
   deactivated: boolean;
+  lastUsageSyncAt?: Date;
   createdAt: Date;
   updatedAt: Date;
 
@@ -25,6 +26,7 @@ export class WorkspaceUser implements WorkspaceUserAttributes {
     driveUsage,
     backupsUsage,
     rootFolderId,
+    lastUsageSyncAt,
     deactivated,
     createdAt,
     updatedAt,
@@ -39,6 +41,7 @@ export class WorkspaceUser implements WorkspaceUserAttributes {
     this.backupsUsage = Number(backupsUsage ?? 0);
     this.deactivated = deactivated;
     this.rootFolderId = rootFolderId;
+    this.lastUsageSyncAt = lastUsageSyncAt;
     this.createdAt = createdAt;
     this.updatedAt = updatedAt;
   }

--- a/src/modules/workspaces/models/workspace-users.model.ts
+++ b/src/modules/workspaces/models/workspace-users.model.ts
@@ -70,6 +70,9 @@ export class WorkspaceUserModel
   @Column(DataType.BOOLEAN)
   deactivated: boolean;
 
+  @Column(DataType.DATE)
+  lastUsageSyncAt: Date;
+
   @Column
   createdAt: Date;
 

--- a/src/modules/workspaces/repositories/workspaces.repository.ts
+++ b/src/modules/workspaces/repositories/workspaces.repository.ts
@@ -19,7 +19,7 @@ import {
 } from '../attributes/workspace-items-users.attributes';
 import { WorkspaceItemUser } from '../domains/workspace-item-user.domain';
 import { FileModel } from '../../file/file.model';
-import { FileAttributes } from '../../file/file.domain';
+import { FileAttributes, FileStatus } from '../../file/file.domain';
 import { FolderAttributes } from '../../folder/folder.domain';
 import { Op } from 'sequelize';
 import { FolderModel } from '../../folder/folder.model';
@@ -389,6 +389,15 @@ export class SequelizeWorkspaceRepository {
   ): Promise<void> {
     await this.modelWorkspaceUser.update(update, {
       where: { id: workspaceUserId },
+    });
+  }
+
+  async updateWorkspaceUserBy(
+    where: Partial<WorkspaceUserAttributes>,
+    update: Partial<WorkspaceUserAttributes>,
+  ): Promise<void> {
+    await this.modelWorkspaceUser.update(update, {
+      where,
     });
   }
 

--- a/src/modules/workspaces/repositories/workspaces.repository.ts
+++ b/src/modules/workspaces/repositories/workspaces.repository.ts
@@ -19,7 +19,7 @@ import {
 } from '../attributes/workspace-items-users.attributes';
 import { WorkspaceItemUser } from '../domains/workspace-item-user.domain';
 import { FileModel } from '../../file/file.model';
-import { FileAttributes, FileStatus } from '../../file/file.domain';
+import { FileAttributes } from '../../file/file.domain';
 import { FolderAttributes } from '../../folder/folder.domain';
 import { Op } from 'sequelize';
 import { FolderModel } from '../../folder/folder.model';

--- a/src/modules/workspaces/workspaces.controller.ts
+++ b/src/modules/workspaces/workspaces.controller.ts
@@ -449,6 +449,25 @@ export class WorkspacesController {
     return this.workspaceUseCases.getWorkspaceTeams(user, workspaceId);
   }
 
+  @Get('/:workspaceId/usage')
+  @ApiOperation({
+    summary: 'User usage in drive',
+  })
+  @ApiBearerAuth()
+  @ApiParam({ name: 'workspaceId', type: String, required: true })
+  @ApiOkResponse({
+    description: 'User usage in drive',
+  })
+  @UseGuards(WorkspaceGuard)
+  @WorkspaceRequiredAccess(AccessContext.WORKSPACE, WorkspaceRole.MEMBER)
+  async calculateUserUsage(
+    @Param('workspaceId', ValidateUUIDPipe)
+    workspaceId: WorkspaceAttributes['id'],
+    @UserDecorator() user: User,
+  ) {
+    return this.workspaceUseCases.getUserUsageInWorkspace(user, workspaceId);
+  }
+
   @Post('/:workspaceId/files')
   @ApiOperation({
     summary: 'Create File',

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -401,6 +401,7 @@ export const newWorkspaceUser = (params?: {
     key: randomDataGenerator.string({ length: 32 }),
     workspaceId: params?.workspaceId || v4(),
     spaceLimit: spaceLimit,
+    lastUsageSyncAt: new Date(),
     driveUsage: 0,
     backupsUsage: 0,
     deactivated: false,


### PR DESCRIPTION
Due to the current files and folders structure, and the files being removed using a background process when the parent folder is deleted. We need a way to calculate the workspace member's usage on the fly. 

However, using a sum of all the files with TRASHED or EXISTS status would affect the scalability of the request, so we need to manage it using  a sort of "caching" with the last_sync_at date.  This it is just a temporal solution and it should be modified once the deltas solution is implemented.