### PR TITLE
[PB-2445]: fix/make-correct-ownership-transfer-when-leaving-the-workspace

### DIFF
--- a/src/modules/workspaces/repositories/team.repository.ts
+++ b/src/modules/workspaces/repositories/team.repository.ts
@@ -206,7 +206,7 @@ export class SequelizeWorkspaceTeamRepository {
     user: User,
   ): Promise<WorkspaceTeam[]> {
     const teams = await this.teamModel.findAll({
-      where: { workspaceId, ownerId: user.uuid },
+      where: { workspaceId, managerId: user.uuid },
     });
 
     return teams.map((team) => this.toDomain(team));

--- a/src/modules/workspaces/workspaces.usecase.spec.ts
+++ b/src/modules/workspaces/workspaces.usecase.spec.ts
@@ -4226,6 +4226,10 @@ describe('WorkspacesUsecases', () => {
           .spyOn(folderUseCases, 'renameFolder')
           .mockResolvedValueOnce(resultingRenamedFolder);
 
+        const shortIdentifier = Buffer.from(memberWorkspaceUser.id)
+          .toString('base64')
+          .substring(0, 6);
+
         await expect(
           service.transferPersonalItemsToWorkspaceOwner(workspace.id, member),
         ).resolves.toBeUndefined();
@@ -4236,7 +4240,7 @@ describe('WorkspacesUsecases', () => {
         );
         expect(folderUseCases.renameFolder).toHaveBeenCalledWith(
           resultingFolder,
-          member.username,
+          `${member.username} - ${shortIdentifier}`,
         );
       });
     });

--- a/src/modules/workspaces/workspaces.usecase.ts
+++ b/src/modules/workspaces/workspaces.usecase.ts
@@ -2236,15 +2236,22 @@ export class WorkspacesUsecases {
 
     await this.workspaceRepository.updateItemBy(
       {
-        createdBy: ownerWorkspaceUser.memberId,
+        createdBy: memberWorkspaceUser.memberId,
+        workspaceId,
       },
       {
-        workspaceId,
-        itemId: memberRootFolder.uuid,
+        createdBy: workspace.ownerId,
       },
     );
 
-    await this.folderUseCases.renameFolder(movedFolder, user.username);
+    const shortMemberIdentifier = Buffer.from(memberWorkspaceUser.id)
+      .toString('base64')
+      .substring(0, 6);
+
+    await this.folderUseCases.renameFolder(
+      movedFolder,
+      `${user.username} - ${shortMemberIdentifier}`,
+    );
   }
 
   async removeWorkspaceMember(


### PR DESCRIPTION
There was a bug where transferred files weren't correctly updated with the creator as the workspace owner. This resulted in a 403 error as the owner ended up attempting to access files that were not theirs.