### PR TITLE
[_]: fix/ createFile fix and rootFolderId as uuid when client is drive-web

### DIFF
--- a/src/modules/file/file.usecase.ts
+++ b/src/modules/file/file.usecase.ts
@@ -93,7 +93,7 @@ export class FileUseCases {
     const maybeAlreadyExistentFile = await this.fileRepository.findOneBy({
       name: newFileDto.name,
       folderId: folder.id,
-      type: newFileDto.type,
+      ...(newFileDto.type ? { type: newFileDto.type } : null),
       userId: user.id,
       status: FileStatus.EXISTS,
     });

--- a/src/modules/user/user.controller.ts
+++ b/src/modules/user/user.controller.ts
@@ -98,6 +98,8 @@ export class UserController {
     @Req() req: Request,
     @Res({ passthrough: true }) res: Response,
   ) {
+    const isDriveWeb = req.headers['internxt-client'] === 'drive-web';
+
     try {
       const response = await this.userUseCases.createUser(createUserDto);
       const keys = await this.keyServerUseCases.addKeysToUser(
@@ -137,6 +139,9 @@ export class UserController {
         user: {
           ...response.user,
           root_folder_id: response.user.rootFolderId,
+          ...(isDriveWeb
+            ? { rootFolderId: response.user.rootFolderUuid }
+            : null),
           ...keys,
         },
         token: response.token,

--- a/src/modules/user/user.usecase.ts
+++ b/src/modules/user/user.usecase.ts
@@ -417,11 +417,12 @@ export class UserUseCases {
           password: user.password.toString(),
           mnemonic: user.mnemonic.toString(),
           rootFolderId: rootFolder.id,
+          rootFolderUuid: rootFolder.uuid,
           bucket: bucket.id,
           uuid: userUuid,
           userId: networkPass,
           hasReferralsProgram: false,
-        } as unknown as User,
+        } as unknown as User & { rootFolderUuid: string },
         uuid: userUuid,
       };
     } catch (err) {


### PR DESCRIPTION
Drive-web is migrating to use uuids, they need to get the rootFolder uuid when the user is created.

Also, fixed a bug that was making the endpoint fail when type is missing.