### PR TITLE
[PB-2366] fix: workspace_items_users and sharings queries speed improved

### DIFF
--- a/migrations/20240719013824-add-item-index-sharings-table.js
+++ b/migrations/20240719013824-add-item-index-sharings-table.js
@@ -1,0 +1,17 @@
+'use strict';
+
+const indexName = 'sharings_item_id_index';
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.sequelize.query(
+      `CREATE INDEX CONCURRENTLY ${indexName} ON sharings (item_id)`,
+    );
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.sequelize.query(
+      `DROP INDEX CONCURRENTLY ${indexName}`,
+    );
+  },
+};

--- a/migrations/20240719013827-add-item-id-workspace-item-users-table.js
+++ b/migrations/20240719013827-add-item-id-workspace-item-users-table.js
@@ -1,0 +1,17 @@
+'use strict';
+
+const indexName = 'workspace_items_users_item_id_index';
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.sequelize.query(
+      `CREATE INDEX CONCURRENTLY ${indexName} ON workspace_items_users (item_id)`,
+    );
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.sequelize.query(
+      `DROP INDEX CONCURRENTLY ${indexName}`,
+    );
+  },
+};

--- a/src/modules/sharing/sharing.repository.ts
+++ b/src/modules/sharing/sharing.repository.ts
@@ -480,6 +480,7 @@ export class SequelizeSharingRepository implements SharingRepository {
             {
               model: WorkspaceItemUserModel,
               as: 'workspaceUser',
+              required: true,
               include: [
                 {
                   model: UserModel,
@@ -549,6 +550,7 @@ export class SequelizeSharingRepository implements SharingRepository {
           include: [
             {
               model: WorkspaceItemUserModel,
+              required: true,
               include: [
                 {
                   model: UserModel,


### PR DESCRIPTION
We have a sequential scan made on sharings and workspace_items_users (a table that is expected to grow) making the navigation and queries slow. 

1. Added a required: true to the query to convert left outer joins into inner joins (we do not care about sharings that does not have a workspace_items_users equivalent)
2. Added index on sharings and workspace_items_users. 

For more info, refer to: https://inxt.atlassian.net/browse/PB-2366?focusedCommentId=27484

Requires migrations, please do not merge without running them.