### PR TITLE
[PB-2763] fix: add webhooks notifications on storage changes

### DIFF
--- a/src/externals/notifications/events/notification.event.ts
+++ b/src/externals/notifications/events/notification.event.ts
@@ -4,6 +4,7 @@ export class NotificationEvent extends Event {
   email: string;
   clientId: string;
   userId: string;
+  event: string;
 
   constructor(
     name: string,
@@ -11,10 +12,12 @@ export class NotificationEvent extends Event {
     email: string,
     clientId: string,
     userId: string,
+    event?: string,
   ) {
     super(name, payload);
     this.email = email;
     this.clientId = clientId;
     this.userId = userId;
+    this.event = event;
   }
 }

--- a/src/externals/notifications/listeners/notification.listener.ts
+++ b/src/externals/notifications/listeners/notification.listener.ts
@@ -15,7 +15,7 @@ export class NotificationListener {
 
   @OnEvent('notification.*')
   async handleNotificationEvent(event: NotificationEvent) {
-    Logger.log(`event ${event.name} handled`, 'NotificationListener');
+    Logger.log(`event ${event.name} handled`, this.constructor.name);
     const apiNotificationURL: string = this.configService.get(
       'apis.notifications.url',
     );
@@ -23,7 +23,7 @@ export class NotificationListener {
       'X-API-KEY': this.configService.get('apis.notifications.key') as string,
     };
     const eventData = {
-      event: event.name,
+      event: event.event,
       payload: event.payload,
       email: event.email,
       clientId: event.clientId,
@@ -34,13 +34,19 @@ export class NotificationListener {
         headers,
       })
       .catch((err) => {
-        Logger.error(`eror in event ${event.name}`, err);
+        Logger.error(
+          `[NOTIFICATIONS_ERROR] Error in event ${event.name}: ${
+            err.message
+          } Data: ${JSON.stringify(eventData, null, null)}`,
+          this.constructor.name,
+        );
       });
     if (res && res.status !== 201) {
       Logger.warn(
         `Post to notifications service failed with status ${
           res.status
-        }. Data: ${JSON.stringify(eventData, null, 2)}`,
+        }. Data: ${JSON.stringify(eventData, null, null)}`,
+        this.constructor.name,
       );
     }
   }

--- a/src/externals/notifications/notifications.module.ts
+++ b/src/externals/notifications/notifications.module.ts
@@ -9,18 +9,20 @@ import { AnalyticsListener } from './listeners/analytics.listener';
 import { ShareLinkListener } from './listeners/share-link.listener';
 import { AuthListener } from './listeners/auth.listener';
 import { NewsletterService } from '../newsletter';
+import { StorageNotificationService } from './storage.notifications.service';
 @Module({
   imports: [ConfigModule, HttpClientModule, MailerModule],
   controllers: [],
   providers: [
     NotificationService,
     NotificationListener,
+    StorageNotificationService,
     AnalyticsListener,
     SendLinkListener,
     ShareLinkListener,
     AuthListener,
     NewsletterService,
   ],
-  exports: [NotificationService],
+  exports: [NotificationService, StorageNotificationService],
 })
 export class NotificationModule {}

--- a/src/externals/notifications/storage.notifications.service.ts
+++ b/src/externals/notifications/storage.notifications.service.ts
@@ -1,0 +1,88 @@
+import { Injectable } from '@nestjs/common';
+import { NotificationService } from './notification.service';
+import { User } from '../../modules/user/user.domain';
+import { NotificationEvent } from './events/notification.event';
+
+enum StorageEvents {
+  FILE_CREATED = 'FILE_CREATED',
+  FOLDER_CREATED = 'FOLDER_CREATED',
+  FILE_UPDATED = 'FILE_UPDATED',
+  FOLDER_UPDATED = 'FOLDER_UPDATED',
+  ITEMS_TO_TRASH = 'ITEMS_TO_TRASH',
+}
+
+interface EventArguments {
+  payload: any;
+  user: User;
+  clientId: string;
+}
+
+@Injectable()
+export class StorageNotificationService {
+  constructor(private notificationService: NotificationService) {}
+
+  fileCreated({ payload, user, clientId }: EventArguments) {
+    const event = new NotificationEvent(
+      'notification.itemCreated',
+      payload,
+      user.email,
+      clientId,
+      user.uuid,
+      StorageEvents.FILE_CREATED,
+    );
+
+    this.notificationService.add(event);
+  }
+
+  fileUpdated({ payload, user, clientId }: EventArguments) {
+    const event = new NotificationEvent(
+      'notification.itemUpdated',
+      payload,
+      user.email,
+      clientId,
+      user.uuid,
+      StorageEvents.FILE_UPDATED,
+    );
+
+    this.notificationService.add(event);
+  }
+
+  folderCreated({ payload, user, clientId }: EventArguments) {
+    const event = new NotificationEvent(
+      'notification.itemCreated',
+      payload,
+      user.email,
+      clientId,
+      user.uuid,
+      StorageEvents.FOLDER_CREATED,
+    );
+
+    this.notificationService.add(event);
+  }
+
+  folderUpdated({ payload, user, clientId }: EventArguments) {
+    const event = new NotificationEvent(
+      'notification.itemUpdated',
+      payload,
+      user.email,
+      clientId,
+      user.uuid,
+      StorageEvents.FOLDER_UPDATED,
+    );
+
+    this.notificationService.add(event);
+  }
+
+  itemsTrashed({ payload, user, clientId }: EventArguments) {
+    const event = new NotificationEvent(
+      'notification.itemsToTrash',
+      payload,
+      user.email,
+      clientId,
+      user.uuid,
+      StorageEvents.ITEMS_TO_TRASH,
+    );
+
+    this.notificationService.add(event);
+  }
+}

--- a/src/modules/file/file.controller.spec.ts
+++ b/src/modules/file/file.controller.spec.ts
@@ -57,6 +57,7 @@ describe('FileController', () => {
   });
 
   describe('move file', () => {
+    const clientId = 'drive-web';
     it('When move file is requested with valid params, then the file is returned with its updated properties', async () => {
       const destinationFolder = newFolder();
       const expectedFile = newFile({
@@ -71,23 +72,38 @@ describe('FileController', () => {
 
       jest.spyOn(fileUseCases, 'moveFile').mockResolvedValue(expectedFile);
 
-      const result = await fileController.moveFile(userMocked, file.uuid, {
-        destinationFolder: destinationFolder.uuid,
-      });
+      const result = await fileController.moveFile(
+        userMocked,
+        file.uuid,
+        {
+          destinationFolder: destinationFolder.uuid,
+        },
+        clientId,
+      );
       expect(result).toEqual(expectedFile);
     });
 
     it('When move file is requested with invalid params, then it should throw an error', () => {
       expect(
-        fileController.moveFile(userMocked, 'invaliduuid', {
-          destinationFolder: v4(),
-        }),
+        fileController.moveFile(
+          userMocked,
+          'invaliduuid',
+          {
+            destinationFolder: v4(),
+          },
+          clientId,
+        ),
       ).rejects.toThrow(BadRequestException);
 
       expect(
-        fileController.moveFile(userMocked, v4(), {
-          destinationFolder: 'invaliduuid',
-        }),
+        fileController.moveFile(
+          userMocked,
+          v4(),
+          {
+            destinationFolder: 'invaliduuid',
+          },
+          clientId,
+        ),
       ).rejects.toThrow(BadRequestException);
     });
   });

--- a/src/modules/file/file.controller.ts
+++ b/src/modules/file/file.controller.ts
@@ -61,13 +61,15 @@ export class FileController {
     @Body() createFileDto: CreateFileDto,
     @Client() clientId: string,
   ) {
-    const result = await this.fileUseCases.createFile(user, createFileDto);
+    const file = await this.fileUseCases.createFile(user, createFileDto);
 
     this.storageNotificationService.fileCreated({
-      payload: result,
+      payload: file,
       user: user,
       clientId,
     });
+
+    return file;
   }
 
   @Get('/count')

--- a/src/modules/file/file.module.ts
+++ b/src/modules/file/file.module.ts
@@ -14,6 +14,7 @@ import { FileModel } from './file.model';
 import { SharingModule } from '../sharing/sharing.module';
 import { WorkspacesModule } from '../workspaces/workspaces.module';
 import { UserModule } from '../user/user.module';
+import { NotificationModule } from '../../externals/notifications/notifications.module';
 
 @Module({
   imports: [
@@ -26,6 +27,7 @@ import { UserModule } from '../user/user.module';
     BridgeModule,
     CryptoModule,
     UserModule,
+    NotificationModule,
   ],
   controllers: [FileController],
   providers: [SequelizeFileRepository, FileUseCases],

--- a/src/modules/folder/folder.controller.spec.ts
+++ b/src/modules/folder/folder.controller.spec.ts
@@ -264,6 +264,8 @@ describe('FolderController', () => {
   });
 
   describe('move folder', () => {
+    const clientId = 'drive-web';
+
     it('When move folder is requested with valid params, then the folder is returned with its updated properties', async () => {
       const destinationFolder = newFolder();
       const expectedFolder = newFolder({
@@ -282,21 +284,32 @@ describe('FolderController', () => {
         userMocked,
         folder.uuid,
         { destinationFolder: destinationFolder.uuid },
+        clientId,
       );
       expect(result).toEqual(expectedFolder);
     });
 
     it('When move folder is requested with invalid params, then it should throw an error', () => {
       expect(
-        folderController.moveFolder(userMocked, 'invaliduuid', {
-          destinationFolder: v4(),
-        }),
+        folderController.moveFolder(
+          userMocked,
+          'invaliduuid',
+          {
+            destinationFolder: v4(),
+          },
+          clientId,
+        ),
       ).rejects.toThrow(BadRequestException);
 
       expect(
-        folderController.moveFolder(userMocked, v4(), {
-          destinationFolder: 'invaliduuid',
-        }),
+        folderController.moveFolder(
+          userMocked,
+          v4(),
+          {
+            destinationFolder: 'invaliduuid',
+          },
+          clientId,
+        ),
       ).rejects.toThrow(BadRequestException);
     });
   });

--- a/src/modules/folder/folder.module.ts
+++ b/src/modules/folder/folder.module.ts
@@ -11,6 +11,7 @@ import { UserModel } from '../user/user.model';
 import { UserModule } from '../user/user.module';
 import { SharingModule } from '../sharing/sharing.module';
 import { WorkspacesModule } from '../workspaces/workspaces.module';
+import { NotificationModule } from '../../externals/notifications/notifications.module';
 
 @Module({
   imports: [
@@ -20,6 +21,7 @@ import { WorkspacesModule } from '../workspaces/workspaces.module';
     CryptoModule,
     forwardRef(() => SharingModule),
     forwardRef(() => WorkspacesModule),
+    NotificationModule,
   ],
   controllers: [FolderController],
   providers: [SequelizeFolderRepository, CryptoService, FolderUseCases],

--- a/src/modules/trash/trash.controller.spec.ts
+++ b/src/modules/trash/trash.controller.spec.ts
@@ -4,7 +4,6 @@ import { FileUseCases } from '../file/file.usecase';
 import { FolderUseCases } from '../folder/folder.usecase';
 import { UserUseCases } from '../user/user.usecase';
 import { TrashUseCases } from './trash.usecase';
-import { NotificationService } from '../../externals/notifications/notification.service';
 import { newUser } from '../../../test/fixtures';
 import { BadRequestException } from '@nestjs/common';
 import { ItemType } from './dto/controllers/move-items-to-trash.dto';
@@ -12,6 +11,7 @@ import {
   DeleteItemType,
   DeleteItemsDto,
 } from './dto/controllers/delete-item.dto';
+import { StorageNotificationService } from '../../externals/notifications/storage.notifications.service';
 
 const user = newUser();
 
@@ -21,19 +21,19 @@ describe('TrashController', () => {
   let fileUseCases: FileUseCases;
   let userUseCases: UserUseCases;
   let trashUseCases: TrashUseCases;
-  let notificationService: NotificationService;
+  let storageNotificationService: StorageNotificationService;
 
   beforeEach(async () => {
     folderUseCases = createMock<FolderUseCases>();
     fileUseCases = createMock<FileUseCases>();
     userUseCases = createMock<UserUseCases>();
     trashUseCases = createMock<TrashUseCases>();
-    notificationService = createMock<NotificationService>();
+    storageNotificationService = createMock<StorageNotificationService>();
     controller = new TrashController(
       fileUseCases,
       folderUseCases,
       userUseCases,
-      notificationService,
+      storageNotificationService,
       trashUseCases,
     );
   });

--- a/src/modules/trash/trash.controller.ts
+++ b/src/modules/trash/trash.controller.ts
@@ -30,8 +30,6 @@ import { Client } from '../auth/decorators/client.decorator';
 import { FileUseCases } from '../file/file.usecase';
 import { FolderUseCases } from '../folder/folder.usecase';
 import { UserUseCases } from '../user/user.usecase';
-import { ItemsToTrashEvent } from '../../externals/notifications/events/items-to-trash.event';
-import { NotificationService } from '../../externals/notifications/notification.service';
 import { User } from '../user/user.domain';
 import { TrashUseCases } from './trash.usecase';
 import {

--- a/src/modules/trash/trash.module.ts
+++ b/src/modules/trash/trash.module.ts
@@ -23,6 +23,7 @@ import { SharingModule } from '../sharing/sharing.module';
     NotificationModule,
     UserModule,
     ShareModule,
+    NotificationModule,
   ],
   controllers: [TrashController],
   providers: [Logger, TrashUseCases],


### PR DESCRIPTION
Moving websockets implementations to drive-server-wip and also fixing notification on items trashed. 

Original implementation:
https://github.com/internxt/drive-server/blob/46d90c4ac8bff466b190a45d86b548b17a0f3f43/src/config/initializers/notifications.ts