### PR TITLE
[PB-2309] feat: created endpoint for folder and files existence

### DIFF
--- a/src/modules/file/file.repository.spec.ts
+++ b/src/modules/file/file.repository.spec.ts
@@ -6,6 +6,7 @@ import { FileStatus } from './file.domain';
 import { FileModel } from './file.model';
 import { FileRepository, SequelizeFileRepository } from './file.repository';
 import { Op } from 'sequelize';
+import { v4 } from 'uuid';
 
 describe('FileRepository', () => {
   let repository: FileRepository;
@@ -91,6 +92,27 @@ describe('FileRepository', () => {
         }),
       );
       expect(result).toEqual(fileSizes);
+    });
+  });
+
+  describe('findFileByFolderUuid', () => {
+    const folderUuid = v4();
+
+    it('When a file is searched, then it should handle the dynamic input', async () => {
+      const searchCriteria = { plainName: ['Report'], type: 'pdf' };
+
+      await repository.findFileByFolderUuid(folderUuid, searchCriteria);
+
+      expect(fileModel.findAll).toHaveBeenCalledWith({
+        where: expect.objectContaining({
+          folderUuid,
+          plainName: {
+            [Op.in]: searchCriteria.plainName,
+          },
+          type: searchCriteria.type,
+          status: FileStatus.EXISTS,
+        }),
+      });
     });
   });
 });

--- a/src/modules/file/file.usecase.ts
+++ b/src/modules/file/file.usecase.ts
@@ -32,6 +32,7 @@ import { v4 } from 'uuid';
 import { CreateFileDto } from './dto/create-file.dto';
 import { UpdateFileMetaDto } from './dto/update-file-meta.dto';
 import { WorkspaceAttributes } from '../workspaces/attributes/workspace.attributes';
+import { Folder } from '../folder/folder.domain';
 
 type SortParams = Array<[SortableFileAttributes, 'ASC' | 'DESC']>;
 
@@ -136,6 +137,19 @@ export class FileUseCases {
     });
 
     return newFile;
