### PR TITLE
feat: added workspace usage and change member assigned space endpoints

### DIFF
--- a/src/modules/workspaces/dto/change-user-assigned-space.dto.ts
+++ b/src/modules/workspaces/dto/change-user-assigned-space.dto.ts
@@ -1,0 +1,13 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsPositive } from 'class-validator';
+import { WorkspaceInvite } from '../domains/workspace-invite.domain';
+
+export class ChangeUserAssignedSpaceDto {
+  @ApiProperty({
+    example: '1073741824',
+    description: 'New Space assigned to user in bytes',
+  })
+  @IsNotEmpty()
+  @IsPositive()
+  spaceLimit: WorkspaceInvite['spaceLimit'];
+}

--- a/src/modules/workspaces/repositories/workspaces.repository.ts
+++ b/src/modules/workspaces/repositories/workspaces.repository.ts
@@ -263,6 +263,21 @@ export class SequelizeWorkspaceRepository {
     return total ?? 0;
   }
 
+  async getTotalDriveAndBackupUsageWorkspaceUsers(
+    workspaceId: WorkspaceAttributes['id'],
+  ): Promise<number> {
+    const [backupsUsageTotal, driveUsageTotal] = await Promise.all([
+      this.modelWorkspaceUser.sum('backupsUsage', {
+        where: { workspaceId },
+      }),
+      this.modelWorkspaceUser.sum('driveUsage', {
+        where: { workspaceId },
+      }),
+    ]);
+
+    return backupsUsageTotal + driveUsageTotal;
+  }
+
   async createInvite(
     invite: Omit<WorkspaceInvite, 'id'>,
   ): Promise<WorkspaceInvite | null> {

--- a/src/modules/workspaces/workspaces.controller.ts
+++ b/src/modules/workspaces/workspaces.controller.ts
@@ -57,6 +57,8 @@ import { avatarStorageS3Config } from '../../externals/multer';
 import { WorkspaceInvitationsPagination } from './dto/workspace-invitations-pagination.dto';
 import { ExtendedHttpExceptionFilter } from '../../common/http-exception-filter-extended.exception';
 import { WorkspaceItemType } from './attributes/workspace-items-users.attributes';
+import { WorkspaceUserAttributes } from './attributes/workspace-users.attributes';
+import { ChangeUserAssignedSpaceDto } from './dto/change-user-assigned-space.dto';
 
 @ApiTags('Workspaces')
 @Controller('workspaces')
@@ -364,6 +366,50 @@ export class WorkspacesController {
     workspaceId: WorkspaceAttributes['id'],
   ) {
     return this.workspaceUseCases.getWorkspaceCredentials(workspaceId);
+  }
+
+  @Get('/:workspaceId/usage')
+  @ApiOperation({
+    summary: 'Gets workspace usage',
+  })
+  @ApiBearerAuth()
+  @ApiParam({ name: 'workspaceId', type: String, required: true })
+  @ApiOkResponse({
+    description: 'Returns workspace usage',
+  })
+  @UseGuards(WorkspaceGuard)
+  @WorkspaceRequiredAccess(AccessContext.WORKSPACE, WorkspaceRole.OWNER)
+  async getWorkspaceStorageUsage(
+    @Param('workspaceId', ValidateUUIDPipe)
+    workspaceId: WorkspaceAttributes['id'],
+  ) {
+    const workspace = await this.workspaceUseCases.findById(workspaceId);
+
+    if (!workspace) {
+      throw new BadRequestException('Workspace not valid');
+    }
+
+    return this.workspaceUseCases.getWorkspaceUsage(workspace);
+  }
+
+  @Patch('/:workspaceId/members/:memberId/usage')
+  @ApiOperation({
+    summary: 'Change workspace member assigned space',
+  })
+  @ApiBearerAuth()
+  @ApiParam({ name: 'workspaceId', type: String, required: true })
+  @UseGuards(WorkspaceGuard)
+  @WorkspaceRequiredAccess(AccessContext.WORKSPACE, WorkspaceRole.OWNER)
+  async changeMemberAssignedSpace(
+    @Param('workspaceId') workspaceId: WorkspaceAttributes['id'],
+    @Param('memberId') memberId: WorkspaceUserAttributes['memberId'],
+    @Body() assignSpaceToUserDto: ChangeUserAssignedSpaceDto,
+  ) {
+    return this.workspaceUseCases.changeUserAssignedSpace(
+      workspaceId,
+      memberId,
+      assignSpaceToUserDto,
+    );
   }
 
   @Get('/:workspaceId/members')


### PR DESCRIPTION
This PR is to unblock the frontend team. I am going to add another PR with the respective tests and required refactors afterwards (tomorrow).

Added endpoint to get the total used storage in the workspace and another endpoint to change the users assigned space.

