### PR TITLE
[PB-2248] feat: get folder contents with uuid

### DIFF
--- a/src/modules/folder/folder.domain.spec.ts
+++ b/src/modules/folder/folder.domain.spec.ts
@@ -1,4 +1,5 @@
 import { newFolder } from '../../../test/fixtures';
+import { FolderStatus } from './folder.domain';
 
 describe('Folder domain', () => {
   it('When the trash check helper is called, then it reflects the trash status of the folder', () => {
@@ -22,5 +23,25 @@ describe('Folder domain', () => {
     const folder = newFolder({ attributes: { deleted: true, removed: true } });
 
     expect(folder.isTrashed()).toBe(false);
+  });
+
+  it('When the folder is removed, then the folder status returns as deleted', () => {
+    const folder = newFolder({ attributes: { removed: true } });
+
+    expect(folder.getFolderStatus()).toBe(FolderStatus.DELETED);
+  });
+
+  it('When the folder is deleted, then the folder status returns as trashed', () => {
+    const folder = newFolder({ attributes: { deleted: true } });
+
+    expect(folder.getFolderStatus()).toBe(FolderStatus.TRASHED);
+  });
+
+  it('When the folder is neither deleted or removed, then the folder status returns as exists', () => {
+    const folder = newFolder({
+      attributes: { removed: false, deleted: false },
+    });
+
+    expect(folder.getFolderStatus()).toBe(FolderStatus.EXISTS);
   });
 });

--- a/src/modules/folder/folder.domain.ts
+++ b/src/modules/folder/folder.domain.ts
@@ -8,6 +8,11 @@ export type SortableFolderAttributes = keyof Pick<
   'id' | 'name' | 'plainName' | 'updatedAt'
 >;
 
+export enum FolderStatus {
+  EXISTS = 'EXISTS',
+  TRASHED = 'TRASHED',
+  DELETED = 'DELETED',
+}
 export interface FolderOptions {
   deleted: FolderAttributes['deleted'];
   removed?: FolderAttributes['removed'];
@@ -88,6 +93,18 @@ export class Folder implements FolderAttributes {
   moveToTrash() {
     this.deleted = true;
     this.deletedAt = new Date();
+  }
+
+  getFolderStatus() {
+    let folderStatus = FolderStatus.EXISTS;
+
+    if (this.removed) {
+      folderStatus = FolderStatus.DELETED;
+    } else if (this.deleted) {
+      folderStatus = FolderStatus.TRASHED;
+    }
+
+    return folderStatus;
   }
 
   removeFromTrash() {


### PR DESCRIPTION
The frontend uses this [endpoint](https://github.com/internxt/drive-server/blob/1a5400fe7da249ea96ff4423e228d9f6d25a90f1/src/app/routes/storage.ts#L838) to check if a file or folder with the same name already exists in the location (and maybe other usecases). They need the same endpoints to switch from ID to UUID usage.