### PR TITLE
[PB-2386] Add phone and email to the account setting section

### DIFF
--- a/migrations/20241013140617-add-email-to-workspaces.js
+++ b/migrations/20241013140617-add-email-to-workspaces.js
@@ -1,0 +1,17 @@
+'use strict';
+
+const tableName = 'workspaces';
+const newColumn = 'email';
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.addColumn(tableName, newColumn, {
+      type: Sequelize.STRING,
+      allowNull: true,
+    });
+  },
+
+  async down(queryInterface) {
+    await queryInterface.removeColumn(tableName, newColumn);
+  },
+};

--- a/src/modules/gateway/dto/initialize-workspace.dto.ts
+++ b/src/modules/gateway/dto/initialize-workspace.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsNotEmpty, IsNumber, IsOptional } from 'class-validator';
+import { IsEmail, IsNotEmpty, IsNumber, IsOptional } from 'class-validator';
 
 export class InitializeWorkspaceDto {
   @ApiProperty({
@@ -22,6 +22,14 @@ export class InitializeWorkspaceDto {
   })
   @IsOptional()
   phoneNumber?: string;
+
+  @ApiProperty({
+    example: 'hello@internxt.com',
+    description: 'Email',
+  })
+  @IsOptional()
+  @IsEmail()
+  email?: string;
 
   @ApiProperty({
     example: 312321312,

--- a/src/modules/workspaces/attributes/workspace.attributes.ts
+++ b/src/modules/workspaces/attributes/workspace.attributes.ts
@@ -10,6 +10,7 @@ export interface WorkspaceAttributes {
   setupCompleted: boolean;
   numberOfSeats: number;
   phoneNumber?: string;
+  email?: string;
   rootFolderId?: string;
   createdAt: Date;
   updatedAt: Date;

--- a/src/modules/workspaces/domains/workspaces.domain.ts
+++ b/src/modules/workspaces/domains/workspaces.domain.ts
@@ -15,6 +15,7 @@ export class Workspace implements WorkspaceAttributes {
   setupCompleted: boolean;
   numberOfSeats: number;
   phoneNumber?: string;
+  email?: string;
   createdAt: Date;
   updatedAt: Date;
 
@@ -31,6 +32,7 @@ export class Workspace implements WorkspaceAttributes {
     avatar,
     numberOfSeats,
     phoneNumber,
+    email,
     createdAt,
     updatedAt,
   }: WorkspaceAttributes) {
@@ -46,6 +48,7 @@ export class Workspace implements WorkspaceAttributes {
     this.rootFolderId = rootFolderId;
     this.numberOfSeats = numberOfSeats;
     this.phoneNumber = phoneNumber;
+    this.email = email;
     this.createdAt = createdAt;
     this.updatedAt = updatedAt;
   }
@@ -83,6 +86,7 @@ export class Workspace implements WorkspaceAttributes {
       workspaceUserId: this.workspaceUserId,
       numberOfSeats: this.numberOfSeats,
       phoneNumber: this.phoneNumber,
+      email: this.email,
       setupCompleted: this.setupCompleted,
       createdAt: this.createdAt,
       updatedAt: this.updatedAt,

--- a/src/modules/workspaces/dto/edit-workspace-details-dto.ts
+++ b/src/modules/workspaces/dto/edit-workspace-details-dto.ts
@@ -1,5 +1,11 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsOptional, IsPhoneNumber, IsString, Length } from 'class-validator';
+import {
+  IsOptional,
+  IsPhoneNumber,
+  IsString,
+  Length,
+  IsEmail,
+} from 'class-validator';
 import { Workspace } from '../domains/workspaces.domain';
 
 export class EditWorkspaceDetailsDto {
@@ -34,4 +40,12 @@ export class EditWorkspaceDetailsDto {
   @IsOptional()
   @IsPhoneNumber()
   phoneNumber?: Workspace['phoneNumber'];
+
+  @ApiProperty({
+    example: 'hello@internxt.com',
+    description: 'Email',
+  })
+  @IsOptional()
+  @IsEmail()
+  email?: Workspace['email'];
 }

--- a/src/modules/workspaces/models/workspace.model.ts
+++ b/src/modules/workspaces/models/workspace.model.ts
@@ -67,6 +67,9 @@ export class WorkspaceModel extends Model implements WorkspaceAttributes {
   @Column(DataType.STRING)
   phoneNumber: string;
 
+  @Column(DataType.STRING)
+  email: string;
+
   @HasOne(() => FolderModel, 'uuid')
   rootFolder: FolderModel;
 


### PR DESCRIPTION
### Ticket
- https://inxt.atlassian.net/browse/PB-2386

### Update
- Allow to the workspace owner add a `phone` an `email` to display in the workspace section.
- The `phone` field already existed. So the `email` field was added to the workspace table.

### PR related
- web:
- sdk: 