### PR TITLE
[PB-2504: fix/file transfer space validation

### DIFF
--- a/src/modules/workspaces/workspaces.usecase.ts
+++ b/src/modules/workspaces/workspaces.usecase.ts
@@ -2212,7 +2212,7 @@ export class WorkspacesUsecases {
     const ownerUsage = await this.calculateFilesSizeSum(
       workspace.ownerId,
       workspace.id,
-      [FileStatus.EXISTS],
+      [FileStatus.EXISTS, FileStatus.TRASHED],
     );
 
     const combinedUsage = Number(memberUsage) + Number(ownerUsage);

--- a/src/modules/workspaces/workspaces.usecase.ts
+++ b/src/modules/workspaces/workspaces.usecase.ts
@@ -2206,7 +2206,7 @@ export class WorkspacesUsecases {
     const memberUsage = await this.calculateFilesSizeSum(
       user.uuid,
       workspace.id,
-      [FileStatus.EXISTS],
+      [FileStatus.EXISTS, FileStatus.TRASHED],
     );
 
     const ownerUsage = await this.calculateFilesSizeSum(

--- a/src/modules/workspaces/workspaces.usecase.ts
+++ b/src/modules/workspaces/workspaces.usecase.ts
@@ -2251,7 +2251,6 @@ export class WorkspacesUsecases {
         },
         { limit: 1, offset: 0 },
       );
-
     const filesInPersonalRootFolder =
       await this.fileUseCases.getFilesInWorkspace(
         user.uuid,


### PR DESCRIPTION
Temporary check to validate the owner has enough space to receive a removed member's files. This is temorary as it should be replaced by a "transfer ownership"  feature in an upcoming release.