### PR TITLE
[_] fix: endpoint folder/:uuid/content now returns all the content

### DIFF
--- a/src/modules/file/file.repository.ts
+++ b/src/modules/file/file.repository.ts
@@ -18,6 +18,18 @@ import { WorkspaceAttributes } from '../workspaces/attributes/workspace.attribut
 export interface FileRepository {
   create(file: Omit<FileAttributes, 'id'>): Promise<File | null>;
   deleteByFileId(fileId: any): Promise<any>;
+  findAllCursor(
+    where: Partial<Record<keyof FileAttributes, any>>,
+    limit: number,
+    offset: number,
+    order: Array<[keyof FileModel, string]>,
+  ): Promise<Array<File> | []>;
+  findAllCursorWithThumbnails(
+    where: Partial<Record<keyof FileAttributes, any>>,
+    limit: number,
+    offset: number,
+    order: Array<[keyof FileModel, string]>,
+  ): Promise<Array<File> | []>;
   findByIdNotDeleted(
     id: FileAttributes['id'],
     where: Partial<FileAttributes>,

--- a/src/modules/file/file.usecase.spec.ts
+++ b/src/modules/file/file.usecase.spec.ts
@@ -864,4 +864,44 @@ describe('FileUseCases', () => {
       expect(result).toEqual(fileSizes);
     });
   });
+
+  describe('getFiles', () => {
+    const userId = userMocked.id;
+
+    it('When limit and offset are specified, then it should use them', async () => {
+      const limit = 10;
+      const offset = 5;
+
+      await service.getFiles(userId, {}, { limit, offset });
+
+      expect(fileRepository.findAllCursorWithThumbnails).toHaveBeenCalledWith(
+        { userId },
+        limit,
+        offset,
+        undefined,
+      );
+    });
+
+    it('When ignorePagination is true, then it should ignore limit and offset', async () => {
+      await service.getFiles(userId, {}, { ignorePagination: true });
+
+      expect(fileRepository.findAllCursorWithThumbnails).toHaveBeenCalledWith(
+        { userId },
+        undefined,
+        undefined,
+        undefined,
+      );
+    });
+
+    it('When sorting is specified, then it should use the specified sort', async () => {
+      await service.getFiles(userId, {}, { sort: [['name', 'ASC']] });
+
+      expect(fileRepository.findAllCursorWithThumbnails).toHaveBeenCalledWith(
+        { userId },
+        20,
+        0,
+        [['name', 'ASC']],
+      );
+    });
+  });
 });

--- a/src/modules/file/file.usecase.ts
+++ b/src/modules/file/file.usecase.ts
@@ -319,29 +319,34 @@ export class FileUseCases {
     userId: UserAttributes['id'],
     where: Partial<FileAttributes>,
     options: {
-      limit: number;
-      offset: number;
+      limit?: number;
+      offset?: number;
       sort?: SortParams;
       withoutThumbnails?: boolean;
+      ignorePagination?: boolean;
     } = {
       limit: 20,
       offset: 0,
     },
   ): Promise<File[]> {
+    const { limit: optionsLimit = 20, offset: optionsOffsets = 0 } = options;
+    const limit = options.ignorePagination ? undefined : optionsLimit;
+    const offset = options.ignorePagination ? undefined : optionsOffsets;
+
     let filesWithMaybePlainName;
     if (options?.withoutThumbnails)
       filesWithMaybePlainName = await this.fileRepository.findAllCursor(
         { ...where, userId },
-        options.limit,
-        options.offset,
+        limit,
+        offset,
         options.sort,
       );
     else
       filesWithMaybePlainName =
         await this.fileRepository.findAllCursorWithThumbnails(
           { ...where, userId },
-          options.limit,
-          options.offset,
+          limit,
+          offset,
           options.sort,
         );
 

--- a/src/modules/folder/folder.controller.ts
+++ b/src/modules/folder/folder.controller.ts
@@ -406,15 +406,23 @@ export class FolderController {
   ) {
     const [currentFolder, childrenFolders, files] = await Promise.all([
       this.folderUseCases.getFolderByUuidAndUser(folderUuid, user),
-      this.folderUseCases.getFolders(user.id, {
-        parentUuid: folderUuid,
-        deleted: false,
-        removed: false,
-      }),
-      this.fileUseCases.getFiles(user.id, {
-        folderUuid: folderUuid,
-        status: FileStatus.EXISTS,
-      }),
+      this.folderUseCases.getFolders(
+        user.id,
+        {
+          parentUuid: folderUuid,
+          deleted: false,
+          removed: false,
+        },
+        { ignorePagination: true },
+      ),
+      this.fileUseCases.getFiles(
+        user.id,
+        {
+          folderUuid: folderUuid,
+          status: FileStatus.EXISTS,
+        },
+        { ignorePagination: true },
+      ),
     ]);
 
     if (!currentFolder) {

--- a/src/modules/folder/folder.repository.ts
+++ b/src/modules/folder/folder.repository.ts
@@ -38,6 +38,12 @@ export interface FolderRepository {
     newFolder: Omit<FolderAttributes, 'id'>,
   ): Promise<Folder>;
   findAll(): Promise<Array<Folder> | []>;
+  findAllCursor(
+    where: Partial<Record<keyof FolderAttributes, any>>,
+    limit: number,
+    offset: number,
+    order: Array<[keyof FolderModel, 'ASC' | 'DESC']>,
+  ): Promise<Array<Folder> | []>;
   findAllByParentIdAndUserId(
     parentId: FolderAttributes['parentId'],
     userId: FolderAttributes['userId'],

--- a/src/modules/folder/folder.usecase.spec.ts
+++ b/src/modules/folder/folder.usecase.spec.ts
@@ -1329,4 +1329,68 @@ describe('FolderUseCases', () => {
       });
     });
   });
