### PR TITLE
[_] fix: return body decorator to existence POST

### DIFF
--- a/src/modules/folder/folder.controller.ts
+++ b/src/modules/folder/folder.controller.ts
@@ -357,6 +357,10 @@ export class FolderController {
   }
 
   @Get('/content/:uuid/folders/existence')
+  @ApiOperation({
+    summary: 'Checks folders existence in folder (use POST request over this)',
+    deprecated: true,
+  })
   @GetDataFromRequest([
     {
       sourceKey: 'params',
@@ -388,6 +392,9 @@ export class FolderController {
   }
 
   @Post('/content/:uuid/folders/existence')
+  @ApiOperation({
+    summary: 'Checks folders existence in folder',
+  })
   @GetDataFromRequest([
     {
       sourceKey: 'params',
@@ -403,7 +410,7 @@ export class FolderController {
   async checkFoldersExistenceInFolder(
     @UserDecorator() user: User,
     @Param('uuid') folderUuid: string,
-    @Query() query: CheckFoldersExistenceDto,
+    @Body() query: CheckFoldersExistenceDto,
   ) {
     const { plainNames } = query;
 


### PR DESCRIPTION
We should get the input from the body in the case of POST. Marked GET as deprecated so no other platforms use it.