### PR TITLE
[PB-2284]: Feat/register notification token endpoint

### DIFF
--- a/migrations/20240624200747-create-user-tokens-table.js
+++ b/migrations/20240624200747-create-user-tokens-table.js
@@ -5,39 +5,49 @@ const tableName = 'user_notification_tokens';
 /** @type {import('sequelize-cli').Migration} */
 module.exports = {
   async up(queryInterface, Sequelize) {
-    await queryInterface.createTable(tableName, {
-      id: {
-        type: Sequelize.UUID,
-        primaryKey: true,
-        defaultValue: Sequelize.UUIDV4,
-      },
-      user_id: {
-        type: Sequelize.STRING(36),
-        allowNull: false,
-        references: {
-          model: 'users',
-          key: 'uuid',
+    await queryInterface.createTable(
+      tableName,
+      {
+        id: {
+          type: Sequelize.UUID,
+          primaryKey: true,
+          defaultValue: Sequelize.UUIDV4,
+        },
+        user_id: {
+          type: Sequelize.STRING(36),
+          allowNull: false,
+          references: {
+            model: 'users',
+            key: 'uuid',
+          },
+        },
+        token: {
+          type: Sequelize.STRING,
+          allowNull: false,
+        },
+        type: {
+          type: Sequelize.ENUM('macos', 'android', 'ios'),
+          allowNull: false,
+        },
+        created_at: {
+          type: Sequelize.DATE,
+          allowNull: false,
+          defaultValue: Sequelize.NOW,
+        },
+        updated_at: {
+          type: Sequelize.DATE,
+          allowNull: false,
+          defaultValue: Sequelize.NOW,
         },
       },
-      token: {
-        type: Sequelize.STRING,
-        allowNull: false,
+      {
+        uniqueKeys: {
+          user_token_type_unique_constraint: {
+            fields: ['user_id', 'token', 'type'],
+          },
+        },
       },
-      type: {
-        type: Sequelize.ENUM('macos', 'android', 'ios'),
-        allowNull: false,
-      },
-      created_at: {
-        type: Sequelize.DATE,
-        allowNull: false,
-        defaultValue: Sequelize.NOW,
-      },
-      updated_at: {
-        type: Sequelize.DATE,
-        allowNull: false,
-        defaultValue: Sequelize.NOW,
-      },
-    });
+    );
   },
 
   async down(queryInterface) {

--- a/migrations/20240624200747-create-user-tokens-table.js
+++ b/migrations/20240624200747-create-user-tokens-table.js
@@ -1,0 +1,46 @@
+'use strict';
+
+const tableName = 'user_notification_tokens';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.createTable(tableName, {
+      id: {
+        type: Sequelize.UUID,
+        primaryKey: true,
+        defaultValue: Sequelize.UUIDV4,
+      },
+      user_id: {
+        type: Sequelize.STRING(36),
+        allowNull: false,
+        references: {
+          model: 'users',
+          key: 'uuid',
+        },
+      },
+      token: {
+        type: Sequelize.STRING,
+        allowNull: false,
+      },
+      type: {
+        type: Sequelize.ENUM('macos', 'android', 'ios'),
+        allowNull: false,
+      },
+      created_at: {
+        type: Sequelize.DATE,
+        allowNull: false,
+        defaultValue: Sequelize.NOW,
+      },
+      updated_at: {
+        type: Sequelize.DATE,
+        allowNull: false,
+        defaultValue: Sequelize.NOW,
+      },
+    });
+  },
+
+  async down(queryInterface) {
+    await queryInterface.dropTable(tableName);
+  },
+};

--- a/src/modules/share/share.module.ts
+++ b/src/modules/share/share.module.ts
@@ -16,6 +16,7 @@ import { ShareUseCases } from './share.usecase';
 import { ThumbnailModule } from '../thumbnail/thumbnail.module';
 import { ThumbnailModel } from '../thumbnail/thumbnail.model';
 import { FileModel } from '../file/file.model';
+import { UserNotificationTokensModel } from '../user/user-notification-tokens.model';
 
 @Module({
   imports: [
@@ -25,6 +26,7 @@ import { FileModel } from '../file/file.model';
       FolderModel,
       UserModel,
       ThumbnailModel,
+      UserNotificationTokensModel,
     ]),
     forwardRef(() => FileModule),
     forwardRef(() => FolderModule),

--- a/src/modules/user/dto/register-notification-token.dto.ts
+++ b/src/modules/user/dto/register-notification-token.dto.ts
@@ -1,0 +1,25 @@
+import { IsEnum, IsNotEmpty } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+
+export enum DeviceType {
+  macos = 'macos',
+  android = 'android',
+  ios = 'ios',
+}
+
+export class RegisterNotificationTokenDto {
+  @IsNotEmpty()
+  @ApiProperty({
+    example: '0f8fad5b-d9cb-469f-a165-70867728950e',
+    description: 'device token',
+  })
+  token: string;
+
+  @IsNotEmpty()
+  @ApiProperty({
+    example: 'macos',
+    description: 'device type',
+  })
+  @IsEnum(DeviceType)
+  type: DeviceType;
+}

--- a/src/modules/user/user-notification-tokens.attribute.ts
+++ b/src/modules/user/user-notification-tokens.attribute.ts
@@ -1,0 +1,8 @@
+export interface UserNotificationTokenAttributes {
+  id: string;
+  userId: string;
+  token: string;
+  type: 'macos' | 'android' | 'ios';
+  createdAt: Date;
+  updatedAt: Date;
+}

--- a/src/modules/user/user-notification-tokens.domain.ts
+++ b/src/modules/user/user-notification-tokens.domain.ts
@@ -1,0 +1,43 @@
+import { UserNotificationTokenAttributes } from './user-notification-tokens.attribute';
+
+export class UserNotificationTokens implements UserNotificationTokenAttributes {
+  id: string;
+  userId: string;
+  token: string;
+  type: 'macos' | 'android' | 'ios';
+  createdAt: Date;
+  updatedAt: Date;
+
+  constructor({
+    id,
+    userId,
+    token,
+    type,
+    createdAt,
+    updatedAt,
+  }: UserNotificationTokenAttributes) {
+    this.id = id;
+    this.userId = userId;
+    this.token = token;
+    this.type = type;
+    this.createdAt = createdAt;
+    this.updatedAt = updatedAt;
+  }
+
+  static build(
+    attributes: UserNotificationTokenAttributes,
+  ): UserNotificationTokens {
+    return new UserNotificationTokens(attributes);
+  }
+
+  toJSON() {
+    return {
+      id: this.id,
+      userId: this.userId,
+      token: this.token,
+      type: this.type,
+      createdAt: this.createdAt,
+      updatedAt: this.updatedAt,
+    };
+  }
+}

--- a/src/modules/user/user-notification-tokens.model.ts
+++ b/src/modules/user/user-notification-tokens.model.ts
@@ -1,0 +1,44 @@
+import {
+  Model,
+  Table,
+  Column,
+  DataType,
+  PrimaryKey,
+  ForeignKey,
+  BelongsTo,
+} from 'sequelize-typescript';
+import { UserModel } from './user.model';
+import { UserNotificationTokenAttributes } from './user-notification-tokens.attribute';
+
+@Table({
+  tableName: 'user_notification_tokens',
+  underscored: true,
+  timestamps: true,
+})
+export class UserNotificationTokensModel
+  extends Model
+  implements UserNotificationTokenAttributes
+{
+  @PrimaryKey
+  @Column({ type: DataType.UUID, defaultValue: DataType.UUIDV4 })
+  id: string;
+
+  @ForeignKey(() => UserModel)
+  @Column({ type: DataType.UUID, allowNull: false })
+  userId: string;
+
+  @BelongsTo(() => UserModel)
+  user: UserModel;
+
+  @Column({ type: DataType.STRING, allowNull: false })
+  token: string;
+
+  @Column({ type: DataType.ENUM('macos', 'android', 'ios'), allowNull: false })
+  type: 'macos' | 'android' | 'ios';
+
+  @Column({ allowNull: false, defaultValue: DataType.NOW })
+  createdAt: Date;
+
+  @Column({ allowNull: false, defaultValue: DataType.NOW })
+  updatedAt: Date;
+}

--- a/src/modules/user/user.controller.spec.ts
+++ b/src/modules/user/user.controller.spec.ts
@@ -15,6 +15,7 @@ import { SignWithCustomDuration } from '../../middlewares/passport';
 import { generateBase64PrivateKeyStub, newUser } from '../../../test/fixtures';
 import { AccountTokenAction } from './user.domain';
 import { v4 } from 'uuid';
+import { DeviceType } from './dto/register-notification-token.dto';
 
 jest.mock('../../config/configuration', () => {
   return {
@@ -189,6 +190,19 @@ describe('User Controller', () => {
       await expect(userController.getMeetTokenAnon(v4())).rejects.toThrow(
         ForbiddenException,
       );
+    });
+  });
+
+  describe('POST /notification-token', () => {
+    const user = newUser();
+    it('When notification token is added, then it adds the token', async () => {
+      userUseCases.registerUserNotificationToken.mockResolvedValueOnce();
+      await expect(
+        userController.addNotificationToken(user, {
+          token: 'test',
+          type: DeviceType.macos,
+        }),
+      ).resolves.toBeUndefined();
     });
   });
 });

--- a/src/modules/user/user.controller.ts
+++ b/src/modules/user/user.controller.ts
@@ -28,6 +28,7 @@ import {
   ApiOkResponse,
   ApiOperation,
   ApiParam,
+  ApiResponse,
   ApiTags,
 } from '@nestjs/swagger';
 import { Public } from '../auth/decorators/public.decorator';
@@ -784,11 +785,11 @@ export class UserController {
 
   @Post('/notification-token')
   @HttpCode(201)
+  @ApiBearerAuth()
   @ApiOperation({
     summary: 'Add a notification token',
   })
-  @ApiOkResponse({ description: 'Creates a notification token' })
-  @Public()
+  @ApiResponse({ status: 201, description: 'Creates a notification token' })
   async addNotificationToken(
     @UserDecorator() user: User,
     @Body() body: RegisterNotificationTokenDto,

--- a/src/modules/user/user.controller.ts
+++ b/src/modules/user/user.controller.ts
@@ -66,6 +66,7 @@ import { SharingService } from '../sharing/sharing.service';
 import { CreateAttemptChangeEmailDto } from './dto/create-attempt-change-email.dto';
 import { HttpExceptionFilter } from '../../lib/http/http-exception.filter';
 import { RequestAccountUnblock } from './dto/account-unblock.dto';
+import { RegisterNotificationTokenDto } from './dto/register-notification-token.dto';
 
 @ApiTags('User')
 @Controller('users')
@@ -779,5 +780,19 @@ export class UserController {
       const token = generateJitsiJWT(null, room, false);
       return { token };
     }
+  }
+
+  @Post('/notification-token')
+  @HttpCode(201)
+  @ApiOperation({
+    summary: 'Add a notification token',
+  })
+  @ApiOkResponse({ description: 'Creates a notification token' })
+  @Public()
+  async addNotificationToken(
+    @UserDecorator() user: User,
+    @Body() body: RegisterNotificationTokenDto,
+  ) {
+    return this.userUseCases.registerUserNotificationToken(user, body);
   }
 }

--- a/src/modules/user/user.controller.ts
+++ b/src/modules/user/user.controller.ts
@@ -783,6 +783,7 @@ export class UserController {
     }
   }
 
+  @UseGuards(ThrottlerGuard)
   @Post('/notification-token')
   @HttpCode(201)
   @ApiBearerAuth()

--- a/src/modules/user/user.model.ts
+++ b/src/modules/user/user.model.ts
@@ -10,10 +10,12 @@ import {
   BelongsTo,
   ForeignKey,
   Unique,
+  HasMany,
 } from 'sequelize-typescript';
 
 import { FolderModel } from '../folder/folder.model';
 import { UserAttributes } from './user.attributes';
+import { UserNotificationTokensModel } from './user-notification-tokens.model';
 
 @Table({
   underscored: true,
@@ -129,4 +131,7 @@ export class UserModel extends Model implements UserAttributes {
   @AllowNull(false)
   @Column
   emailVerified: boolean;
+
+  @HasMany(() => UserNotificationTokensModel)
+  notificationTokens: UserNotificationTokensModel[];
 }

--- a/src/modules/user/user.module.ts
+++ b/src/modules/user/user.module.ts
@@ -44,6 +44,7 @@ import { AttemptChangeEmailModel } from './attempt-change-email.model';
 import { MailerService } from '../../externals/mailer/mailer.service';
 import { SecurityModule } from '../security/security.module';
 import { FeatureLimitModule } from '../feature-limit/feature-limit.module';
+import { UserNotificationTokensModel } from './user-notification-tokens.model';
 
 @Module({
   imports: [
@@ -55,6 +56,7 @@ import { FeatureLimitModule } from '../feature-limit/feature-limit.module';
       FriendInvitationModel,
       KeyServerModel,
       AttemptChangeEmailModel,
+      UserNotificationTokensModel,
     ]),
     forwardRef(() => FolderModule),
     forwardRef(() => FileModule),

--- a/src/modules/user/user.repository.ts
+++ b/src/modules/user/user.repository.ts
@@ -34,6 +34,7 @@ export interface UserRepository {
   setRoomToBetaUser(room: string, user: User): Promise<void>;
   getBetaUserFromRoom(room: string): Promise<User | null>;
   getNotificationTokens(userId: string): Promise<UserNotificationTokens[]>;
+  getNotificationTokenCount(userId: string): Promise<number>;
 }
 
 @Injectable()
@@ -193,9 +194,10 @@ export class SequelizeUserRepository implements UserRepository {
 
   async getNotificationTokens(
     userId: string,
+    where?: Partial<Omit<UserNotificationTokens, 'userId'>>,
   ): Promise<UserNotificationTokens[]> {
     const tokens = await this.modelUserNotificationTokens.findAll({
-      where: { userId },
+      where: { userId, ...where },
     });
 
     return tokens.map((token) => UserNotificationTokens.build(token.toJSON()));
@@ -211,6 +213,10 @@ export class SequelizeUserRepository implements UserRepository {
       token,
       type,
     });
+  }
+
+  async getNotificationTokenCount(userId: string): Promise<number> {
+    return this.modelUserNotificationTokens.count({ where: { userId } });
   }
 
   toDomain(model: UserModel): User {

--- a/src/modules/user/user.usecase.spec.ts
+++ b/src/modules/user/user.usecase.spec.ts
@@ -654,10 +654,11 @@ describe('User use cases', () => {
   describe('getUserNotificationTokens', () => {
     it("When getting notification tokens, Then it should return the user's tokens", async () => {
       const user = newUser();
-      const mockTokens: UserNotificationTokens[] = [];
-      for (let i = 0; i < 3; i++) {
-        mockTokens.push(newNotificationToken());
-      }
+      const mockTokens: UserNotificationTokens[] = [
+        newNotificationToken(),
+        newNotificationToken(),
+      ];
+
       jest
         .spyOn(userRepository, 'getNotificationTokens')
         .mockResolvedValueOnce(mockTokens);

--- a/src/modules/user/user.usecase.spec.ts
+++ b/src/modules/user/user.usecase.spec.ts
@@ -604,15 +604,44 @@ describe('User use cases', () => {
   });
 
   describe('registerUserNotificationToken', () => {
+    const body: RegisterNotificationTokenDto = {
+      token: 'token',
+      type: DeviceType.macos,
+    };
+    it('When registering a notification token where the user has 10 tokens, Then it should throw a BadRequestException', async () => {
+      const user = newUser();
+
+      jest
+        .spyOn(userRepository, 'getNotificationTokenCount')
+        .mockResolvedValue(10);
+
+      await expect(
+        userUseCases.registerUserNotificationToken(user, body),
+      ).rejects.toThrow(BadRequestException);
+    });
+    it('When registering a notification token that already exists, Then it should throw a BadRequestException', async () => {
+      const user = newUser();
+
+      jest
+        .spyOn(userRepository, 'getNotificationTokenCount')
+        .mockResolvedValue(0);
+      jest
+        .spyOn(userRepository, 'getNotificationTokens')
+        .mockResolvedValueOnce([newNotificationToken()]);
+
+      await expect(
+        userUseCases.registerUserNotificationToken(user, body),
+      ).rejects.toThrow(BadRequestException);
+    });
     it('When registering a notification token, Then it should call userRepository.addNotificationToken', async () => {
       const user = newUser();
-      const body: RegisterNotificationTokenDto = {
-        token: 'token',
-        type: DeviceType.macos,
-      };
-      await userUseCases.registerUserNotificationToken(user, body);
 
+      jest
+        .spyOn(userRepository, 'getNotificationTokenCount')
+        .mockResolvedValue(0);
       jest.spyOn(userRepository, 'addNotificationToken');
+
+      await userUseCases.registerUserNotificationToken(user, body);
 
       expect(userRepository.addNotificationToken).toHaveBeenCalledWith(
         user.uuid,

--- a/src/modules/user/user.usecase.ts
+++ b/src/modules/user/user.usecase.ts
@@ -1081,10 +1081,31 @@ export class UserUseCases {
   getBetaUserFromRoom(room: string) {
     return this.userRepository.getBetaUserFromRoom(room);
   }
-  registerUserNotificationToken(
+
+  async registerUserNotificationToken(
     user: User,
     registerTokenDto: RegisterNotificationTokenDto,
   ): Promise<void> {
+    const tokenCount = await this.userRepository.getNotificationTokenCount(
+      user.uuid,
+    );
+
+    if (tokenCount >= 10) {
+      throw new BadRequestException('Max token limit reached');
+    }
+
+    const tokenExists = await this.userRepository.getNotificationTokens(
+      user.uuid,
+      {
+        token: registerTokenDto.token,
+        type: registerTokenDto.type,
+      },
+    );
+
+    if (tokenExists.length > 0) {
+      throw new BadRequestException('Token already exists');
+    }
+
     return this.userRepository.addNotificationToken(
       user.uuid,
       registerTokenDto.token,

--- a/src/modules/user/user.usecase.ts
+++ b/src/modules/user/user.usecase.ts
@@ -69,6 +69,8 @@ import { MailTypes } from '../security/mail-limit/mailTypes';
 import { SequelizeMailLimitRepository } from '../security/mail-limit/mail-limit.repository';
 import { Time } from '../../lib/time';
 import { SequelizeFeatureLimitsRepository } from '../feature-limit/feature-limit.repository';
+import { UserNotificationTokens } from './user-notification-tokens.domain';
+import { RegisterNotificationTokenDto } from './dto/register-notification-token.dto';
 
 class ReferralsNotAvailableError extends Error {
   constructor() {
@@ -1078,5 +1080,19 @@ export class UserUseCases {
 
   getBetaUserFromRoom(room: string) {
     return this.userRepository.getBetaUserFromRoom(room);
+  }
+  registerUserNotificationToken(
+    user: User,
+    registerTokenDto: RegisterNotificationTokenDto,
+  ): Promise<void> {
+    return this.userRepository.addNotificationToken(
+      user.uuid,
+      registerTokenDto.token,
+      registerTokenDto.type,
+    );
+  }
+
+  getUserNotificationTokens(user: User): Promise<UserNotificationTokens[]> {
+    return this.userRepository.getNotificationTokens(user.uuid);
   }
 }

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -16,6 +16,8 @@ import {
   LimitTypes,
 } from '../src/modules/feature-limit/limits.enum';
 import { Limit } from '../src/modules/feature-limit/limit.domain';
+import { UserNotificationTokens } from '../src/modules/user/user-notification-tokens.domain';
+import { UserNotificationTokenAttributes } from '../src/modules/user/user-notification-tokens.attribute';
 
 export const constants = {
   BUCKET_ID_LENGTH: 24,
@@ -263,3 +265,21 @@ export function generateBase64PrivateKeyStub(): string {
   const base64privateKey = Buffer.from(stringPrivateKey).toString('base64');
   return base64privateKey;
 }
+
+export const newNotificationToken = (
+  params: { attributes: Partial<UserNotificationTokenAttributes> } = null,
+): UserNotificationTokens => {
+  const token = UserNotificationTokens.build({
+    id: v4(),
+    userId: v4(),
+    token: v4(),
+    type: 'macos',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  });
+  params?.attributes &&
+    Object.keys(params.attributes).forEach((key) => {
+      token[key] = params.attributes[key];
+    });
+  return token;
+};


### PR DESCRIPTION
Added `user_notification_tokens` table and an endpoint to register these device tokens. Currently, this is aimed at implementing Apple's push notification service for the macOS client to signal real-time changes. Still, the new table contains a type property in case this could be used for a different purpose in the future.