### PR TITLE
[PB-3189] fix: correctly remove children folders from lookup table on delete

### DIFF
--- a/migrations/20241213035931-fix-update-folder-in-lookup-table-function.js
+++ b/migrations/20241213035931-fix-update-folder-in-lookup-table-function.js
@@ -1,0 +1,43 @@
+'use strict';
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.sequelize.query(`
+      CREATE OR REPLACE FUNCTION update_folder_in_look_up_table()
+      RETURNS TRIGGER AS $$
+      DECLARE
+        user_record users%ROWTYPE;
+      BEGIN
+        SELECT * INTO user_record FROM users WHERE id = NEW.user_id;
+        -- If the name has been changed, update the lookup table
+        IF NEW.deleted = false AND NEW.removed = false AND OLD.plain_name != NEW.plain_name THEN
+          UPDATE look_up
+          SET 
+            name = NEW.plain_name,
+            tokenized_name = to_tsvector(NEW.plain_name)
+          WHERE 
+            item_type = 'folder' 
+            AND item_id = NEW.uuid 
+            AND user_id = user_record.uuid;
+        -- If the folder is restored
+        ELSIF NEW.deleted = false and NEW.removed = false AND (old.deleted = true or old.removed = true) THEN
+          INSERT INTO look_up (id, name, tokenized_name, item_id, item_type, user_id)
+          VALUES (uuid_generate_v4(), NEW.plain_name, to_tsvector(NEW.plain_name), NEW.uuid, 'folder', user_record.uuid);
+        -- If the file status changes to deleted / trashed
+        ELSIF (OLD.deleted = false OR OLD.removed = false) AND (NEW.deleted = true OR NEW.removed = true) THEN
+          -- Remove the lookup entry
+          DELETE FROM look_up
+          WHERE
+            item_type = 'folder' 
+            AND item_id = NEW.uuid 
+            AND user_id = user_record.uuid;
+        END IF;
+
+        RETURN NEW;
+      END;
+      $$ LANGUAGE 'plpgsql';
+    `);
+  },
+
+  async down(queryInterface, Sequelize) {},
+};


### PR DESCRIPTION
When you delete a folder, its children folders are not being removed correctly from the lookup table, so searching was showing non accesible folders to the users.

This script just modifies 1 line of the function triggered to fix this behavior. For those who want to compare the changes: original migration [here](https://github.com/internxt/drive-server-wip/blob/b3aec38aa0285d701d926895d357a51fe7eb5d62/migrations/20231004145835-add-triggers-for-lookup.js#L122)

**Old condition:**
` ELSIF OLD.deleted = false AND NEW.removed = false AND (NEW.deleted = true OR NEW.removed = true) THEN
`

**New condition**
`ELSIF (OLD.deleted = false OR OLD.removed = false) AND (NEW.deleted = true OR NEW.removed = true) THEN
`

-----
### How to Reproduce the Issue:

1. Move the following folder structure to the trash:

- Parent Folder
  - Child 1
  - Child 2

2. Permanently delete the Parent Folder from the trash.

3. Search for Child 1 or Child 2 using the search bar.

**Expected Result:**

Child 1 and Child 2 should not appear in the search results.

**Actual Result:**

Child 1 and Child 2 still appear in the search results.