+  }
+
+  async searchFilesInFolder(
+    folderUuid: Folder['uuid'],
+    {
+      plainNames,
+      type,
+    }: { plainNames: File['plainName'][]; type?: File['type'] },
+  ): Promise<File[]> {
+    return this.fileRepository.findFileByFolderUuid(folderUuid, {
+      plainName: plainNames,
+      type,
+    });
   }
 
   async updateFileMetaData(

--- a/src/modules/folder/dto/files-existence-in-folder.dto.spec.ts
+++ b/src/modules/folder/dto/files-existence-in-folder.dto.spec.ts
@@ -1,0 +1,76 @@
+import { validate } from 'class-validator';
+import { plainToInstance } from 'class-transformer';
+import { CheckFileExistenceInFolderDto } from './files-existence-in-folder.dto';
+
+describe('CheckFileExistenceInFolderDto', () => {
+  it('When valid data is passed, then no errors should be returned', async () => {
+    const dto = plainToInstance(CheckFileExistenceInFolderDto, {
+      plainName: ['file1', 'file2'],
+      type: 'txt',
+    });
+
+    const errors = await validate(dto);
+    expect(errors.length).toBe(0);
+  });
+
+  it('When a single string is passed for plainName, then it should be transformed into an array and validate successfully', async () => {
+    const dto = plainToInstance(CheckFileExistenceInFolderDto, {
+      plainName: 'file1',
+      type: 'txt',
+    });
+
+    const errors = await validate(dto);
+    expect(errors.length).toBe(0);
+    expect(dto.plainName).toEqual(['file1']);
+  });
+
+  it('When plainName array exceeds max size, then it should fail', async () => {
+    const plainName = Array.from({ length: 51 }, (_, i) => `file${i + 1}`);
+    const dto = plainToInstance(CheckFileExistenceInFolderDto, {
+      plainName,
+      type: 'txt',
+    });
+
+    const errors = await validate(dto);
+    expect(errors.length).toBeGreaterThan(0);
+    expect(errors[0].constraints).toBeDefined();
+  });
+
+  it('When plainName contains non-string values, then it should fail', async () => {
+    const dto = plainToInstance(CheckFileExistenceInFolderDto, {
+      plainName: [1, 2, 3],
+      type: 'txt',
+    });
+
+    const errors = await validate(dto);
+    expect(errors.length).toBeGreaterThan(0);
+  });
+
+  it('When plainName is not provided, then it should fail', async () => {
+    const dto = plainToInstance(CheckFileExistenceInFolderDto, {
+      type: 'txt',
+    });
+
+    const errors = await validate(dto);
+    expect(errors.length).toBeGreaterThan(0);
+  });
+
+  it('When plainName is an empty array, then it should validate successfully', async () => {
+    const dto = plainToInstance(CheckFileExistenceInFolderDto, {
+      plainName: [],
+      type: 'txt',
+    });
+
+    const errors = await validate(dto);
+    expect(errors.length).toBe(0);
+  });
+
+  it('When type is not provided, then it should validate successfully', async () => {
+    const dto = plainToInstance(CheckFileExistenceInFolderDto, {
+      plainName: ['file1', 'file2'],
+    });
+
+    const errors = await validate(dto);
+    expect(errors.length).toBe(0);
+  });
+});

--- a/src/modules/folder/dto/files-existence-in-folder.dto.ts
+++ b/src/modules/folder/dto/files-existence-in-folder.dto.ts
@@ -1,0 +1,32 @@
+import { Transform } from 'class-transformer';
+import { IsString, ArrayMaxSize, IsArray, IsOptional } from 'class-validator';
+import { FileAttributes } from '../../file/file.domain';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class CheckFileExistenceInFolderDto {
+  @ApiProperty({
+    description: 'Type of file',
+    example: 'pdf',
+    required: false,
+  })
+  @IsString()
+  @IsOptional()
+  type?: FileAttributes['type'];
+
+  @ApiProperty({
+    description: 'Plain name of file',
+    example: 'example',
+  })
+  @IsArray()
+  @ArrayMaxSize(50, {
+    message: 'Names parameter cannot contain more than 50 names',
+  })
+  @IsString({ each: true })
+  @Transform(({ value }) => {
+    if (typeof value === 'string') {
+      return [value];
+    }
+    return value;
+  })
+  plainName: FileAttributes['plainName'][];
+}

--- a/src/modules/folder/dto/folder-existence-in-folder.dto.spec.ts
+++ b/src/modules/folder/dto/folder-existence-in-folder.dto.spec.ts
@@ -1,0 +1,56 @@
+import { validate } from 'class-validator';
+import { plainToInstance } from 'class-transformer';
+import { CheckFoldersExistenceDto } from './folder-existence-in-folder.dto';
+
+describe('CheckFoldersExistenceDto', () => {
+  it('When valid data is passed, then no errors should be returned', async () => {
+    const dto = plainToInstance(CheckFoldersExistenceDto, {
+      plainName: ['folder1', 'folder2'],
+    });
+
+    const errors = await validate(dto);
+    expect(errors.length).toBe(0);
+  });
+
+  it('When a single string is passed, then it should be transformed into an array and validate successfully', async () => {
+    const dto = plainToInstance(CheckFoldersExistenceDto, {
+      plainName: 'folder1',
+    });
+
+    const errors = await validate(dto);
+    expect(errors.length).toBe(0);
+    expect(dto.plainName).toEqual(['folder1']);
+  });
+
+  it('When plainName array exceeds max size, then it should fail', async () => {
+    const plainName = Array.from({ length: 51 }, (_, i) => `folder${i + 1}`);
+    const dto = plainToInstance(CheckFoldersExistenceDto, { plainName });
+
+    const errors = await validate(dto);
+    expect(errors.length).toBeGreaterThan(0);
+    expect(errors[0].constraints).toBeDefined();
+  });
+
+  it('When plainName contains non-string values, then it should fail', async () => {
+    const dto = plainToInstance(CheckFoldersExistenceDto, {
+      plainName: [1, 2, 3],
+    });
+
+    const errors = await validate(dto);
+    expect(errors.length).toBeGreaterThan(0);
+  });
+
+  it('When plainName is not provided, then it should fail', async () => {
+    const dto = plainToInstance(CheckFoldersExistenceDto, {});
+
+    const errors = await validate(dto);
+    expect(errors.length).toBeGreaterThan(0);
+  });
+
+  it('When plainName is an empty array, then it should validate successfully', async () => {
+    const dto = plainToInstance(CheckFoldersExistenceDto, { plainName: [] });
+
+    const errors = await validate(dto);
+    expect(errors.length).toBe(0);
+  });
+});

--- a/src/modules/folder/dto/folder-existence-in-folder.dto.ts
+++ b/src/modules/folder/dto/folder-existence-in-folder.dto.ts
@@ -1,0 +1,22 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Transform } from 'class-transformer';
+import { IsString, ArrayMaxSize, IsArray } from 'class-validator';
+
+export class CheckFoldersExistenceDto {
+  @ApiProperty({
+    description: 'Plain name of folder',
+    example: 'my folder',
+  })
+  @IsArray()
+  @ArrayMaxSize(50, {
+    message: 'Names parameter cannot contain more than 50 names',
+  })
+  @IsString({ each: true })
+  @Transform(({ value }) => {
+    if (typeof value === 'string') {
+      return [value];
+    }
+    return value;
+  })
+  plainName: string[];
+}

