### PR TITLE
[PB-3447] feat: storage changes notifications support for workspaces

### DIFF
--- a/src/externals/notifications/storage.notifications.service.ts
+++ b/src/externals/notifications/storage.notifications.service.ts
@@ -98,7 +98,6 @@ export class StorageNotificationService {
   }
 
   public async getTokensAndSendNotification(userUuid: string) {
-    console.log({ userUuid });
     const tokens = await this.userRepository.getNotificationTokens(userUuid, {
       type: 'macos',
     });

--- a/src/modules/auth/decorators/requester.decorator.spec.ts
+++ b/src/modules/auth/decorators/requester.decorator.spec.ts
@@ -1,0 +1,55 @@
+import { ExecutionContext } from '@nestjs/common';
+import { requesterFactory } from './requester.decorator';
+
+describe('requesterFactory', () => {
+  let mockGetRequest: jest.Mock;
+
+  beforeEach(() => {
+    mockGetRequest = jest.fn();
+  });
+
+  const createMockExecutionContext = (req: any): ExecutionContext =>
+    ({
+      switchToHttp: jest.fn().mockReturnValue({
+        getRequest: mockGetRequest.mockReturnValue(req),
+      }),
+    }) as unknown as ExecutionContext;
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('When requester is present, it should return requester', () => {
+    const mockRequest = {
+      requester: { id: 1, name: 'John Doe' },
+    };
+    const mockExecutionContext = createMockExecutionContext(mockRequest);
+
+    const result = requesterFactory(null, mockExecutionContext);
+
+    expect(result).toEqual(mockRequest.requester);
+  });
+
+  it('When requester is absent, it should default to user', () => {
+    const mockRequest = {
+      user: { id: 2, name: 'Jane Doe' },
+    };
+    const mockExecutionContext = createMockExecutionContext(mockRequest);
+
+    const result = requesterFactory(null, mockExecutionContext);
+
+    expect(result).toEqual(mockRequest.user);
+  });
+
+  it('When both requester and user are present, it should return requester', () => {
+    const mockRequest = {
+      requester: { id: 1, name: 'John Doe' },
+      user: { id: 2, name: 'Jane Doe' },
+    };
+    const mockExecutionContext = createMockExecutionContext(mockRequest);
+
+    const result = requesterFactory(null, mockExecutionContext);
+
+    expect(result).toEqual(mockRequest.requester);
+  });
+});

--- a/src/modules/auth/decorators/requester.decorator.ts
+++ b/src/modules/auth/decorators/requester.decorator.ts
@@ -1,0 +1,9 @@
+import { createParamDecorator, ExecutionContext } from '@nestjs/common';
+import { User } from '../../user/user.domain';
+
+export const requesterFactory = (_, ctx: ExecutionContext): User => {
+  const req = ctx.switchToHttp().getRequest();
+  return req.requester || req.user;
+};
+
+export const Requester = createParamDecorator(requesterFactory);

--- a/src/modules/file/file.controller.spec.ts
+++ b/src/modules/file/file.controller.spec.ts
@@ -2,7 +2,7 @@ import { createMock } from '@golevelup/ts-jest';
 import { Test, TestingModule } from '@nestjs/testing';
 import { BadRequestException, NotFoundException } from '@nestjs/common';
 import { v4 } from 'uuid';
-import { newFile, newFolder } from '../../../test/fixtures';
+import { newFile, newFolder, newUser } from '../../../test/fixtures';
 import { FileUseCases } from './file.usecase';
 import { User } from '../user/user.domain';
 import { File, FileStatus } from './file.domain';
@@ -15,6 +15,8 @@ describe('FileController', () => {
   let fileUseCases: FileUseCases;
   let file: File;
   const clientId = 'drive-web';
+
+  const requester = newUser();
 
   const userMocked = User.build({
     id: 1,
@@ -81,6 +83,7 @@ describe('FileController', () => {
           destinationFolder: destinationFolder.uuid,
         },
         clientId,
+        requester,
       );
       expect(result).toEqual(expectedFile);
     });
@@ -94,6 +97,7 @@ describe('FileController', () => {
             destinationFolder: v4(),
           },
           clientId,
+          requester,
         ),
       ).rejects.toThrow(BadRequestException);
 
@@ -105,6 +109,7 @@ describe('FileController', () => {
             destinationFolder: 'invaliduuid',
           },
           clientId,
+          requester,
         ),
       ).rejects.toThrow(BadRequestException);
     });
