### PR TITLE
fix: remove search workspace by ownerId on get members

### DIFF
--- a/src/modules/workspaces/workspaces.usecase.ts
+++ b/src/modules/workspaces/workspaces.usecase.ts
@@ -1592,11 +1592,9 @@ export class WorkspacesUsecases {
 
   async getWorkspaceMembers(
     workspaceId: WorkspaceAttributes['id'],
-    user: User,
     search?: string,
   ) {
     const workspace = await this.workspaceRepository.findOne({
-      ownerId: user.uuid,
       id: workspaceId,
     });
     if (!workspace) {


### PR DESCRIPTION
Workspace was being searched with ownerId for some reason. Removed that part as members can also use that usecase.