### PR TITLE
[PB-2381] fix: workspace usage is now calculated on the fly

### DIFF
--- a/src/modules/file/file.repository.spec.ts
+++ b/src/modules/file/file.repository.spec.ts
@@ -29,20 +29,15 @@ describe('FileRepository', () => {
   describe('getSumSizeOfFilesByStatuses', () => {
     it('When called with specific statuses and options, then it should fetch file sizes', async () => {
       const statuses = [FileStatus.EXISTS, FileStatus.TRASHED];
-      const options = {
-        limit: 100,
-        offset: 0,
-        createdFrom: new Date('2023-01-01'),
-      };
-      const fileSizes = [{ size: '100' }, { size: '200' }];
+      const totalUsage = 100;
+      const sizesSum = [{ total: totalUsage }];
 
-      jest.spyOn(fileModel, 'findAll').mockResolvedValueOnce(fileSizes as any);
+      jest.spyOn(fileModel, 'findAll').mockResolvedValueOnce(sizesSum as any);
 
-      const result = await repository.getSumSizeOfFilesByStatuses(
+      const result = await repository.getSumSizeOfFilesInWorkspaceByStatuses(
         user.uuid,
         workspace.id,
         statuses,
-        options,
       );
 
       expect(fileModel.findAll).toHaveBeenCalledWith(
@@ -57,41 +52,35 @@ describe('FileRepository', () => {
             where: expect.objectContaining({
               createdBy: user.uuid,
               workspaceId: workspace.id,
-              createdAt: { [Op.gte]: options.createdFrom },
             }),
           }),
         }),
       );
-      expect(result).toEqual(fileSizes);
+      expect(result).toEqual(totalUsage);
     });
 
     it('When files removed from a specific date are fetch, then it should include the date in the query', async () => {
       const statuses = [FileStatus.DELETED];
-      const options = {
-        limit: 100,
-        offset: 0,
-        removedFrom: new Date('2023-01-01'),
-      };
-      const fileSizes = [{ size: '100' }, { size: '200' }];
 
-      jest.spyOn(fileModel, 'findAll').mockResolvedValueOnce(fileSizes as any);
+      const totalUsage = 100;
+      const sizesSum = [{ total: totalUsage }];
 
-      const result = await repository.getSumSizeOfFilesByStatuses(
+      jest.spyOn(fileModel, 'findAll').mockResolvedValueOnce(sizesSum as any);
+
+      const result = await repository.getSumSizeOfFilesInWorkspaceByStatuses(
         user.uuid,
         workspace.id,
         statuses,
-        options,
       );
 
       expect(fileModel.findAll).toHaveBeenCalledWith(
         expect.objectContaining({
           where: expect.objectContaining({
             [Op.or]: expect.arrayContaining([{ status: statuses[0] }]),
-            removedAt: { [Op.gte]: options.removedFrom },
           }),
         }),
       );
-      expect(result).toEqual(fileSizes);
+      expect(result).toEqual(totalUsage);
     });
   });
 

--- a/src/modules/file/file.usecase.spec.ts
+++ b/src/modules/file/file.usecase.spec.ts
@@ -795,73 +795,22 @@ describe('FileUseCases', () => {
 
     it('When called with specific statuses and options, then it should use them to fetch files', async () => {
       const statuses = [FileStatus.EXISTS, FileStatus.TRASHED];
-      const fileSizes = [{ size: '100' }, { size: '200' }];
+      const totalSum = 100;
 
       jest
-        .spyOn(fileRepository, 'getSumSizeOfFilesByStatuses')
-        .mockResolvedValue(fileSizes);
-
-      const createdFrom = new Date('2023-01-01');
-
-      const options = {
-        limit: 100,
-        offset: 0,
-        createdFrom,
-      };
-      const result = await service.getWorkspaceFilesSizeSumByStatuses(
-        user.uuid,
-        workspace.id,
-        statuses,
-        options,
-      );
-
-      expect(fileRepository.getSumSizeOfFilesByStatuses).toHaveBeenCalledWith(
-        user.uuid,
-        workspace.id,
-        statuses,
-        {
-          limit: options.limit,
-          offset: options.offset,
-          order: [['uuid', 'ASC']],
-          createdFrom: createdFrom,
-          removedFrom: undefined,
-        },
-      );
-      expect(result).toEqual(fileSizes);
-    });
-
-    it('When there are no file sizes, then it should return an empty array', async () => {
-      const statuses = [FileStatus.EXISTS, FileStatus.TRASHED];
-      const options = {
-        limit: 100,
-        offset: 0,
-      };
-      const fileSizes: { size: string }[] = [];
-
-      jest
-        .spyOn(fileRepository, 'getSumSizeOfFilesByStatuses')
-        .mockResolvedValue(fileSizes);
+        .spyOn(fileRepository, 'getSumSizeOfFilesInWorkspaceByStatuses')
+        .mockResolvedValue(totalSum);
 
       const result = await service.getWorkspaceFilesSizeSumByStatuses(
         user.uuid,
         workspace.id,
         statuses,
-        { ...options, order: [['uuid', 'ASC']] },
       );
 
-      expect(fileRepository.getSumSizeOfFilesByStatuses).toHaveBeenCalledWith(
-        user.uuid,
-        workspace.id,
-        statuses,
-        {
-          limit: options.limit,
-          offset: options.offset,
-          order: [['uuid', 'ASC']],
-          createdFrom: undefined,
-          removedFrom: undefined,
-        },
-      );
-      expect(result).toEqual(fileSizes);
+      expect(
+        fileRepository.getSumSizeOfFilesInWorkspaceByStatuses,
+      ).toHaveBeenCalledWith(user.uuid, workspace.id, statuses);
+      expect(result).toEqual(totalSum);
     });
   });
 });

--- a/src/modules/file/file.usecase.ts
+++ b/src/modules/file/file.usecase.ts
@@ -358,27 +358,11 @@ export class FileUseCases {
     createdBy: UserAttributes['uuid'],
     workspaceId: WorkspaceAttributes['id'],
     statuses: FileStatus[],
-    options: {
-      limit: number;
-      offset: number;
-      order?: Array<[keyof File, string]>;
-      createdFrom?: Date;
-      removedFrom?: Date;
-    },
   ) {
-    const fetchOrder = options?.order ?? [['uuid', 'ASC']];
-
-    return this.fileRepository.getSumSizeOfFilesByStatuses(
+    return this.fileRepository.getSumSizeOfFilesInWorkspaceByStatuses(
       createdBy,
       workspaceId,
       statuses,
-      {
-        limit: options.limit,
-        offset: options.offset,
-        order: fetchOrder,
-        createdFrom: options?.createdFrom,
-        removedFrom: options?.removedFrom,
-      },
     );
   }
 


### PR DESCRIPTION
The previous usage calculation approach was inconsistent. This PR aligns the approach with what we use for individuals.

1. Get usage: Usage is calculated and the value is saved in driveUsage for caching purposes.
2. Upload file: The driveUsage value is used and file.size is added to it. This covers cases such as multiple files upload.

The frontend already calls get usage every time an operation involving drive changes is performed. However, we should not rely solely on this. There are areas for improvement, I'll request a ticket to be opened to address these improvements.