### PR TITLE
[PB-2294, PB-2291] feat: enabled share with public users and get folder tree

### DIFF
--- a/src/modules/file/file.repository.ts
+++ b/src/modules/file/file.repository.ts
@@ -484,6 +484,27 @@ export class SequelizeFileRepository implements FileRepository {
     });
   }
 
+  async getFilesByFolderUuid(
+    folderUuid: Folder['uuid'],
+    status: FileStatus,
+  ): Promise<File[]> {
+    const files = await this.fileModel.findAll({
+      where: {
+        folderUuid,
+        status,
+      },
+      include: [
+        {
+          model: this.thumbnailModel,
+          as: 'thumbnails',
+          required: false,
+        },
+      ],
+    });
+
+    return files.map(this.toDomain.bind(this));
+  }
+
   async findAllByUserIdExceptFolderIds(
     userId: FileAttributes['userId'],
     exceptFolderIds: FileAttributes['folderId'][],

--- a/src/modules/file/file.usecase.ts
+++ b/src/modules/file/file.usecase.ts
@@ -184,6 +184,13 @@ export class FileUseCases {
     };
   }
 
+  async getFilesByFolderUuid(
+    folderUuid: FileAttributes['folderUuid'],
+    status: FileStatus,
+  ) {
+    return this.fileRepository.getFilesByFolderUuid(folderUuid, status);
+  }
+
   async getFilesByFolderId(
     folderId: FileAttributes['folderId'],
     userId: FileAttributes['userId'],

--- a/src/modules/folder/folder.controller.spec.ts
+++ b/src/modules/folder/folder.controller.spec.ts
@@ -2,7 +2,7 @@ import { createMock } from '@golevelup/ts-jest';
 import { Test, TestingModule } from '@nestjs/testing';
 import { BadRequestException } from '@nestjs/common';
 import { v4 } from 'uuid';
-import { newFile, newFolder } from '../../../test/fixtures';
+import { newFile, newFolder, newUser } from '../../../test/fixtures';
 import { FileUseCases } from '../file/file.usecase';
 import {
   BadRequestInvalidOffsetException,
@@ -87,6 +87,31 @@ describe('FolderController', () => {
       await expect(folderController.getFolderSize(folder.uuid)).rejects.toThrow(
         CalculateFolderSizeTimeoutException,
       );
+    });
+  });
+
+  describe('getFolderTree', () => {
+    it('When folder tree is requested, then it should return the tree', async () => {
+      const user = newUser();
+      const folder = newFolder();
+      const mockFolderTree = {
+        ...folder,
+        children: [
+          {
+            ...newFolder({
+              attributes: { parentUuid: folder.uuid, parentId: folder.id },
+            }),
+          },
+        ],
+        files: [],
+      };
+
+      jest
+        .spyOn(folderUseCases, 'getFolderTree')
+        .mockResolvedValue(mockFolderTree);
+
+      const result = await folderController.getFolderTree(user, folder.uuid);
+      expect(result).toEqual({ tree: mockFolderTree });
     });
   });
 

--- a/src/modules/folder/folder.controller.ts
+++ b/src/modules/folder/folder.controller.ts
@@ -584,6 +584,21 @@ export class FolderController {
     return this.folderUseCases.getFolderAncestors(user, folderUuid);
   }
 
+  @Get('/:uuid/tree')
+  @WorkspacesInBehalfValidationFolder([
+    { sourceKey: 'params', fieldName: 'uuid', newFieldName: 'itemId' },
+  ])
+  async getFolderTree(
+    @UserDecorator() user: User,
+    @Param('uuid') folderUuid: Folder['uuid'],
+  ) {
+    const folderWithTree = await this.folderUseCases.getFolderTree(
+      user,
+      folderUuid,
+    );
+    return { tree: folderWithTree };
+  }
+
   @Get('/:id/metadata')
   async getFolderById(
     @UserDecorator() user: User,

--- a/src/modules/folder/folder.repository.ts
+++ b/src/modules/folder/folder.repository.ts
@@ -58,6 +58,10 @@ export interface FolderRepository {
     deleted: FolderAttributes['deleted'],
   ): Promise<Folder | null>;
   findOne(where: Partial<FolderAttributes>): Promise<Folder | null>;
+  findAllByParentUuid(
+    parentUuid: Folder['parentUuid'],
+    deleted?: boolean,
+  ): Promise<Array<Folder>>;
   findInTree(
     folderTreeRootId: FolderAttributes['parentId'],
     folderId: FolderAttributes['id'],
@@ -201,6 +205,16 @@ export class SequelizeFolderRepository implements FolderRepository {
     });
 
     return folders.map(this.toDomain.bind(this));
+  }
+
+  async findAllByParentUuid(
+    parentUuid: Folder['parentUuid'],
+    deleted = false,
+  ): Promise<Array<Folder>> {
+    const folders = await this.folderModel.findAll({
+      where: { parentUuid, deleted },
+    });
+    return folders.map((folder) => this.toDomain(folder));
   }
 
   async findAll(where = {}): Promise<Array<Folder> | []> {

--- a/src/modules/sharing/sharing.controller.ts
+++ b/src/modules/sharing/sharing.controller.ts
@@ -58,6 +58,7 @@ import { ThrottlerGuard } from '../../guards/throttler.guard';
 import { SetSharingPasswordDto } from './dto/set-sharing-password.dto';
 import { UuidDto } from '../../common/uuid.dto';
 import { HttpExceptionFilter } from '../../lib/http/http-exception.filter';
+import { WorkspacesInBehalfGuard } from '../workspaces/guards/workspaces-resources-in-behalf.decorator';
 
 @ApiTags('Sharing')
 @Controller('sharings')
@@ -604,6 +605,10 @@ export class SharingController {
     dataSources: [{ sourceKey: 'body', fieldName: 'itemId' }],
   })
   @UseGuards(FeatureLimit) */
+  @WorkspacesInBehalfGuard([
+    { sourceKey: 'body', fieldName: 'itemId' },
+    { sourceKey: 'body', fieldName: 'itemType' },
+  ])
   createSharing(
     @UserDecorator() user,
     @Body() acceptInviteDto: CreateSharingDto,

--- a/src/modules/workspaces/workspaces.usecase.ts
+++ b/src/modules/workspaces/workspaces.usecase.ts
@@ -1553,7 +1553,7 @@ export class WorkspacesUsecases {
     });
 
     if (!item) {
-      throw new NotFoundException('Item does not exist');
+      throw new NotFoundException('Item does not exist in workspace');
     }
 
     return item.isOwnedBy(requester);


### PR DESCRIPTION
This PR adds:
1) Required decorator for public sharings (made sure that the sharings are shown correctly on the respective endpoint)
2) Added a missing endpoint for firefox downloads (migrated from drive-server, isn't new logic)