### PR TITLE
[_] chore: removed event handled log

### DIFF
--- a/src/externals/notifications/listeners/notification.listener.ts
+++ b/src/externals/notifications/listeners/notification.listener.ts
@@ -15,7 +15,6 @@ export class NotificationListener {
 
   @OnEvent('notification.*')
   async handleNotificationEvent(event: NotificationEvent) {
-    Logger.log(`event ${event.name} handled`, this.constructor.name);
     const apiNotificationURL: string = this.configService.get(
       'apis.notifications.url',
     );


### PR DESCRIPTION
Removing a previous log from the notifications listener. I noticed we reach to almost 3000 records of this log in less than 30 minutes.

This gets logged too much as it is done for multiple actions. We do not need to know every time an event is received, it is enough if we just log the errors and possible not 201 responses from the notifications API.