### PR TITLE
[_] fix: lower case emails on auth endpoints

### DIFF
--- a/src/modules/auth/auth.controller.ts
+++ b/src/modules/auth/auth.controller.ts
@@ -60,7 +60,9 @@ export class AuthController {
   @ApiOkResponse({ description: 'Retrieve details' })
   @Public()
   async login(@Body() body: LoginDto) {
-    const user = await this.userUseCases.findByEmail(body.email);
+    const email = body.email.toLowerCase();
+
+    const user = await this.userUseCases.findByEmail(email);
 
     if (!user) {
       throw new UnauthorizedException('Wrong login credentials');

--- a/src/modules/user/user.usecase.ts
+++ b/src/modules/user/user.usecase.ts
@@ -356,7 +356,8 @@ export class UserUseCases {
   }
 
   async createUser(newUser: NewUser) {
-    const { email, password, salt } = newUser;
+    const { email: rawEmail, password, salt } = newUser;
+    const email = rawEmail.toLowerCase();
 
     const maybeExistentUser = await this.userRepository.findByUsername(email);
     const userAlreadyExists = !!maybeExistentUser;
@@ -1197,7 +1198,7 @@ export class UserUseCases {
   async loginAccess(loginAccessDto: LoginAccessDto) {
     const MAX_LOGIN_FAIL_ATTEMPTS = 10;
 
-    const userData = await this.findByEmail(loginAccessDto.email);
+    const userData = await this.findByEmail(loginAccessDto.email.toLowerCase());
 
     if (!userData) {
       Logger.debug(
@@ -1263,7 +1264,7 @@ export class UserUseCases {
     }
 
     const user = {
-      email: loginAccessDto.email,
+      email: userData.email,
       userId: userData.userId,
       mnemonic: userData.mnemonic.toString(),
       root_folder_id: userData.rootFolderId,


### PR DESCRIPTION
Previous auth endpoints always convert to lowercase emails. This PR intends to apply the same logic so we do not rely on the client transforming values.