### PR TITLE
[PB-3262]: fix/correctly calculate available space in workspace when accepting an invite

### DIFF
--- a/src/modules/workspaces/workspaces.usecase.spec.ts
+++ b/src/modules/workspaces/workspaces.usecase.spec.ts
@@ -1289,9 +1289,7 @@ describe('WorkspacesUsecases', () => {
       jest
         .spyOn(userRepository, 'findByUuid')
         .mockResolvedValueOnce(workspaceUser);
-      jest
-        .spyOn(service, 'getAssignableSpaceInWorkspace')
-        .mockResolvedValueOnce(3000);
+      jest.spyOn(service, 'getOwnerAvailableSpace').mockResolvedValueOnce(3000);
 
       await expect(
         service.acceptWorkspaceInvite(invitedUser, 'anyUuid'),
@@ -1317,9 +1315,7 @@ describe('WorkspacesUsecases', () => {
       jest
         .spyOn(userRepository, 'findByUuid')
         .mockResolvedValueOnce(workspaceUser);
-      jest
-        .spyOn(service, 'getAssignableSpaceInWorkspace')
-        .mockResolvedValueOnce(3000);
+      jest.spyOn(service, 'getOwnerAvailableSpace').mockResolvedValueOnce(3000);
       jest.spyOn(service, 'adjustOwnerStorage').mockResolvedValueOnce();
 
       await service.acceptWorkspaceInvite(invitedUser, 'anyUuid');
@@ -1356,9 +1352,7 @@ describe('WorkspacesUsecases', () => {
       jest
         .spyOn(userRepository, 'findByUuid')
         .mockResolvedValueOnce(workspaceUser);
-      jest
-        .spyOn(service, 'getAssignableSpaceInWorkspace')
-        .mockResolvedValueOnce(3000);
+      jest.spyOn(service, 'getOwnerAvailableSpace').mockResolvedValueOnce(3000);
       jest.spyOn(service, 'adjustOwnerStorage').mockResolvedValueOnce();
 
       await service.acceptWorkspaceInvite(invitedUser, 'anyUuid');
@@ -1389,9 +1383,7 @@ describe('WorkspacesUsecases', () => {
       jest
         .spyOn(userRepository, 'findByUuid')
         .mockResolvedValueOnce(workspaceUser);
-      jest
-        .spyOn(service, 'getAssignableSpaceInWorkspace')
-        .mockResolvedValueOnce(3000);
+      jest.spyOn(service, 'getOwnerAvailableSpace').mockResolvedValueOnce(3000);
       jest
         .spyOn(teamRepository, 'addUserToTeam')
         .mockRejectedValueOnce(
@@ -1432,9 +1424,7 @@ describe('WorkspacesUsecases', () => {
       jest
         .spyOn(userRepository, 'findByUuid')
         .mockResolvedValueOnce(workspaceUser);
-      jest
-        .spyOn(service, 'getAssignableSpaceInWorkspace')
-        .mockResolvedValueOnce(3000);
+      jest.spyOn(service, 'getOwnerAvailableSpace').mockResolvedValueOnce(3000);
       jest
         .spyOn(workspaceRepository, 'addUserToWorkspace')
         .mockRejectedValueOnce(
@@ -1474,9 +1464,7 @@ describe('WorkspacesUsecases', () => {
       jest
         .spyOn(userRepository, 'findByUuid')
         .mockResolvedValueOnce(workspaceUser);
-      jest
-        .spyOn(service, 'getAssignableSpaceInWorkspace')
-        .mockResolvedValueOnce(3000);
+      jest.spyOn(service, 'getOwnerAvailableSpace').mockResolvedValueOnce(3000);
       jest.spyOn(service, 'adjustOwnerStorage').mockResolvedValueOnce();
 
       await service.acceptWorkspaceInvite(invitedUser, 'anyUuid');

--- a/src/modules/workspaces/workspaces.usecase.ts
+++ b/src/modules/workspaces/workspaces.usecase.ts
@@ -1525,7 +1525,7 @@ export class WorkspacesUsecases {
       );
     }
 
-    const spaceLeft = await this.getAssignableSpaceInWorkspace(workspace);
+    const spaceLeft = await this.getOwnerAvailableSpace(workspace);
 
     if (invite.spaceLimit > spaceLeft) {
       throw new BadRequestException(


### PR DESCRIPTION
I was incorrectly calculating the available space in a workspace as `ownerAvailableSpace - spaceAssignedInInvites` this caused a scenario where the last user to accept an invite would be unable to join as the space assigned in their own invitation was being counted as unassignable space. Now when accepting an invite the assignable space is taken as simply the owner's available space