### PR TITLE
[_] fix: added sharing guard to workspace decorator to enable permissions

### DIFF
--- a/src/modules/file/file.controller.ts
+++ b/src/modules/file/file.controller.ts
@@ -10,6 +10,7 @@ import {
   Post,
   Put,
   Query,
+  UseGuards,
 } from '@nestjs/common';
 import {
   ApiBearerAuth,
@@ -31,6 +32,9 @@ import { UpdateFileMetaDto } from './dto/update-file-meta.dto';
 import { ValidateUUIDPipe } from '../workspaces/pipes/validate-uuid.pipe';
 import { WorkspacesInBehalfValidationFile } from '../workspaces/guards/workspaces-resources-in-behalf.decorator';
 import { CreateFileDto } from './dto/create-file.dto';
+import { RequiredSharingPermissions } from '../sharing/guards/sharing-permissions.decorator';
+import { SharingActionName } from '../sharing/sharing.domain';
+import { SharingPermissionsGuard } from '../sharing/guards/sharing-permissions.guard';
 
 const filesStatuses = ['ALL', 'EXISTS', 'TRASHED', 'DELETED'] as const;
 
@@ -44,6 +48,8 @@ export class FileController {
     summary: 'Create File',
   })
   @ApiBearerAuth()
+  @RequiredSharingPermissions(SharingActionName.UploadFile)
+  @UseGuards(SharingPermissionsGuard)
   async createFile(
     @UserDecorator() user: User,
     @Body() createFileDto: CreateFileDto,
@@ -146,6 +152,7 @@ export class FileController {
     required: true,
     description: 'file uuid',
   })
+  @RequiredSharingPermissions(SharingActionName.RenameItems)
   @WorkspacesInBehalfValidationFile([
     { sourceKey: 'params', fieldName: 'uuid', newFieldName: 'itemId' },
   ])

--- a/src/modules/file/file.module.ts
+++ b/src/modules/file/file.module.ts
@@ -13,6 +13,7 @@ import { ThumbnailModule } from '../thumbnail/thumbnail.module';
 import { FileModel } from './file.model';
 import { SharingModule } from '../sharing/sharing.module';
 import { WorkspacesModule } from '../workspaces/workspaces.module';
