### PR TITLE
[PB-3045]: fix/get-ancestors-in-workspace

### DIFF
--- a/migrations/20241004142347-get-folder-ancestor-omit-root-children.js
+++ b/migrations/20241004142347-get-folder-ancestor-omit-root-children.js
@@ -1,0 +1,42 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface) {
+    await queryInterface.sequelize.query(`
+      CREATE OR REPLACE FUNCTION get_folder_ancestors_excluding_root_children(folder_id UUID, u_id INT)
+      RETURNS setof folders AS $$
+      BEGIN
+        RETURN QUERY
+        WITH RECURSIVE hier AS (
+          SELECT c.*
+          FROM folders c
+          WHERE c.removed = FALSE
+          AND c.uuid = folder_id
+          UNION
+          SELECT f.*
+          FROM folders f
+          INNER JOIN hier fh ON fh.parent_id = f.id
+          WHERE f.removed = FALSE
+          AND f.user_id = u_id
+          AND f.parent_id IS NOT NULL
+          AND NOT EXISTS (
+            SELECT 1
+            FROM folders root
+            WHERE root.id = f.parent_id
+            AND root.parent_id IS NULL
+          )
+        )
+        SELECT * FROM hier
+        WHERE parent_id IS NOT NULL; -- Exclude the root folder itself
+      END;
+      $$ LANGUAGE plpgsql;
+    `);
+  },
+
+  async down(queryInterface) {
+    await queryInterface.sequelize.query(
+      'drop function get_folder_ancestors_excluding_root_children;',
+    );
+  },
+};

--- a/src/modules/folder/folder.controller.spec.ts
+++ b/src/modules/folder/folder.controller.spec.ts
@@ -476,4 +476,66 @@ describe('FolderController', () => {
       ).rejects.toThrow(InvalidParentFolderException);
     });
   });
+
+  describe('getgetFolderAncestors', () => {
+    it('When get folder ancestors is requested with workspace query param as false, then it should return the ancestors', async () => {
+      const user = newUser();
+      const folder = newFolder({ owner: user });
+      const mockAncestors = [
+        newFolder({
+          attributes: { parentUuid: folder.parentUuid },
+          owner: user,
+        }),
+        newFolder({
+          attributes: { parentUuid: folder.parentUuid },
+          owner: user,
+        }),
+      ];
+
+      jest
+        .spyOn(folderUseCases, 'getFolderAncestors')
+        .mockResolvedValue(mockAncestors);
+
+      const result = await folderController.getFolderAncestors(
+        user,
+        folder.uuid,
+        false,
+      );
+      expect(result).toEqual({ ancestors: mockAncestors });
+      expect(folderUseCases.getFolderAncestors).toHaveBeenCalledWith(
+        user,
+        folder.uuid,
+      );
+    });
+
+    it('When get folder ancestors is requested with workspace query param as true, then it should return the ancestors', async () => {
+      const user = newUser();
+      const folder = newFolder({ owner: user });
+      const mockAncestors = [
+        newFolder({
+          attributes: { parentUuid: folder.parentUuid },
+          owner: user,
+        }),
+        newFolder({
+          attributes: { parentUuid: folder.parentUuid },
+          owner: user,
+        }),
+      ];
+
+      jest
+        .spyOn(folderUseCases, 'getFolderAncestors')
+        .mockResolvedValue(mockAncestors);
+
+      const result = await folderController.getFolderAncestors(
+        user,
+        folder.uuid,
+        true,
+      );
+      expect(result).toEqual({ ancestors: mockAncestors });
+      expect(folderUseCases.getFolderAncestorsInWorkspace).toHaveBeenCalledWith(
+        user,
+        folder.uuid,
+      );
+    });
+  });
 });

