### PR TITLE
[PB-3316]: fix/correctly allow increasing decreasing workspace seats

### DIFF
--- a/src/modules/gateway/gateway.module.ts
+++ b/src/modules/gateway/gateway.module.ts
@@ -1,12 +1,11 @@
 import { Module } from '@nestjs/common';
 import { GatewayController } from './gateway.controller';
-import { BridgeModule } from '../../externals/bridge/bridge.module';
 import { GatewayUseCases } from './gateway.usecase';
 import { WorkspacesModule } from '../workspaces/workspaces.module';
 import { UserModule } from '../user/user.module';
 
 @Module({
-  imports: [BridgeModule, WorkspacesModule, UserModule],
+  imports: [WorkspacesModule, UserModule],
   controllers: [GatewayController],
   providers: [GatewayUseCases],
 })

--- a/src/modules/gateway/gateway.usecase.spec.ts
+++ b/src/modules/gateway/gateway.usecase.spec.ts
@@ -8,7 +8,6 @@ import {
   newWorkspaceTeam,
 } from '../../../test/fixtures';
 import { BadRequestException, NotFoundException } from '@nestjs/common';
-import { BridgeService } from '../../externals/bridge/bridge.service';
 import { v4 } from 'uuid';
 import { GatewayUseCases } from './gateway.usecase';
 import { InitializeWorkspaceDto } from './dto/initialize-workspace.dto';
@@ -17,7 +16,6 @@ describe('GatewayUseCases', () => {
   let service: GatewayUseCases;
   let userRepository: SequelizeUserRepository;
   let workspaceUseCases: WorkspacesUsecases;
-  let networkService: BridgeService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -31,7 +29,6 @@ describe('GatewayUseCases', () => {
       SequelizeUserRepository,
     );
     workspaceUseCases = module.get<WorkspacesUsecases>(WorkspacesUsecases);
-    networkService = module.get<BridgeService>(BridgeService);
   });
 
   it('should be defined', () => {
@@ -145,6 +142,7 @@ describe('GatewayUseCases', () => {
         expect(workspaceUseCases.updateWorkspaceLimit).toHaveBeenCalledWith(
           workspace.id,
           maxSpaceBytes,
+          undefined,
         );
       });
 
@@ -193,6 +191,7 @@ describe('GatewayUseCases', () => {
         expect(workspaceUseCases.updateWorkspaceLimit).toHaveBeenCalledWith(
           workspace.id,
           maxSpaceBytes,
+          numberOfSeats,
         );
       });
     });

--- a/src/modules/gateway/gateway.usecase.ts
+++ b/src/modules/gateway/gateway.usecase.ts
@@ -7,15 +7,13 @@ import {
 import { InitializeWorkspaceDto } from './dto/initialize-workspace.dto';
 import { WorkspacesUsecases } from '../workspaces/workspaces.usecase';
 import { SequelizeUserRepository } from '../user/user.repository';
-import { BridgeService } from '../../externals/bridge/bridge.service';
 import { User } from '../user/user.domain';
 
 @Injectable()
 export class GatewayUseCases {
   constructor(
-    private workspaceUseCases: WorkspacesUsecases,
-    private userRepository: SequelizeUserRepository,
-    private networkService: BridgeService,
+    private readonly workspaceUseCases: WorkspacesUsecases,
+    private readonly userRepository: SequelizeUserRepository,
   ) {}
 
   async initializeWorkspace(initializeWorkspaceDto: InitializeWorkspaceDto) {
@@ -26,14 +24,18 @@ export class GatewayUseCases {
       initializeWorkspaceDto;
 
     try {
-      return this.workspaceUseCases.initiateWorkspace(ownerId, maxSpaceBytes, {
-        address,
-        numberOfSeats,
-        phoneNumber,
-      });
+      return await this.workspaceUseCases.initiateWorkspace(
+        ownerId,
+        maxSpaceBytes,
+        {
+          address,
+          numberOfSeats,
+          phoneNumber,
+        },
+      );
     } catch (error) {
       Logger.error('[GATEWAY/WORKSPACE] Error initializing workspace', error);
-      throw new BadRequestException();
+      throw error;
     }
   }
 
@@ -73,7 +75,7 @@ export class GatewayUseCases {
         `[GATEWAY/WORKSPACE] Error updating workspace for owner ${ownerId}`,
         error,
       );
-      throw new BadRequestException();
+      throw error;
     }
   }
 

--- a/src/modules/workspaces/workspaces.usecase.ts
+++ b/src/modules/workspaces/workspaces.usecase.ts
@@ -519,7 +519,6 @@ export class WorkspacesUsecases {
       newWorkspaceSpaceLimit / (newNumberOfSeats ?? workspace.numberOfSeats);
     const spaceDifference = newSpacePerUser - currentSpacePerUser;
 
-    console.log('newWorkspaceSpaceLimit', newWorkspaceSpaceLimit);
     const workspaceUsers =
       await this.workspaceRepository.findWorkspaceUsers(workspaceId);
 

--- a/src/modules/workspaces/workspaces.usecase.ts
+++ b/src/modules/workspaces/workspaces.usecase.ts
@@ -497,6 +497,7 @@ export class WorkspacesUsecases {
   async updateWorkspaceLimit(
     workspaceId: Workspace['id'],
     newWorkspaceSpaceLimit: number,
+    newNumberOfSeats?: number,
   ) {
     const workspace = await this.workspaceRepository.findById(workspaceId);
 
@@ -514,9 +515,11 @@ export class WorkspacesUsecases {
     const currentSpacePerUser =
       currentWorkspaceSpaceLimit / workspace.numberOfSeats;
 
-    const newSpacePerUser = newWorkspaceSpaceLimit / workspace.numberOfSeats;
+    const newSpacePerUser =
+      newWorkspaceSpaceLimit / (newNumberOfSeats ?? workspace.numberOfSeats);
     const spaceDifference = newSpacePerUser - currentSpacePerUser;
 
+    console.log('newWorkspaceSpaceLimit', newWorkspaceSpaceLimit);
     const workspaceUsers =
       await this.workspaceRepository.findWorkspaceUsers(workspaceId);
 


### PR DESCRIPTION
Update the updateWorkspaceStorage to handle an increment or decrement in the numberOfSeats available for a workspace. Some logic for this already existed, but this was updated to now assign new space to the owner or to deduct space when seat count decreases.