### PR TITLE
[_] fix: fixed error when fetching the sharing type

### DIFF
--- a/src/modules/file/file.controller.ts
+++ b/src/modules/file/file.controller.ts
@@ -126,11 +126,9 @@ export class FileController {
       const err = error as Error;
       const { email, uuid } = user;
       Logger.error(
-        `[SHARING/REPLACE] Error while replacing file. CONTEXT:${JSON.stringify(
-          {
-            user: { email, uuid },
-          },
-        )}}, STACK: ${err.stack || 'No stack trace'}`,
+        `[FILE/REPLACE] Error while replacing file. CONTEXT:${JSON.stringify({
+          user: { email, uuid },
+        })}}, STACK: ${err.stack || 'No stack trace'}`,
       );
 
       throw error;

--- a/src/modules/sharing/sharing.repository.ts
+++ b/src/modules/sharing/sharing.repository.ts
@@ -221,13 +221,17 @@ export class SequelizeSharingRepository implements SharingRepository {
     type?: SharingType,
     sharedWithType?: SharedWithType,
   ): Promise<Sharing> {
+    const optionalWhere = {
+      ...(type ? { type } : null),
+      ...(sharedWithType ? { sharedWithType } : null),
+    };
+
     const raw = await this.sharings.findOne({
       where: {
         itemId,
         itemType,
         [Op.or]: [{ ownerId: userId }, { sharedWith: userId }],
-        type,
-        sharedWithType,
+        ...optionalWhere,
       },
     });
 

--- a/src/modules/sharing/sharing.service.ts
+++ b/src/modules/sharing/sharing.service.ts
@@ -2200,6 +2200,7 @@ export class SharingService {
         itemId,
         itemType,
         SharingType.Public,
+        sharedWithType,
       ),
       this.sharingRepository.findOneByOwnerOrSharedWithItem(
         user.uuid,


### PR DESCRIPTION
We were having this error too frequently.  When the new field for workspaces was added, we needed to add the filter for all the parts where we fetch sharings, one was missing.

![image](https://github.com/user-attachments/assets/4ba71175-7027-41fd-b6f5-8d3c3828000c)