+import { UserModule } from '../user/user.module';
 
 @Module({
   imports: [
@@ -24,6 +25,7 @@ import { WorkspacesModule } from '../workspaces/workspaces.module';
     forwardRef(() => WorkspacesModule),
     BridgeModule,
     CryptoModule,
+    UserModule,
   ],
   controllers: [FileController],
   providers: [SequelizeFileRepository, FileUseCases],

--- a/src/modules/folder/folder.controller.ts
+++ b/src/modules/folder/folder.controller.ts
@@ -49,6 +49,8 @@ import { CreateFolderDto } from './dto/create-folder.dto';
 import { CheckFoldersExistenceDto } from './dto/folder-existence-in-folder.dto';
 import { InvalidParentFolderException } from './exception/invalid-parent-folder';
 import { CheckFileExistenceInFolderDto } from './dto/files-existence-in-folder.dto';
+import { RequiredSharingPermissions } from '../sharing/guards/sharing-permissions.decorator';
+import { SharingActionName } from '../sharing/sharing.domain';
 
 const foldersStatuses = ['ALL', 'EXISTS', 'TRASHED', 'DELETED'] as const;
 
@@ -689,6 +691,7 @@ export class FolderController {
   @WorkspacesInBehalfValidationFolder([
     { sourceKey: 'params', fieldName: 'uuid', newFieldName: 'itemId' },
   ])
+  @RequiredSharingPermissions(SharingActionName.RenameItems)
   async updateFolderMetadata(
     @Param('uuid', ValidateUUIDPipe)
     folderUuid: Folder['uuid'],

--- a/src/modules/sharing/decorators/behalfUser.decorator.ts
+++ b/src/modules/sharing/decorators/behalfUser.decorator.ts
@@ -4,6 +4,6 @@ export const BehalfUserDecorator = createParamDecorator(
   async (_, ctx: ExecutionContext) => {
     const req = ctx.switchToHttp().getRequest();
 
-    return req.behalfUser;
+    return req?.behalfUser;
   },
 );

--- a/src/modules/sharing/guards/sharing-permissions.guard.ts
+++ b/src/modules/sharing/guards/sharing-permissions.guard.ts
@@ -38,7 +38,6 @@ export class SharingPermissionsGuard implements CanActivate {
       PermissionsMetadataName,
       context.getHandler(),
     );
-    const { action } = permissionsOptions;
 
     const request = context.switchToHttp().getRequest();
     const requester = request?.user as User;
@@ -49,9 +48,15 @@ export class SharingPermissionsGuard implements CanActivate {
 
     const resourcesToken = request.headers['internxt-resources-token'];
 
-    if (!resourcesToken || typeof resourcesToken !== 'string') {
+    if (
+      !resourcesToken ||
+      typeof resourcesToken !== 'string' ||
+      !permissionsOptions
+    ) {
       return true;
     }
+
+    const { action } = permissionsOptions;
 
     const decoded = verifyWithDefaultSecret(resourcesToken) as
       | {
@@ -100,7 +105,8 @@ export class SharingPermissionsGuard implements CanActivate {
       throw new NotFoundException('Resource owner not found');
     }
 
-    request.behalfUser = resourceOwner;
+    request.user = resourceOwner;
+    request.isSharedItem = true;
 
     return true;
   }

--- a/src/modules/trash/trash.module.ts
+++ b/src/modules/trash/trash.module.ts
@@ -10,6 +10,7 @@ import { ShareModule } from '../share/share.module';
 import { ShareModel } from '../share/share.repository';
 import { FileModel } from '../file/file.model';
 import { WorkspacesModule } from '../workspaces/workspaces.module';
+import { SharingModule } from '../sharing/sharing.module';
 
 @Module({
   imports: [
@@ -17,6 +18,7 @@ import { WorkspacesModule } from '../workspaces/workspaces.module';
     forwardRef(() => FileModule),
     forwardRef(() => ShareModule),
     forwardRef(() => WorkspacesModule),
+    forwardRef(() => SharingModule),
     FolderModule,
     NotificationModule,
     UserModule,

--- a/src/modules/workspaces/guards/workspaces-resources-in-behalf.decorator.ts
+++ b/src/modules/workspaces/guards/workspaces-resources-in-behalf.decorator.ts
@@ -1,6 +1,7 @@
 import { applyDecorators, UseGuards, SetMetadata } from '@nestjs/common';
 import { WorkspacesResourcesItemsInBehalfGuard } from './workspaces-resources-in-items-in-behalf.guard';
 import { WorkspaceItemType } from '../attributes/workspace-items-users.attributes';
+import { SharingPermissionsGuard } from '../../sharing/guards/sharing-permissions.guard';
 
 export interface DataSource {
   sourceKey?: 'body' | 'query' | 'params' | 'headers';
@@ -39,7 +40,8 @@ const createValidationDecorator = (
   return applyDecorators(
     SetMetadata(WORKSPACE_IN_BEHALF_SOURCES_META_KEY, dataSourcesWithOptions),
     SetMetadata(WORKSPACE_IN_BEHALF_ACTION_META_KEY, options?.action),
-    UseGuards(WorkspacesResourcesItemsInBehalfGuard),
+    // TODO: rename this guard or remove sharings from here
+    UseGuards(SharingPermissionsGuard, WorkspacesResourcesItemsInBehalfGuard),
   );
 };
 

--- a/src/modules/workspaces/guards/workspaces-resources-in-items-in-behalf.guard.ts
+++ b/src/modules/workspaces/guards/workspaces-resources-in-items-in-behalf.guard.ts
@@ -19,7 +19,7 @@ import { WorkspaceItemUser } from '../domains/workspace-item-user.domain';
 import { verifyWithDefaultSecret } from '../../../lib/jwt';
 import { isUUID } from 'class-validator';
 
-export interface DecodedToken {
+export interface DecodedWorkspaceToken {
   workspaceId: string;
 }
 
@@ -88,7 +88,11 @@ export class WorkspacesResourcesItemsInBehalfGuard implements CanActivate {
 
     const actionHandler = this.getActionHandler(action);
 
-    const canUserPerformAction = await actionHandler(requester, extractedData);
+    const bypassActionCheck = request.isSharedItem;
+
+    const canUserPerformAction = bypassActionCheck
+      ? true
+      : await actionHandler(requester, extractedData);
 
     if (!canUserPerformAction) {
       throw new ForbiddenException(
@@ -176,9 +180,9 @@ export class WorkspacesResourcesItemsInBehalfGuard implements CanActivate {
     return extractedData;
   }
 
-  private decodeWorkspaceToken(token: string): DecodedToken {
+  private decodeWorkspaceToken(token: string): DecodedWorkspaceToken {
     try {
-      const decoded = verifyWithDefaultSecret(token) as DecodedToken;
+      const decoded = verifyWithDefaultSecret(token) as DecodedWorkspaceToken;
       if (!decoded?.workspaceId) {
         throw new Error();
       }

--- a/src/modules/workspaces/workspaces.controller.spec.ts
+++ b/src/modules/workspaces/workspaces.controller.spec.ts
@@ -620,7 +620,6 @@ describe('Workspace Controller', () => {
 
   describe('GET /:workspaceId', () => {
     it('When a workspace is requested, then it should return the workspace data', async () => {
-      const user = newUser();
       const workspace = newWorkspace();
 
       jest
@@ -628,7 +627,7 @@ describe('Workspace Controller', () => {
         .mockResolvedValueOnce(workspace.toJSON());
 
       await expect(
-        workspacesController.getWorkspaceDetails(workspace.id, user),
+        workspacesController.getWorkspaceDetails(workspace.id),
       ).resolves.toEqual(workspace.toJSON());
     });
   });

--- a/src/modules/workspaces/workspaces.controller.ts
+++ b/src/modules/workspaces/workspaces.controller.ts
@@ -62,7 +62,6 @@ import { OrderBy } from '../../common/order.type';
 import { SharingPermissionsGuard } from '../sharing/guards/sharing-permissions.guard';
 import { RequiredSharingPermissions } from '../sharing/guards/sharing-permissions.decorator';
 import { SharingActionName } from '../sharing/sharing.domain';
-import { BehalfUserDecorator } from '../sharing/decorators/behalfUser.decorator';
 import { WorkspaceItemType } from './attributes/workspace-items-users.attributes';
 import { SharingService } from '../sharing/sharing.service';
 import { WorkspaceTeam } from './domains/workspace-team.domain';
@@ -552,15 +551,10 @@ export class WorkspacesController {
   async createFile(
     @Param('workspaceId', ValidateUUIDPipe)
     workspaceId: WorkspaceAttributes['id'],
-    @BehalfUserDecorator() behalfUser: User,
     @UserDecorator() user: User,
     @Body() createFileDto: CreateWorkspaceFileDto,
   ) {
-    return this.workspaceUseCases.createFile(
-      behalfUser ?? user,
-      workspaceId,
-      createFileDto,
-    );
+    return this.workspaceUseCases.createFile(user, workspaceId, createFileDto);
   }
 
   @Post('/:workspaceId/shared/')
@@ -1000,7 +994,6 @@ export class WorkspacesController {
   async getWorkspaceDetails(
     @Param('workspaceId', ValidateUUIDPipe)
     workspaceId: WorkspaceAttributes['id'],
-    @UserDecorator() user: User,
   ) {
     return this.workspaceUseCases.getWorkspaceDetails(workspaceId);
   }


### PR DESCRIPTION
There were some problems when the workspace header (needed to reuse some endpoints) and the sharings header (navigation through shared folders) are in the same request. This PR addresses them. 

However, I left a TODO comment to find a cleaner way to do this.