### PR TITLE
[_] fix: removed build docker compose from unit tests action

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -37,11 +37,6 @@ jobs:
       - run: echo //npm.pkg.github.com/:_authToken=${{ secrets.PERSONAL_ACCESS_TOKEN }} >> .npmrc
       - run: echo "always-auth=true" >> .npmrc
 
-      - name: Setup environment
-        uses: isbang/compose-action@v1.4.1
-        with:
-          compose-file: './infrastructure/docker-compose.yml'
-
       - name: Install dependencies
         run: yarn
 


### PR DESCRIPTION
We have a problem with docker compose while running the test action. This command is actually not needed for this action, so I am removing it to make the pipeline work as expected.

![image](https://github.com/user-attachments/assets/cad643a2-e346-4809-a392-7f6168bd7fbe)