+
+  describe('getFolders', () => {
+    const userId = userMocked.id;
+    const folder = newFolder({ attributes: { userId: userMocked.id } });
+    const folders = [
+      folder,
+      newFolder({ attributes: { userId: userMocked.id } }),
+    ];
+
+    it('When fetching folders, then it should use default options', async () => {
+      jest
+        .spyOn(folderRepository, 'findAllCursor')
+        .mockResolvedValueOnce(folders);
+
+      const result = await service.getFolders(userId, {});
+
+      expect(folderRepository.findAllCursor).toHaveBeenCalledWith(
+        { userId },
+        20,
+        0,
+        undefined,
+      );
+      expect(result).toEqual(folders);
+    });
+
+    it('When limit and offset are specified, then it should use them', async () => {
+      const limit = 10;
+      const offset = 5;
+
+      jest
+        .spyOn(folderRepository, 'findAllCursor')
+        .mockResolvedValueOnce(folders);
+
+      const result = await service.getFolders(userId, {}, { limit, offset });
+
+      expect(folderRepository.findAllCursor).toHaveBeenCalledWith(
+        { userId },
+        limit,
+        offset,
+        undefined,
+      );
+      expect(result).toEqual(folders);
+    });
+
+    it('When ignorePagination is true, then it should ignore limit and offset', async () => {
+      jest
+        .spyOn(folderRepository, 'findAllCursor')
+        .mockResolvedValueOnce(folders);
+
+      const result = await service.getFolders(
+        userId,
+        {},
+        { ignorePagination: true },
+      );
+
+      expect(folderRepository.findAllCursor).toHaveBeenCalledWith(
+        { userId },
+        undefined,
+        undefined,
+        undefined,
+      );
+      expect(result).toEqual(folders);
+    });
+  });
 });

--- a/src/modules/folder/folder.usecase.ts
+++ b/src/modules/folder/folder.usecase.ts
@@ -575,15 +575,25 @@ export class FolderUseCases {
   async getFolders(
     userId: FolderAttributes['userId'],
     where: Partial<FolderAttributes>,
-    options: { limit: number; offset: number; sort?: SortParams } = {
+    options: {
+      limit?: number;
+      offset?: number;
+      sort?: SortParams;
+      ignorePagination?: boolean;
+    } = {
       limit: 20,
       offset: 0,
+      ignorePagination: false,
     },
   ): Promise<Folder[]> {
+    const { limit: optionsLimit = 20, offset: optionsOffsets = 0 } = options;
+    const limit = options.ignorePagination ? undefined : optionsLimit;
+    const offset = options.ignorePagination ? undefined : optionsOffsets;
+
     const foldersWithMaybePlainName = await this.folderRepository.findAllCursor(
       { ...where, userId },
-      options.limit,
-      options.offset,
+      limit,
+      offset,
       options.sort,
     );
 


### PR DESCRIPTION
**This is a clone of:** https://github.com/internxt/drive-server-wip/pull/364

The frontend uses the folder/:id endpoint (created in drive-server) to retrieve all content within a folder. This endpoint is utilized in multiple parts of drive-web, making it challenging to deprecate it all at once. Therefore, we are migrating this endpoint.

**Issue:**
The migrated endpoint currently does not function as expected, returning only 20 files or folders.

**Fix:**
This PR includes changes to ensure the folder/:folderUuid/content endpoint works as intended, retrieving all the content within a folder without the 20-item limit.