### PR TITLE
[PB-2347]: feat/assign free storage to owner

### DIFF
--- a/migrations/20241029132704-update--workspace-owners-space-limit.js
+++ b/migrations/20241029132704-update--workspace-owners-space-limit.js
@@ -1,0 +1,37 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface) {
+    await queryInterface.sequelize.query(`
+      -- seats
+      WITH workspace_seats AS (
+        SELECT 
+          w.number_of_seats as seats,
+          w.id
+        FROM 
+          workspaces w
+      ),
+
+      -- members
+      workspace_members AS (
+        SELECT 
+          wu.workspace_id, 
+          COUNT(wu.member_id) AS members
+        FROM 
+          workspace_users wu
+        GROUP BY 
+          wu.workspace_id
+      )
+
+      UPDATE workspace_users wu
+      SET space_limit = (wu.space_limit * ws.seats) - (wu.space_limit * (wm.members - 1))
+      FROM workspace_seats ws
+      INNER JOIN workspace_members wm ON ws.id = wm.workspace_id
+      WHERE wu.workspace_id = ws.id
+      AND wu.member_id = (SELECT owner_id FROM workspaces w WHERE w.id = wu.workspace_id);
+    `);
+  },
+
+  async down() {},
+};

--- a/src/modules/workspaces/domains/workspaces.domain.ts
+++ b/src/modules/workspaces/domains/workspaces.domain.ts
@@ -62,8 +62,8 @@ export class Workspace implements WorkspaceAttributes {
     return this.setupCompleted === true;
   }
 
-  isWorkspaceFull(currentUsersCount: number) {
-    return this.numberOfSeats <= currentUsersCount;
+  isWorkspaceFull(currentUsersCount: number, numberOfInvites: number = 0) {
+    return this.numberOfSeats <= currentUsersCount + numberOfInvites;
   }
 
   isDefaultTeam(team: WorkspaceTeam) {

--- a/src/modules/workspaces/dto/create-workspace-invite.dto.ts
+++ b/src/modules/workspaces/dto/create-workspace-invite.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsNotEmpty } from 'class-validator';
+import { IsNotEmpty, IsPositive } from 'class-validator';
 import { User } from '../../user/user.domain';
 import { WorkspaceInvite } from '../domains/workspace-invite.domain';
 
@@ -11,6 +11,11 @@ export class CreateWorkspaceInviteDto {
   @IsNotEmpty()
   invitedUser: User['email'];
 
+  @ApiProperty({
+    example: '1073741824',
+    description: 'Space assigned to user in bytes',
+  })
+  @IsPositive()
   spaceLimit?: WorkspaceInvite['spaceLimit'];
 
   @ApiProperty({

--- a/src/modules/workspaces/workspaces.usecase.spec.ts
+++ b/src/modules/workspaces/workspaces.usecase.spec.ts
@@ -1531,19 +1531,25 @@ describe('WorkspacesUsecases', () => {
     const workspace = newWorkspace();
     const workspaceDefaultUser = newUser();
     it('When there is space left, then it should return the correct space left', async () => {
-      jest.spyOn(networkService, 'getLimit').mockResolvedValue(1000000);
+      const limit = 1000000;
+      const usedInUsers = 500000;
+      const assignedInInvitations = 200000;
+
+      jest.spyOn(networkService, 'getLimit').mockResolvedValue(limit);
       jest
         .spyOn(workspaceRepository, 'getTotalSpaceLimitInWorkspaceUsers')
-        .mockResolvedValue(500000);
-      /* jest
+        .mockResolvedValue(usedInUsers);
+      jest
         .spyOn(workspaceRepository, 'getSpaceLimitInInvitations')
-        .mockResolvedValue(200000); */
+        .mockResolvedValue(assignedInInvitations);
 
       const assignableSpace = await service.getAssignableSpaceInWorkspace(
         workspace,
         workspaceDefaultUser,
       );
-      expect(assignableSpace).toBe(500000);
+      expect(assignableSpace).toBe(
+        limit - (usedInUsers + assignedInInvitations),
+      );
     });
   });
 


### PR DESCRIPTION
All/any unasigned space in the workspace is assigned to the owner. Whenever a user joins space specified in the invite gets deducted from the owner, and whenever a user leaves or is kicked from the workspace that space will be reassigned to the owner.

This PR contains changes made in #402 