@@ -212,6 +217,7 @@ describe('FileController', () => {
           newFile().uuid,
           null,
           clientId,
+          requester,
         ),
       ).rejects.toThrow(BadRequestException);
 
@@ -221,6 +227,7 @@ describe('FileController', () => {
           newFile().uuid,
           undefined,
           clientId,
+          requester,
         ),
       ).rejects.toThrow(BadRequestException);
 
@@ -230,6 +237,7 @@ describe('FileController', () => {
           newFile().uuid,
           {},
           clientId,
+          requester,
         ),
       ).rejects.toThrow(BadRequestException);
     });
@@ -255,6 +263,7 @@ describe('FileController', () => {
         mockFile.uuid,
         newMetadataInfo,
         clientId,
+        requester,
       );
       expect(result).toEqual(expectedFile);
     });

--- a/src/modules/file/file.controller.ts
+++ b/src/modules/file/file.controller.ts
@@ -41,6 +41,7 @@ import { GetDataFromRequest } from '../../common/extract-data-from-request';
 import { StorageNotificationService } from '../../externals/notifications/storage.notifications.service';
 import { Client } from '../auth/decorators/client.decorator';
 import { getPathDepth } from '../../lib/path';
+import { Requester } from '../auth/decorators/requester.decorator';
 
 const filesStatuses = ['ALL', 'EXISTS', 'TRASHED', 'DELETED'] as const;
 
