### PR TITLE
[_] chore: use substring operator instead of literals

### DIFF
--- a/src/modules/workspaces/repositories/workspaces.repository.spec.ts
+++ b/src/modules/workspaces/repositories/workspaces.repository.spec.ts
@@ -295,7 +295,7 @@ describe('SequelizeWorkspaceRepository', () => {
           [Op.or]: expect.arrayContaining([
             expect.objectContaining({
               '$member.lastname$': {
-                [Op.like]: Sequelize.literal(`\'%${searchValue}%\'`),
+                [Op.substring]: searchValue,
               },
             }),
           ]),

--- a/src/modules/workspaces/repositories/workspaces.repository.ts
+++ b/src/modules/workspaces/repositories/workspaces.repository.ts
@@ -341,17 +341,17 @@ export class SequelizeWorkspaceRepository {
             [Op.or]: [
               {
                 '$member.name$': {
-                  [Op.like]: Sequelize.literal(`\'%${search}%\'`),
+                  [Op.substring]: search,
                 },
               },
               {
                 '$member.lastname$': {
-                  [Op.like]: Sequelize.literal(`\'%${search}%\'`),
+                  [Op.substring]: search,
                 },
               },
               {
                 '$member.email$': {
-                  [Op.like]: Sequelize.literal(`\'%${search}%\'`),
+                  [Op.substring]: search,
                 },
               },
             ],


### PR DESCRIPTION
This is to dismiss this warning and to use the operators the library provides us with

![image](https://github.com/internxt/drive-server-wip/assets/143480783/fa77959d-8a2c-4c6b-b863-2758a580f396)

Query with substring operator
![image](https://github.com/internxt/drive-server-wip/assets/143480783/7c83d6bc-bc29-46cd-99ef-1c24b850f094)

Query with sequelize literal and interpolating variables

![image](https://github.com/internxt/drive-server-wip/assets/143480783/9eaf218e-5e8b-4699-8e94-fcb714976920)


