### PR TITLE
[PB-2770] fix: check file existence with name encrypted backend side

### DIFF
--- a/src/modules/file/dto/create-file.dto.ts
+++ b/src/modules/file/dto/create-file.dto.ts
@@ -9,13 +9,6 @@ import {
 
 export class CreateFileDto {
   @ApiProperty({
-    description: 'The name of the file',
-    example: 'example',
-  })
-  @IsString()
-  name: string;
-
-  @ApiProperty({
     description: 'The bucket where the file is stored',
     example: 'my-bucket',
   })

--- a/src/modules/file/file.usecase.spec.ts
+++ b/src/modules/file/file.usecase.spec.ts
@@ -642,7 +642,6 @@ describe('FileUseCases', () => {
 
   describe('createFile', () => {
     const newFileDto: CreateFileDto = {
-      name: 'Test File',
       bucket: 'test-bucket',
       fileId: 'file-id',
       encryptVersion: 'v1',
@@ -676,7 +675,6 @@ describe('FileUseCases', () => {
       const existingFile = newFile({
         attributes: {
           folderId: folder.id,
-          name: newFileDto.name,
           plainName: newFileDto.plainName,
         },
       });

--- a/src/modules/file/file.usecase.ts
+++ b/src/modules/file/file.usecase.ts
@@ -98,19 +98,19 @@ export class FileUseCases {
       throw new ForbiddenException('Folder is not yours');
     }
 
+    const cryptoFileName = this.cryptoService.encryptName(
+      newFileDto.plainName,
+      folder.id,
+    );
+
     const maybeAlreadyExistentFile = await this.fileRepository.findOneBy({
-      name: newFileDto.name,
+      name: cryptoFileName,
       plainName: newFileDto.plainName,
       folderId: folder.id,
       ...(newFileDto.type ? { type: newFileDto.type } : null),
       userId: user.id,
       status: FileStatus.EXISTS,
     });
-
-    const cryptoFileName = this.cryptoService.encryptName(
-      newFileDto.plainName,
-      folder.id,
-    );
 
     const fileAlreadyExists = !!maybeAlreadyExistentFile;
 

--- a/src/modules/workspaces/repositories/workspaces.repository.ts
+++ b/src/modules/workspaces/repositories/workspaces.repository.ts
@@ -140,10 +140,6 @@ export class SequelizeWorkspaceRepository {
     await this.modelWorkspaceInvite.destroy({ where: { id: inviteId } });
   }
 
-  async createFile(inviteId: WorkspaceInviteAttributes['id']): Promise<void> {
-    await this.modelWorkspaceInvite.destroy({ where: { id: inviteId } });
-  }
-
   async createItem(
     item: Omit<WorkspaceItemUserAttributes, 'id'>,
   ): Promise<WorkspaceItemUser | null> {

--- a/src/modules/workspaces/workspaces.usecase.spec.ts
+++ b/src/modules/workspaces/workspaces.usecase.spec.ts
@@ -2018,7 +2018,6 @@ describe('WorkspacesUsecases', () => {
   describe('createFile', () => {
     const workspace = newWorkspace();
     const createFileDto: CreateWorkspaceFileDto = {
-      name: 'New File',
       bucket: 'bucket-id',
       fileId: 'file-id',
       encryptVersion: 'v1',

--- a/src/modules/workspaces/workspaces.usecase.ts
+++ b/src/modules/workspaces/workspaces.usecase.ts
@@ -755,14 +755,8 @@ export class WorkspacesUsecases {
       workspace.workspaceUserId,
     );
 
-    const cryptoFileName = this.cryptoService.encryptName(
-      createFileDto.plainName,
-      folder.id,
-    );
-
     const createdFile = await this.fileUseCases.createFile(networkUser, {
       ...createFileDto,
-      name: cryptoFileName,
     });
 
     const createdItemFile = await this.workspaceRepository.createItem({


### PR DESCRIPTION
We now encrypt the file names on the backend, this PR ignores the name value sent by the frontend.