### PR TITLE
[PB-2424] Chore: use query to get information about Shared Items

### DIFF
--- a/src/modules/workspaces/guards/workspaces-resources-in-items-in-behalf.guard.ts
+++ b/src/modules/workspaces/guards/workspaces-resources-in-items-in-behalf.guard.ts
@@ -88,7 +88,7 @@ export class WorkspacesResourcesItemsInBehalfGuard implements CanActivate {
 
     const actionHandler = this.getActionHandler(action);
 
-    const bypassActionCheck = request.query.isSharedItem;
+    const bypassActionCheck = request.query?.isSharedItem || false;
 
     const canUserPerformAction = bypassActionCheck
       ? true

--- a/src/modules/workspaces/guards/workspaces-resources-in-items-in-behalf.guard.ts
+++ b/src/modules/workspaces/guards/workspaces-resources-in-items-in-behalf.guard.ts
@@ -88,7 +88,7 @@ export class WorkspacesResourcesItemsInBehalfGuard implements CanActivate {
 
     const actionHandler = this.getActionHandler(action);
 
-    const bypassActionCheck = request.isSharedItem;
+    const bypassActionCheck = request.query.isSharedItem;
 
     const canUserPerformAction = bypassActionCheck
       ? true


### PR DESCRIPTION
### Update
- Fix: using `query` to get the information about `isSharedItem`. 

### Related to
- sdk : https://github.com/internxt/sdk/pull/246
- web : https://github.com/internxt/drive-web/pull/1290