### PR TITLE
[_] fix: sharing field is returned while navigating folders

### DIFF
--- a/src/modules/folder/folder.repository.ts
+++ b/src/modules/folder/folder.repository.ts
@@ -229,6 +229,11 @@ export class SequelizeFolderRepository implements FolderRepository {
             workspaceId,
           },
         },
+        {
+          model: SharingModel,
+          attributes: ['type', 'id'],
+          required: false,
+        },
       ],
       limit,
       offset,


### PR DESCRIPTION
We had missing the "sharings"  field while listing folders in a workspace. That field is needed to show the respective icon of "shared" on the UI.