--- a/src/modules/folder/folder.repository.spec.ts
+++ b/src/modules/folder/folder.repository.spec.ts
@@ -5,6 +5,8 @@ import { FolderModel } from './folder.model';
 import { Folder } from './folder.domain';
 import { newFolder } from '../../../test/fixtures';
 import { FileStatus } from '../file/file.domain';
+import { v4 } from 'uuid';
+import { Op } from 'sequelize';
 
 jest.mock('./folder.model', () => ({
   FolderModel: {
@@ -105,6 +107,44 @@ describe('SequelizeFolderRepository', () => {
       await expect(repository.calculateFolderSize(folder.uuid)).rejects.toThrow(
         CalculateFolderSizeTimeoutException,
       );
+    });
+  });
+
+  describe('findByParentUuid', () => {
+    const parentUuid = v4();
+    const plainNames = ['Document', 'Image'];
+
+    it('When folders are searched with names, then it should handle the call with names', async () => {
+      await repository.findByParentUuid(parentUuid, {
+        plainName: plainNames,
+        deleted: false,
+        removed: false,
+      });
+
+      expect(folderModel.findAll).toHaveBeenCalledWith({
+        where: {
+          parentUuid: parentUuid,
+          plainName: { [Op.in]: plainNames },
+          deleted: false,
+          removed: false,
+        },
+      });
+    });
+
+    it('When called without specific criteria, then it should handle the call', async () => {
+      await repository.findByParentUuid(parentUuid, {
+        plainName: [],
+        deleted: false,
+        removed: false,
+      });
+
+      expect(folderModel.findAll).toHaveBeenCalledWith({
+        where: {
+          parentUuid: parentUuid,
+          deleted: false,
+          removed: false,
+        },
+      });
     });
   });
 });

--- a/src/modules/folder/folder.usecase.ts
+++ b/src/modules/folder/folder.usecase.ts
@@ -531,6 +531,29 @@ export class FolderUseCases {
     );
   }
 
+  async searchFoldersInFolder(
+    user: User,
+    folderUuid: Folder['uuid'],
+    { plainNames }: { plainNames: Folder['plainName'][] },
+  ): Promise<Folder[]> {
+    const parentFolder = await this.folderRepository.findOne({
+      userId: user.id,
+      uuid: folderUuid,
+      removed: false,
+      deleted: false,
+    });
+
+    if (!parentFolder) {
+      throw new BadRequestException('Folder not valid!');
+    }
+
+    return this.folderRepository.findByParentUuid(parentFolder.uuid, {
+      plainName: plainNames,
+      deleted: false,
+      removed: false,
+    });
+  }
+
   getFoldersUpdatedAfter(
     userId: UserAttributes['id'],
     where: Partial<FolderAttributes>,


### PR DESCRIPTION
The frontend loops through all the files inside a folder to know if there is a file with the same name already created inside it. This operation is a burden for the backend and not eficient.