### PR TITLE
[_]: fix/retrun user's root folder when retrieving ancestors in workspaces

### DIFF
--- a/migrations/20241018040841-modify-get-folder-ancestor-omit-root-children-function.js
+++ b/migrations/20241018040841-modify-get-folder-ancestor-omit-root-children-function.js
@@ -1,0 +1,36 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface) {
+    await queryInterface.sequelize.query(`
+      CREATE OR REPLACE FUNCTION get_folder_ancestors_excluding_root_children(folder_id UUID, u_id INT)
+      RETURNS setof folders AS $$
+      BEGIN
+        RETURN QUERY
+        WITH RECURSIVE hier AS (
+          SELECT c.*
+          FROM folders c
+          WHERE c.removed = FALSE
+          AND c.uuid = folder_id
+          UNION
+          SELECT f.*
+          FROM folders f
+          INNER JOIN hier fh ON fh.parent_id = f.id
+          WHERE f.removed = FALSE
+          AND f.user_id = u_id
+          AND f.parent_id IS NOT NULL
+        )
+        SELECT * FROM hier
+        WHERE parent_id IS NOT NULL; -- Exclude the root folder itself
+      END;
+      $$ LANGUAGE plpgsql;
+    `);
+  },
+
+  async down(queryInterface) {
+    await queryInterface.sequelize.query(
+      'drop function get_folder_ancestors_excluding_root_children;',
+    );
+  },
+};

--- a/src/modules/auth/decorators/workspace.decorator.ts
+++ b/src/modules/auth/decorators/workspace.decorator.ts
@@ -1,0 +1,8 @@
+import { createParamDecorator, ExecutionContext } from '@nestjs/common';
+
+export const Workspace = createParamDecorator(
+  async (_, ctx: ExecutionContext) => {
+    const req = ctx.switchToHttp().getRequest();
+    return req.workspace || undefined;
+  },
+);

--- a/src/modules/folder/folder.controller.spec.ts
+++ b/src/modules/folder/folder.controller.spec.ts
@@ -2,7 +2,12 @@ import { createMock } from '@golevelup/ts-jest';
 import { Test, TestingModule } from '@nestjs/testing';
 import { BadRequestException } from '@nestjs/common';
 import { v4 } from 'uuid';
-import { newFile, newFolder, newUser } from '../../../test/fixtures';
+import {
+  newFile,
+  newFolder,
+  newUser,
+  newWorkspace,
+} from '../../../test/fixtures';
 import { FileUseCases } from '../file/file.usecase';
 import {
   BadRequestInvalidOffsetException,
@@ -478,9 +483,10 @@ describe('FolderController', () => {
   });
 
   describe('getgetFolderAncestors', () => {
-    it('When get folder ancestors is requested with workspace query param as false, then it should return the ancestors', async () => {
+    it('When get folder ancestors is requested with workspace as undefined, then it should return the ancestors', async () => {
       const user = newUser();
       const folder = newFolder({ owner: user });
+      const workspace = undefined;
       const mockAncestors = [
         newFolder({
           attributes: { parentUuid: folder.parentUuid },
@@ -498,8 +504,8 @@ describe('FolderController', () => {
 
       const result = await folderController.getFolderAncestors(
         user,
+        workspace,
         folder.uuid,
-        false,
       );
       expect(result).toEqual(mockAncestors);
       expect(folderUseCases.getFolderAncestors).toHaveBeenCalledWith(
@@ -508,9 +514,10 @@ describe('FolderController', () => {
       );
     });
 
-    it('When get folder ancestors is requested with workspace query param as true, then it should return the ancestors', async () => {
+    it('When get folder ancestors is requested with a workspace, then it should return the ancestors', async () => {
       const user = newUser();
       const folder = newFolder({ owner: user });
+      const workspace = newWorkspace({ owner: user });
       const mockAncestors = [
         newFolder({
           attributes: { parentUuid: folder.parentUuid },
@@ -528,8 +535,8 @@ describe('FolderController', () => {
 
       const result = await folderController.getFolderAncestors(
         user,
+        workspace,
         folder.uuid,
-        true,
       );
       expect(result).toEqual(mockAncestors);
       expect(folderUseCases.getFolderAncestorsInWorkspace).toHaveBeenCalledWith(

--- a/src/modules/folder/folder.controller.ts
+++ b/src/modules/folder/folder.controller.ts
@@ -25,6 +25,7 @@ import {
 } from '@nestjs/swagger';
 import { FolderUseCases } from './folder.usecase';
 import { User as UserDecorator } from '../auth/decorators/user.decorator';
+import { Workspace as WorkspaceDecorator } from '../auth/decorators/workspace.decorator';
 import { User } from '../user/user.domain';
 import { FileUseCases } from '../file/file.usecase';
 import {
@@ -56,6 +57,7 @@ import { GetDataFromRequest } from '../../common/extract-data-from-request';
 import { StorageNotificationService } from '../../externals/notifications/storage.notifications.service';
 import { Client } from '../auth/decorators/client.decorator';
 import { BasicPaginationDto } from '../../common/dto/basic-pagination.dto';
+import { Workspace } from '../workspaces/domains/workspaces.domain';
 
 const foldersStatuses = ['ALL', 'EXISTS', 'TRASHED', 'DELETED'] as const;
 
@@ -699,8 +701,8 @@ export class FolderController {
   @WorkspacesInBehalfValidationFolder()
   async getFolderAncestors(
     @UserDecorator() user: User,
+    @WorkspaceDecorator() workspace: Workspace,
     @Param('uuid') folderUuid: Folder['uuid'],
-    @Query('workspace') workspace: boolean,
   ) {
     if (!validate(folderUuid)) {
       throw new BadRequestException('Invalid UUID provided');

--- a/src/modules/workspaces/guards/workspaces-resources-in-items-in-behalf.guard.spec.ts
+++ b/src/modules/workspaces/guards/workspaces-resources-in-items-in-behalf.guard.spec.ts
@@ -268,6 +268,9 @@ describe('WorkspacesResourcesItemsInBehalfGuard', () => {
       expect(excutionContext.switchToHttp().getRequest().requester).toEqual(
         user,
       );
+      expect(excutionContext.switchToHttp().getRequest().workspace).toEqual(
+        workspace,
+      );
     });
   });
 

--- a/src/modules/workspaces/guards/workspaces-resources-in-items-in-behalf.guard.ts
+++ b/src/modules/workspaces/guards/workspaces-resources-in-items-in-behalf.guard.ts
@@ -105,6 +105,7 @@ export class WorkspacesResourcesItemsInBehalfGuard implements CanActivate {
 
     request.user = behalfUser;
     request.requester = requester;
+    request.workspace = workspace;
 
     return true;
   }


### PR DESCRIPTION
In #407 I excluded both the workspace root folder and the user's root folder from the ancestors result. Turns out that that the ancestors call for personal drives always returns the root folder, so for compatibility this PR fixes this and now only the workspace's root folder is excluded.