### PR TITLE
[BR-191]: fix: folder size now is being calculated correctly

### DIFF
--- a/src/modules/folder/folder.repository.spec.ts
+++ b/src/modules/folder/folder.repository.spec.ts
@@ -35,32 +35,30 @@ describe('SequelizeFolderRepository', () => {
         SELECT 
             fl1.uuid,
             fl1.parent_uuid,
-            f1.size AS filesize,
+            COALESCE(f1.size, 0) AS filesize,
             1 AS row_num,
             fl1.user_id as owner_id
         FROM folders fl1
-        LEFT JOIN files f1 ON f1.folder_uuid = fl1.uuid
+        LEFT JOIN files f1 ON f1.folder_uuid = fl1.uuid AND f1.status != 'DELETED'
         WHERE fl1.uuid = :folderUuid
-        AND fl1.removed = FALSE 
-        AND fl1.deleted = FALSE
-        AND f1.status != 'DELETED'
+          AND fl1.removed = FALSE 
+          AND fl1.deleted = FALSE
         
         UNION ALL
         
         SELECT 
             fl2.uuid,
             fl2.parent_uuid,
-            f2.size AS filesize,
+            COALESCE(f2.size, 0) AS filesize,
             fr.row_num + 1,
             fr.owner_id
         FROM folders fl2
-        INNER JOIN files f2 ON f2.folder_uuid = fl2.uuid
+        LEFT JOIN files f2 ON f2.folder_uuid = fl2.uuid AND f2.status != 'DELETED'
         INNER JOIN folder_recursive fr ON fr.uuid = fl2.parent_uuid
         WHERE fr.row_num < 100000
-        AND fl2.user_id = fr.owner_id
-        AND fl2.removed = FALSE 
-        AND fl2.deleted = FALSE
-        AND f2.status != 'DELETED'
+          AND fl2.user_id = fr.owner_id
+          AND fl2.removed = FALSE 
+          AND fl2.deleted = FALSE
     ) 
     SELECT COALESCE(SUM(filesize), 0) AS totalsize FROM folder_recursive;
       `;

--- a/src/modules/folder/folder.repository.spec.ts
+++ b/src/modules/folder/folder.repository.spec.ts
@@ -4,6 +4,7 @@ import { SequelizeFolderRepository } from './folder.repository';
 import { FolderModel } from './folder.model';
 import { Folder } from './folder.domain';
 import { newFolder } from '../../../test/fixtures';
+import { FileStatus } from '../file/file.domain';
 
 jest.mock('./folder.model', () => ({
   FolderModel: {
@@ -39,7 +40,7 @@ describe('SequelizeFolderRepository', () => {
             1 AS row_num,
             fl1.user_id as owner_id
         FROM folders fl1
-        LEFT JOIN files f1 ON f1.folder_uuid = fl1.uuid AND f1.status != 'DELETED'
+        LEFT JOIN files f1 ON f1.folder_uuid = fl1.uuid AND f1.status IN (:fileStatusCondition)
         WHERE fl1.uuid = :folderUuid
           AND fl1.removed = FALSE 
           AND fl1.deleted = FALSE
@@ -53,7 +54,7 @@ describe('SequelizeFolderRepository', () => {
             fr.row_num + 1,
             fr.owner_id
         FROM folders fl2
-        LEFT JOIN files f2 ON f2.folder_uuid = fl2.uuid AND f2.status != 'DELETED'
+        LEFT JOIN files f2 ON f2.folder_uuid = fl2.uuid AND f2.status IN (:fileStatusCondition)
         INNER JOIN folder_recursive fr ON fr.uuid = fl2.parent_uuid
         WHERE fr.row_num < 100000
           AND fl2.user_id = fr.owner_id
@@ -75,9 +76,23 @@ describe('SequelizeFolderRepository', () => {
         {
           replacements: {
             folderUuid: folder.uuid,
+            fileStatusCondition: [FileStatus.EXISTS, FileStatus.TRASHED],
           },
         },
       );
+    });
+
+    it('When calculate folder size is requested without trashed files, then it should only request existent files', async () => {
+      const folderModelSpy = jest.spyOn(FolderModel.sequelize, 'query');
+
+      await repository.calculateFolderSize(folder.uuid, false);
+
+      expect(folderModelSpy).toHaveBeenCalledWith(expect.any(String), {
+        replacements: {
+          folderUuid: folder.uuid,
+          fileStatusCondition: [FileStatus.EXISTS],
+        },
+      });
     });
 
     it('When the folder size calculation times out, then throw an exception', async () => {

--- a/src/modules/folder/folder.usecase.spec.ts
+++ b/src/modules/folder/folder.usecase.spec.ts
@@ -617,6 +617,24 @@ describe('FolderUseCases', () => {
       expect(folderRepository.calculateFolderSize).toHaveBeenCalledTimes(1);
       expect(folderRepository.calculateFolderSize).toHaveBeenCalledWith(
         folder.uuid,
+        true,
+      );
+    });
+
+    it('When the folder size is required without including trashed files, then it should request the size without trash', async () => {
+      const mockSize = 123456789;
+
+      jest
+        .spyOn(folderRepository, 'calculateFolderSize')
+        .mockResolvedValueOnce(mockSize);
+
+      const result = await service.getFolderSizeByUuid(folder.uuid, false);
+
+      expect(result).toBe(mockSize);
+      expect(folderRepository.calculateFolderSize).toHaveBeenCalledTimes(1);
+      expect(folderRepository.calculateFolderSize).toHaveBeenCalledWith(
+        folder.uuid,
+        false,
       );
     });
 

--- a/src/modules/folder/folder.usecase.ts
+++ b/src/modules/folder/folder.usecase.ts
@@ -316,7 +316,9 @@ export class FolderUseCases {
     const folders = foldersById.concat(foldersByUuid);
 
     const backups = folders.filter((f) => f.isBackup(driveRootFolder));
-    const driveFolders = folders.filter((f) => !f.isBackup(driveRootFolder) && f.id !== user.rootFolderId);
+    const driveFolders = folders.filter(
+      (f) => !f.isBackup(driveRootFolder) && f.id !== user.rootFolderId,
+    );
 
     await Promise.all([
       driveFolders.length > 0
@@ -632,7 +634,13 @@ export class FolderUseCases {
     await this.folderRepository.deleteByUser(user, folders);
   }
 
-  getFolderSizeByUuid(folderUuid: Folder['uuid']): Promise<number> {
-    return this.folderRepository.calculateFolderSize(folderUuid);
+  getFolderSizeByUuid(
+    folderUuid: Folder['uuid'],
+    includeTrashedFiles = true,
+  ): Promise<number> {
+    return this.folderRepository.calculateFolderSize(
+      folderUuid,
+      includeTrashedFiles,
+    );
   }
 }

--- a/src/modules/sharing/sharing.service.ts
+++ b/src/modules/sharing/sharing.service.ts
@@ -2089,6 +2089,6 @@ export class SharingService {
       throw new SharingNotFoundException();
     }
 
-    return this.folderUsecases.getFolderSizeByUuid(sharing.itemId);
+    return this.folderUsecases.getFolderSizeByUuid(sharing.itemId, false);
   }
 }


### PR DESCRIPTION
The size was not being calculated correctly when folders only contained subfolders without any files.

The previous query used an INNER JOIN combined with a WHERE condition for the files, which excluded folders (and their subfolders and files) if they did not contain any files.

This PR changes the INNER JOIN to a RIGHT JOIN and moves the FILE.STATUS != 'DELETED' condition to the join clause.

Additionally, there was a small bug in this query (primarily used for public sharings). When a folder is shared, users should not download TRASHED files, so including them in the total size calculation is incorrect.

**A small improvement outside of the ticket scope:**

Due to the nature of this query, which fails when 1000 rows have been calculated, I suggest adding a field in the response to indicate to the frontend that the totalSize might not be accurate if rows_number equals 1000.