--- a/src/modules/folder/folder.controller.spec.ts
+++ b/src/modules/folder/folder.controller.spec.ts
@@ -501,7 +501,7 @@ describe('FolderController', () => {
         folder.uuid,
         false,
       );
-      expect(result).toEqual({ ancestors: mockAncestors });
+      expect(result).toEqual(mockAncestors);
       expect(folderUseCases.getFolderAncestors).toHaveBeenCalledWith(
         user,
         folder.uuid,
@@ -523,7 +523,7 @@ describe('FolderController', () => {
       ];
 
       jest
-        .spyOn(folderUseCases, 'getFolderAncestors')
+        .spyOn(folderUseCases, 'getFolderAncestorsInWorkspace')
         .mockResolvedValue(mockAncestors);
 
       const result = await folderController.getFolderAncestors(
@@ -531,7 +531,7 @@ describe('FolderController', () => {
         folder.uuid,
         true,
       );
-      expect(result).toEqual({ ancestors: mockAncestors });
+      expect(result).toEqual(mockAncestors);
       expect(folderUseCases.getFolderAncestorsInWorkspace).toHaveBeenCalledWith(
         user,
         folder.uuid,

--- a/src/modules/folder/folder.controller.ts
+++ b/src/modules/folder/folder.controller.ts
@@ -20,6 +20,7 @@ import {
   ApiOkResponse,
   ApiOperation,
   ApiParam,
+  ApiQuery,
   ApiTags,
 } from '@nestjs/swagger';
 import { FolderUseCases } from './folder.usecase';
@@ -690,16 +691,24 @@ export class FolderController {
       value: 'folder',
     },
   ])
+  @ApiQuery({
+    name: 'workspace',
+    description: 'If true, will return ancestors in workspace',
+    type: Boolean,
+  })
   @WorkspacesInBehalfValidationFolder()
   async getFolderAncestors(
     @UserDecorator() user: User,
     @Param('uuid') folderUuid: Folder['uuid'],
+    @Query('workspace') workspace: boolean,
   ) {
     if (!validate(folderUuid)) {
       throw new BadRequestException('Invalid UUID provided');
     }
 
-    return this.folderUseCases.getFolderAncestors(user, folderUuid);
+    return !workspace
+      ? this.folderUseCases.getFolderAncestors(user, folderUuid)
+      : this.folderUseCases.getFolderAncestorsInWorkspace(user, folderUuid);
   }
 
   @Get('/:uuid/tree')

--- a/src/modules/folder/folder.usecase.spec.ts
+++ b/src/modules/folder/folder.usecase.spec.ts
@@ -1252,4 +1252,23 @@ describe('FolderUseCases', () => {
       });
     });
   });
+
+  describe('getFolderAncestorsInWorkspace', () => {
+    it('Should return the ancestors of a folder in a workspace', async () => {
+      const user = newUser();
+      const folder = newFolder({ attributes: { userId: user.id } });
+      const ancestors = [newFolder({ owner: user })];
+
+      jest
+        .spyOn(folderRepository, 'getFolderAncestorsInWorkspace')
+        .mockResolvedValueOnce(ancestors);
+
+      const result = await service.getFolderAncestorsInWorkspace(
+        user,
+        folder.uuid,
+      );
+
+      expect(result).toEqual(ancestors);
+    });
+  });
 });

--- a/src/modules/folder/folder.usecase.ts
+++ b/src/modules/folder/folder.usecase.ts
@@ -715,6 +715,16 @@ export class FolderUseCases {
     return this.folderRepository.getFolderAncestors(user, folderUuid);
   }
 
+  getFolderAncestorsInWorkspace(
+    user: User,
+    folderUuid: Folder['uuid'],
+  ): Promise<Folder[]> {
+    return this.folderRepository.getFolderAncestorsInWorkspace(
+      user,
+      folderUuid,
+    );
+  }
+
   async moveFolder(
     user: User,
     folderUuid: Folder['uuid'],


### PR DESCRIPTION
Added a function that exclude direct children of a root folder, in the case of workspaces those are indiviudual root folder. So this fixes an error where currently the ancestors endpoint returns the user's root folder.