### PR TITLE
[PB-2446]: feat/remove workspace member from workspace

### DIFF
--- a/src/modules/workspaces/repositories/workspaces.repository.spec.ts
+++ b/src/modules/workspaces/repositories/workspaces.repository.spec.ts
@@ -125,6 +125,25 @@ describe('SequelizeWorkspaceRepository', () => {
       const result = await repository.findWorkspaceUser({ memberId: '1' });
       expect(result).toBeNull();
     });
+
+    it('When a workspace user is searched with a user include, then it should return the user', async () => {
+      const user = newUser();
+      const mockWorworkspaceUserkspaceUser = newWorkspaceUser({
+        memberId: user.uuid,
+        member: user,
+      });
+
+      jest
+        .spyOn(workspaceUserModel, 'findOne')
+        .mockResolvedValueOnce(mockWorworkspaceUserkspaceUser as any);
+
+      const result = await repository.findWorkspaceUser(
+        { memberId: '1' },
+        true,
+      );
+      expect(result).toBeInstanceOf(WorkspaceUser);
+      expect(result.member).toBeInstanceOf(User);
+    });
   });
 
   describe('getSpaceLimitInInvitations', () => {

--- a/src/modules/workspaces/repositories/workspaces.repository.ts
+++ b/src/modules/workspaces/repositories/workspaces.repository.ts
@@ -124,9 +124,11 @@ export class SequelizeWorkspaceRepository {
 
   async findWorkspaceUser(
     where: Partial<WorkspaceUserAttributes>,
+    includeUser = false,
   ): Promise<WorkspaceUser> {
     const workspaceUser = await this.modelWorkspaceUser.findOne({
       where,
+      include: includeUser ? [{ model: UserModel, as: 'member' }] : [],
     });
 
     return workspaceUser ? this.workspaceUserToDomain(workspaceUser) : null;

--- a/src/modules/workspaces/workspaces.controller.spec.ts
+++ b/src/modules/workspaces/workspaces.controller.spec.ts
@@ -631,4 +631,24 @@ describe('Workspace Controller', () => {
       ).resolves.toEqual(workspace.toJSON());
     });
   });
+
+  describe('DELETE /:workspaceId/members/:memberId', () => {
+    it('When a member is removed from the workspace, then it should call the service with the respective arguments', async () => {
+      const workspaceId = v4();
+      const memberId = v4();
+
+      jest
+        .spyOn(workspacesUsecases, 'removeWorkspaceMember')
+        .mockResolvedValue(Promise.resolve());
+
+      await expect(
+        workspacesController.removeWorkspaceMember(workspaceId, memberId),
+      ).resolves.toBeUndefined();
+
+      expect(workspacesUsecases.removeWorkspaceMember).toHaveBeenCalledWith(
+        workspaceId,
+        memberId,
+      );
+    });
+  });
 });

--- a/src/modules/workspaces/workspaces.controller.ts
+++ b/src/modules/workspaces/workspaces.controller.ts
@@ -995,4 +995,25 @@ export class WorkspacesController {
   ) {
     return this.workspaceUseCases.getWorkspaceDetails(workspaceId);
   }
+
+  @Delete(':workspaceId/members/:memberId')
+  @ApiBearerAuth()
+  @ApiOperation({
+    summary: 'Remove member from workspace',
+  })
+  @ApiParam({ name: 'workspaceId', type: String, required: true })
+  @ApiParam({ name: 'memberId', type: String, required: true })
+  @ApiOkResponse({
+    description: 'Member removed from workspace',
+  })
+  @UseGuards(WorkspaceGuard)
+  @WorkspaceRequiredAccess(AccessContext.WORKSPACE, WorkspaceRole.OWNER)
+  async removeWorkspaceMember(
+    @Param('workspaceId', ValidateUUIDPipe)
+    workspaceId: WorkspaceAttributes['id'],
+    @Param('memberId', ValidateUUIDPipe)
+    memberId: WorkspaceTeamAttributes['id'],
+  ) {
+    return this.workspaceUseCases.removeWorkspaceMember(workspaceId, memberId);
+  }
 }

--- a/src/modules/workspaces/workspaces.usecase.ts
+++ b/src/modules/workspaces/workspaces.usecase.ts
@@ -2213,6 +2213,26 @@ export class WorkspacesUsecases {
     await this.folderUseCases.renameFolder(movedFolder, user.username);
   }
 
+  async removeWorkspaceMember(
+    workspaceId: Workspace['id'],
+    memberId: User['uuid'],
+  ): Promise<void> {
+    const workspaceUserToRemove =
+      await this.workspaceRepository.findWorkspaceUser(
+        {
+          workspaceId,
+          memberId,
+        },
+        true,
+      );
+
+    if (!workspaceUserToRemove) {
+      throw new NotFoundException('User not found in workspace');
+    }
+
+    await this.leaveWorkspace(workspaceId, workspaceUserToRemove.member);
+  }
+
   async leaveWorkspace(
     workspaceId: Workspace['id'],
     user: User,
@@ -2246,6 +2266,7 @@ export class WorkspacesUsecases {
       workspaceId,
     );
   }
+
   async validateWorkspaceInvite(
     inviteId: WorkspaceInvite['id'],
   ): Promise<string> {


### PR DESCRIPTION
Endpoint to remove users from workspace. This ultimately uses the same usecase leaveWorkspace so the same logic is applied to user removal (files transfer to owner and team ownership transferred to owner if applicable)