### PR TITLE
[_]: fix/restore old folders/existence GET with query param

### DIFF
--- a/src/modules/folder/dto/folder-existence-in-folder-old.dto.ts
+++ b/src/modules/folder/dto/folder-existence-in-folder-old.dto.ts
@@ -1,0 +1,22 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Transform } from 'class-transformer';
+import { IsString, ArrayMaxSize, IsArray } from 'class-validator';
+
+export class CheckFoldersExistenceOldDto {
+  @ApiProperty({
+    description: 'Plain name of folder or array of plain names',
+    example: ['My folder'],
+  })
+  @IsArray()
+  @ArrayMaxSize(50, {
+    message: 'Names parameter cannot contain more than 50 names',
+  })
+  @IsString({ each: true })
+  @Transform(({ value }) => {
+    if (typeof value === 'string') {
+      return [value];
+    }
+    return value;
+  })
+  plainName: string[];
+}

--- a/src/modules/folder/folder.controller.spec.ts
+++ b/src/modules/folder/folder.controller.spec.ts
@@ -377,6 +377,53 @@ describe('FolderController', () => {
     });
   });
 
+  describe('checkFoldersExistenceInFolderOld', () => {
+    const user = newUser();
+    const folderUuid = v4();
+    const plainNames = ['Documents', 'Photos'];
+
+    it('When valid folderUuid and plainNames are provided, then it should return existent folders', async () => {
+      const mockFolders = [
+        newFolder({ attributes: { plainName: 'Documents', userId: user.id } }),
+        newFolder({ attributes: { plainName: 'Photos', userId: user.id } }),
+      ];
+
+      jest
+        .spyOn(folderUseCases, 'searchFoldersInFolder')
+        .mockResolvedValue(mockFolders);
+
+      const result = await folderController.checkFoldersExistenceInFolderOld(
+        user,
+        folderUuid,
+        { plainName: plainNames },
+      );
+
+      expect(result).toEqual({ existentFolders: mockFolders });
+      expect(folderUseCases.searchFoldersInFolder).toHaveBeenCalledWith(
+        user,
+        folderUuid,
+        { plainNames },
+      );
+    });
+
+    it('When folders are not found, then it should return an empty array', async () => {
+      jest.spyOn(folderUseCases, 'searchFoldersInFolder').mockResolvedValue([]);
+
+      const result = await folderController.checkFoldersExistenceInFolderOld(
+        user,
+        folderUuid,
+        { plainName: plainNames },
+      );
+
+      expect(result).toEqual({ existentFolders: [] });
+      expect(folderUseCases.searchFoldersInFolder).toHaveBeenCalledWith(
+        user,
+        folderUuid,
+        { plainNames },
+      );
+    });
+  });
+
   describe('checkFoldersExistenceInFolder', () => {
     const user = newUser();
     const folderUuid = v4();

--- a/src/modules/folder/folder.controller.ts
+++ b/src/modules/folder/folder.controller.ts
@@ -59,6 +59,7 @@ import { Client } from '../auth/decorators/client.decorator';
 import { BasicPaginationDto } from '../../common/dto/basic-pagination.dto';
 import { Workspace } from '../workspaces/domains/workspaces.domain';
 import { getPathDepth } from '../../lib/path';
+import { CheckFoldersExistenceOldDto } from './dto/folder-existence-in-folder-old.dto';
 
 const foldersStatuses = ['ALL', 'EXISTS', 'TRASHED', 'DELETED'] as const;
 
@@ -355,6 +356,37 @@ export class FolderController {
     };
   }
 
+  @Get('/content/:uuid/folders/existence')
+  @GetDataFromRequest([
+    {
+      sourceKey: 'params',
+      fieldName: 'uuid',
+      newFieldName: 'itemId',
+    },
+    {
+      fieldName: 'itemType',
+      value: 'folder',
+    },
+  ])
+  @WorkspacesInBehalfValidationFolder()
+  async checkFoldersExistenceInFolderOld(
+    @UserDecorator() user: User,
+    @Param('uuid') folderUuid: string,
+    @Query() query: CheckFoldersExistenceOldDto,
+  ) {
+    const { plainName } = query;
+
+    const folders = await this.folderUseCases.searchFoldersInFolder(
+      user,
+      folderUuid,
+      {
+        plainNames: plainName,
+      },
+    );
+
+    return { existentFolders: folders };
+  }
+
   @Post('/content/:uuid/folders/existence')
   @GetDataFromRequest([
     {
@@ -371,7 +403,7 @@ export class FolderController {
   async checkFoldersExistenceInFolder(
     @UserDecorator() user: User,
     @Param('uuid') folderUuid: string,
-    @Body() query: CheckFoldersExistenceDto,
+    @Query() query: CheckFoldersExistenceDto,
   ) {
     const { plainNames } = query;
 


### PR DESCRIPTION
Changing folders/content/:uuid/folders/existence from GET to POST broke the windows client, this PR reintroduces folders/content/:uuid/folders/existence as GET (temporarily?) mantaining the query param that was being used instead of body. 

folders/content/:uuid/folders/existence remained untouched as POST request, as not to break drive-web.