@@ -156,6 +157,7 @@ export class FileController {
     @Param('uuid') fileUuid: File['uuid'],
     @Body() fileData: ReplaceFileDto,
     @Client() clientId: string,
+    @Requester() requester: User,
   ) {
     try {
       const file = await this.fileUseCases.replaceFile(
@@ -166,7 +168,7 @@ export class FileController {
 
       this.storageNotificationService.fileUpdated({
         payload: file,
-        user: user,
+        user: requester,
         clientId,
       });
 
@@ -219,6 +221,7 @@ export class FileController {
     fileUuid: File['uuid'],
     @Body() updateFileMetaDto: UpdateFileMetaDto,
     @Client() clientId: string,
+    @Requester() requester: User,
   ) {
     if (!updateFileMetaDto || Object.keys(updateFileMetaDto).length === 0) {
       throw new BadRequestException('Missing update file metadata');
@@ -231,7 +234,7 @@ export class FileController {
 
     this.storageNotificationService.fileUpdated({
       payload: result,
-      user: user,
+      user: requester,
       clientId,
     });
 
@@ -327,6 +330,7 @@ export class FileController {
     @Param('uuid') fileUuid: File['uuid'],
     @Body() moveFileData: MoveFileDto,
     @Client() clientId: string,
+    @Requester() requester: User,
   ) {
     if (!validate(fileUuid) || !validate(moveFileData.destinationFolder)) {
       throw new BadRequestException('Invalid UUID provided');
@@ -339,7 +343,7 @@ export class FileController {
 
     this.storageNotificationService.fileUpdated({
       payload: file,
-      user: user,
+      user: requester,
       clientId,
     });
 

--- a/src/modules/folder/folder.controller.spec.ts
+++ b/src/modules/folder/folder.controller.spec.ts
@@ -21,6 +21,8 @@ import { User } from '../user/user.domain';
 import { FileStatus } from '../file/file.domain';
 import { InvalidParentFolderException } from './exception/invalid-parent-folder';
 
+const requester = newUser();
+
 describe('FolderController', () => {
   let folderController: FolderController;
   let folderUseCases: FolderUseCases;
@@ -290,6 +292,7 @@ describe('FolderController', () => {
         folder.uuid,
         { destinationFolder: destinationFolder.uuid },
         clientId,
+        requester,
       );
       expect(result).toEqual(expectedFolder);
     });
@@ -303,6 +306,7 @@ describe('FolderController', () => {
             destinationFolder: v4(),
           },
           clientId,
+          requester,
         ),
       ).rejects.toThrow(BadRequestException);
 
@@ -314,6 +318,7 @@ describe('FolderController', () => {
             destinationFolder: 'invaliduuid',
           },
           clientId,
+          requester,
         ),
       ).rejects.toThrow(BadRequestException);
     });

--- a/src/modules/folder/folder.controller.ts
+++ b/src/modules/folder/folder.controller.ts
@@ -60,6 +60,7 @@ import { BasicPaginationDto } from '../../common/dto/basic-pagination.dto';
 import { Workspace } from '../workspaces/domains/workspaces.domain';
 import { getPathDepth } from '../../lib/path';
 import { CheckFoldersExistenceOldDto } from './dto/folder-existence-in-folder-old.dto';
+import { Requester } from '../auth/decorators/requester.decorator';
 
 const foldersStatuses = ['ALL', 'EXISTS', 'TRASHED', 'DELETED'] as const;
 
@@ -116,6 +117,7 @@ export class FolderController {
     @UserDecorator() user: User,
     @Body() createFolderDto: CreateFolderDto,
     @Client() clientId: string,
+    @Requester() requester: User,
   ) {
     const folder = await this.folderUseCases.createFolder(
       user,
@@ -124,7 +126,7 @@ export class FolderController {
 
     this.storageNotificationService.folderCreated({
       payload: folder,
-      user: user,
+      user: requester,
       clientId,
     });
 
@@ -830,6 +832,7 @@ export class FolderController {
     @UserDecorator() user: User,
     @Body() updateFolderMetaDto: UpdateFolderMetaDto,
     @Client() clientId: string,
+    @Requester() requester: User,
   ) {
     const folderUpdated = await this.folderUseCases.updateFolderMetaData(
       user,
@@ -839,7 +842,7 @@ export class FolderController {
 
     this.storageNotificationService.folderUpdated({
       payload: folderUpdated,
-      user: user,
+      user: requester,
       clientId,
     });
 
@@ -872,6 +875,7 @@ export class FolderController {
     @Param('uuid') folderUuid: Folder['uuid'],
     @Body() moveFolderData: MoveFolderDto,
     @Client() clientId: string,
+    @Requester() requester: User,
   ) {
     if (!validate(folderUuid) || !validate(moveFolderData.destinationFolder)) {
       throw new BadRequestException('Invalid UUID provided');
@@ -884,7 +888,7 @@ export class FolderController {
 
     this.storageNotificationService.folderUpdated({
       payload: folder,
-      user: user,
+      user: requester,
       clientId,
     });
 

--- a/src/modules/sharing/decorators/behalfUser.decorator.ts
+++ b/src/modules/sharing/decorators/behalfUser.decorator.ts
@@ -1,9 +1,0 @@
-import { createParamDecorator, ExecutionContext } from '@nestjs/common';
-
-export const BehalfUserDecorator = createParamDecorator(
-  async (_, ctx: ExecutionContext) => {
-    const req = ctx.switchToHttp().getRequest();
-
-    return req?.behalfUser;
-  },
-);

--- a/src/modules/sharing/guards/sharing-permissions.guard.ts
+++ b/src/modules/sharing/guards/sharing-permissions.guard.ts
@@ -99,6 +99,7 @@ export class SharingPermissionsGuard implements CanActivate {
     }
 
     request.user = resourceOwner;
+    request.requester = request.requester || request.user;
     request.isSharedItem = true;
 
     return true;

--- a/src/modules/trash/trash.controller.spec.ts
+++ b/src/modules/trash/trash.controller.spec.ts
@@ -14,6 +14,7 @@ import {
 import { StorageNotificationService } from '../../externals/notifications/storage.notifications.service';
 
 const user = newUser();
+const requester = newUser();
 
 describe('TrashController', () => {
   let controller: TrashController;
@@ -55,6 +56,7 @@ describe('TrashController', () => {
         },
         user,
         'anyid',
+        requester,
       ),
     ).rejects.toThrow(BadRequestException);
   });
@@ -63,7 +65,7 @@ describe('TrashController', () => {
     const body = { items: [] };
     jest.spyOn(fileUseCases, 'moveFilesToTrash');
 
-    await controller.moveItemsToTrash(body, user, '');
+    await controller.moveItemsToTrash(body, user, '', requester);
     expect(fileUseCases.moveFilesToTrash).not.toHaveBeenCalled();
   });
 
@@ -101,6 +103,7 @@ describe('TrashController', () => {
       },
       user,
       '',
+      requester,
     );
 
     expect(fileUseCases.moveFilesToTrash).toHaveBeenCalledWith(

--- a/src/modules/user/user.repository.ts
+++ b/src/modules/user/user.repository.ts
@@ -104,7 +104,7 @@ export class SequelizeUserRepository implements UserRepository {
     return user ? this.toDomain(user) : null;
   }
 
-  async findAllBy(where: any): Promise<Array<User> | []> {
+  async findAllBy(where: any): Promise<Array<User>> {
     const users = await this.modelUser.findAll({ where });
     return users.map((user) => this.toDomain(user));
   }

--- a/src/modules/workspaces/workspaces.controller.spec.ts
+++ b/src/modules/workspaces/workspaces.controller.spec.ts
@@ -14,15 +14,22 @@ import { v4 } from 'uuid';
 import { WorkspaceUserMemberDto } from './dto/workspace-user-member.dto';
 import { CreateWorkspaceFolderDto } from './dto/create-workspace-folder.dto';
 import { WorkspaceItemType } from './attributes/workspace-items-users.attributes';
+import { StorageNotificationService } from '../../externals/notifications/storage.notifications.service';
+import { CreateWorkspaceFileDto } from './dto/create-workspace-file.dto';
 
 describe('Workspace Controller', () => {
   let workspacesController: WorkspacesController;
   let workspacesUsecases: DeepMocked<WorkspacesUsecases>;
+  let storageNotificationService: DeepMocked<StorageNotificationService>;
 
   beforeEach(async () => {
     workspacesUsecases = createMock<WorkspacesUsecases>();
+    storageNotificationService = createMock<StorageNotificationService>();
 
-    workspacesController = new WorkspacesController(workspacesUsecases);
+    workspacesController = new WorkspacesController(
+      workspacesUsecases,
+      storageNotificationService,
+    );
   });
 
   it('should be defined', () => {
@@ -621,6 +628,7 @@ describe('Workspace Controller', () => {
       await workspacesController.createFolder(
         workspaceId,
         user,
+        'clientId',
         createFolderDto,
       );
 
@@ -628,6 +636,36 @@ describe('Workspace Controller', () => {
         user,
         workspaceId,
         createFolderDto,
+      );
+    });
+  });
+
+  describe('POST /:workspaceId/files', () => {
+    it('When a file is created successfully, then it should call the service with the respective arguments', async () => {
+      const user = newUser();
+      const workspaceId = v4();
+      const createFileDto: CreateWorkspaceFileDto = {
+        plainName: 'New File',
+        folderUuid: v4(),
+        bucket: v4(),
+        fileId: v4(),
+        encryptVersion: '',
+        size: BigInt(100),
+        type: 'pdf',
+        modificationTime: new Date(),
+      };
+
+      await workspacesController.createFile(
+        workspaceId,
+        user,
+        'clientId',
+        createFileDto,
+      );
+
+      expect(workspacesUsecases.createFile).toHaveBeenCalledWith(
+        user,
+        workspaceId,
+        createFileDto,
       );
     });
   });

--- a/src/modules/workspaces/workspaces.module.ts
+++ b/src/modules/workspaces/workspaces.module.ts
@@ -23,6 +23,7 @@ import { HttpClientModule } from 'src/externals/http/http.module';
 import { CryptoModule } from '../../externals/crypto/crypto.module';
 import { FuzzySearchUseCases } from '../fuzzy-search/fuzzy-search.usecase';
 import { FuzzySearchModule } from '../fuzzy-search/fuzzy-search.module';
+import { NotificationModule } from '../../externals/notifications/notifications.module';
 
 @Module({
   imports: [
@@ -43,6 +44,7 @@ import { FuzzySearchModule } from '../fuzzy-search/fuzzy-search.module';
     MailerModule,
     HttpClientModule,
     FuzzySearchModule,
+    NotificationModule,
   ],
   controllers: [WorkspacesController],
   providers: [


### PR DESCRIPTION
We need to start sending notifications when a file changes in workspaces. 

The request should be sent to the requester, so we set `request.requester = userMakingTheRequest` in the guard to be able to know exactly who is making the request without relying only on `request.user` which could be the `resourceOwner` (normally not a real user in the case of a workspace file)