### PR TITLE
[_] fix: only show sharings in the current workspace

### DIFF
--- a/src/modules/sharing/sharing.repository.spec.ts
+++ b/src/modules/sharing/sharing.repository.spec.ts
@@ -28,6 +28,7 @@ describe('SharingRepository', () => {
   describe('findFilesByOwnerAndSharedWithTeamInworkspace', () => {
     it('When files are searched by owner and team in workspace, then it should return the shared files', async () => {
       const teamId = v4();
+      const workspaceId = v4();
       const ownerId = v4();
       const offset = 0;
       const limit = 10;
@@ -54,6 +55,7 @@ describe('SharingRepository', () => {
 
       const result =
         await repository.findFilesByOwnerAndSharedWithTeamInworkspace(
+          workspaceId,
           teamId,
           ownerId,
           offset,
@@ -68,6 +70,7 @@ describe('SharingRepository', () => {
   });
 
   describe('findFoldersByOwnerAndSharedWithTeamInworkspace', () => {
+    const workspaceId = v4();
     it('When folders are searched by owner and team in workspace, then it should return the shared folders', async () => {
       const teamId = v4();
       const ownerId = v4();
@@ -92,6 +95,7 @@ describe('SharingRepository', () => {
 
       const result =
         await repository.findFoldersByOwnerAndSharedWithTeamInworkspace(
+          workspaceId,
           teamId,
           ownerId,
           offset,

--- a/src/modules/sharing/sharing.repository.ts
+++ b/src/modules/sharing/sharing.repository.ts
@@ -30,6 +30,7 @@ import { PreCreatedUserAttributes } from '../user/pre-created-users.attributes';
 import { WorkspaceTeamAttributes } from '../workspaces/attributes/workspace-team.attributes';
 import { WorkspaceItemUserModel } from '../workspaces/models/workspace-items-users.model';
 import { WorkspaceItemUserAttributes } from '../workspaces/attributes/workspace-items-users.attributes';
+import { WorkspaceAttributes } from '../workspaces/attributes/workspace.attributes';
 
 interface SharingRepository {
   getInvitesByItem(
@@ -443,6 +444,7 @@ export class SequelizeSharingRepository implements SharingRepository {
   }
 
   async findFilesByOwnerAndSharedWithTeamInworkspace(
+    workspaceId: WorkspaceAttributes['id'],
     teamId: WorkspaceTeamAttributes['id'],
     ownerId: WorkspaceItemUserAttributes['createdBy'],
     offset: number,
@@ -481,6 +483,9 @@ export class SequelizeSharingRepository implements SharingRepository {
               model: WorkspaceItemUserModel,
               as: 'workspaceUser',
               required: true,
+              where: {
+                workspaceId,
+              },
               include: [
                 {
                   model: UserModel,
@@ -513,6 +518,7 @@ export class SequelizeSharingRepository implements SharingRepository {
   }
 
   async findFoldersByOwnerAndSharedWithTeamInworkspace(
+    workspaceId: WorkspaceAttributes['id'],
     teamId: WorkspaceTeamAttributes['id'],
     ownerId: WorkspaceItemUserAttributes['createdBy'],
     offset: number,
@@ -551,6 +557,9 @@ export class SequelizeSharingRepository implements SharingRepository {
             {
               model: WorkspaceItemUserModel,
               required: true,
+              where: {
+                workspaceId,
+              },
               include: [
                 {
                   model: UserModel,

--- a/src/modules/sharing/sharing.service.spec.ts
+++ b/src/modules/sharing/sharing.service.spec.ts
@@ -492,6 +492,7 @@ describe('Sharing Use Cases', () => {
   describe('getSharedFilesInWorkspaces', () => {
     const user = newUser();
     const teamId = v4();
+    const workspaceId = v4();
     const offset = 0;
     const limit = 10;
     const order: [string, string][] = [['name', 'asc']];
@@ -517,6 +518,7 @@ describe('Sharing Use Cases', () => {
 
       const result = await sharingService.getSharedFilesInWorkspaces(
         user,
+        workspaceId,
         teamId,
         offset,
         limit,
@@ -554,6 +556,7 @@ describe('Sharing Use Cases', () => {
 
       const result = await sharingService.getSharedFilesInWorkspaces(
         user,
+        workspaceId,
         teamId,
         offset,
         limit,
@@ -585,6 +588,7 @@ describe('Sharing Use Cases', () => {
       await expect(
         sharingService.getSharedFilesInWorkspaces(
           user,
+          workspaceId,
           teamId,
           offset,
           limit,
@@ -597,6 +601,7 @@ describe('Sharing Use Cases', () => {
   describe('getSharedFoldersInWorkspace', () => {
     const user = newUser();
     const teamId = v4();
+    const workspaceId = v4();
     const offset = 0;
     const limit = 10;
     const order: [string, string][] = [['name', 'asc']];
@@ -623,6 +628,7 @@ describe('Sharing Use Cases', () => {
 
       const result = await sharingService.getSharedFoldersInWorkspace(
         user,
+        workspaceId,
         teamId,
         offset,
         limit,
@@ -660,6 +666,7 @@ describe('Sharing Use Cases', () => {
 
       const result = await sharingService.getSharedFoldersInWorkspace(
         user,
+        workspaceId,
         teamId,
         offset,
         limit,
@@ -691,6 +698,7 @@ describe('Sharing Use Cases', () => {
       await expect(
         sharingService.getSharedFoldersInWorkspace(
           user,
+          workspaceId,
           teamId,
           offset,
           limit,

--- a/src/modules/sharing/sharing.service.ts
+++ b/src/modules/sharing/sharing.service.ts
@@ -52,6 +52,7 @@ import { aes } from '@internxt/lib';
 import { Environment } from '@internxt/inxt-js';
 import { SequelizeUserReferralsRepository } from '../user/user-referrals.repository';
 import { SharingNotFoundException } from './exception/sharing-not-found.exception';
+import { Workspace } from '../workspaces/domains/workspaces.domain';
 
 export class InvalidOwnerError extends Error {
   constructor() {
@@ -1787,6 +1788,7 @@ export class SharingService {
 
   async getSharedFoldersInWorkspace(
     user: User,
+    workspaceId: Workspace['id'],
     teamId: Sharing['sharedWith'],
     offset: number,
     limit: number,
@@ -1794,6 +1796,7 @@ export class SharingService {
   ): Promise<GetItemsReponse> {
     const foldersWithSharedInfo =
       await this.sharingRepository.findFoldersByOwnerAndSharedWithTeamInworkspace(
+        workspaceId,
         teamId,
         user.uuid,
         offset,
@@ -1838,6 +1841,7 @@ export class SharingService {
 
   async getSharedFilesInWorkspaces(
     user: User,
+    workspaceId: Workspace['id'],
     teamId: Sharing['sharedWith'],
     offset: number,
     limit: number,
@@ -1845,6 +1849,7 @@ export class SharingService {
   ): Promise<GetItemsReponse> {
     const filesWithSharedInfo =
       await this.sharingRepository.findFilesByOwnerAndSharedWithTeamInworkspace(
+        workspaceId,
         teamId,
         user.uuid,
         offset,

--- a/src/modules/workspaces/workspaces.controller.spec.ts
+++ b/src/modules/workspaces/workspaces.controller.spec.ts
@@ -507,12 +507,14 @@ describe('Workspace Controller', () => {
     it('When shared files are requested, then it should call the service with the respective arguments', async () => {
       const user = newUser();
       const teamId = v4();
+      const workspaceId = v4();
       const orderBy = 'createdAt:ASC';
       const page = 1;
       const perPage = 50;
       const order = [['createdAt', 'ASC']];
 
       await workspacesController.getSharedFiles(
+        workspaceId,
         teamId,
         user,
         orderBy,
@@ -522,6 +524,7 @@ describe('Workspace Controller', () => {
 
       expect(sharingUseCases.getSharedFilesInWorkspaces).toHaveBeenCalledWith(
         user,
+        workspaceId,
         teamId,
         page,
         perPage,
@@ -534,12 +537,14 @@ describe('Workspace Controller', () => {
     it('When shared folders are requested, then it should call the service with the respective arguments', async () => {
       const user = newUser();
       const teamId = v4();
+      const workspaceId = v4();
       const orderBy = 'createdAt:ASC';
       const page = 1;
       const perPage = 50;
       const order = [['createdAt', 'ASC']];
 
       await workspacesController.getSharedFolders(
+        workspaceId,
         teamId,
         user,
         orderBy,
@@ -549,6 +554,7 @@ describe('Workspace Controller', () => {
 
       expect(sharingUseCases.getSharedFoldersInWorkspace).toHaveBeenCalledWith(
         user,
+        workspaceId,
         teamId,
         page,
         perPage,

--- a/src/modules/workspaces/workspaces.controller.ts
+++ b/src/modules/workspaces/workspaces.controller.ts
@@ -594,6 +594,8 @@ export class WorkspacesController {
   @UseGuards(WorkspaceGuard)
   @WorkspaceRequiredAccess(AccessContext.TEAM, WorkspaceRole.MEMBER)
   async getSharedFiles(
+    @Param('workspaceId', ValidateUUIDPipe)
+    workspaceId: WorkspaceTeamAttributes['id'],
     @Param('teamId', ValidateUUIDPipe)
     teamId: WorkspaceTeamAttributes['id'],
     @UserDecorator() user: User,
@@ -607,6 +609,7 @@ export class WorkspacesController {
 
     return this.sharingUseCases.getSharedFilesInWorkspaces(
       user,
+      workspaceId,
       teamId,
       page,
       perPage,
@@ -621,6 +624,8 @@ export class WorkspacesController {
   @UseGuards(WorkspaceGuard)
   @WorkspaceRequiredAccess(AccessContext.TEAM, WorkspaceRole.MEMBER)
   async getSharedFolders(
+    @Param('workspaceId', ValidateUUIDPipe)
+    workspaceId: WorkspaceTeamAttributes['id'],
     @Param('teamId', ValidateUUIDPipe)
     teamId: WorkspaceTeamAttributes['id'],
     @UserDecorator() user: User,
@@ -634,6 +639,7 @@ export class WorkspacesController {
 
     return this.sharingUseCases.getSharedFoldersInWorkspace(
       user,
+      workspaceId,
       teamId,
       page,
       perPage,


### PR DESCRIPTION
Sharings in workspaces were listing items from other workspaces due to the "OR" query bad formulated. This PR adds a filter by workspaceId to only show sharings in the current workspace