### PR TITLE
[PB-3601] feat: migrate user endpoints

### DIFF
--- a/src/modules/user/dto/update-profile.dto.ts
+++ b/src/modules/user/dto/update-profile.dto.ts
@@ -1,19 +1,48 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsNotEmpty } from 'class-validator';
+import {
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  MaxLength,
+  ValidateIf,
+} from 'class-validator';
 import { UserAttributes } from '../user.attributes';
 
 export class UpdateProfileDto {
-  @IsNotEmpty()
+  @IsOptional()
+  @IsString()
+  @ValidateIf((o) => o.name !== null)
+  @IsNotEmpty({ message: 'Name should not be empty if provided.' })
+  @MaxLength(100, { message: 'Name must be at most 100 characters long.' })
   @ApiProperty({
     example: 'Internxt',
     description: 'Name of the new user',
   })
-  name: UserAttributes['name'];
+  name?: UserAttributes['name'];
 
-  @IsNotEmpty()
+  @ValidateIf((o) => o.name === null)
+  @IsNotEmpty({ message: 'Name should not be null if provided.' })
+  @ApiProperty({
+    example: 'Internxt',
+    description: 'Name of the new user',
+  })
+  nameNullCheck?: string;
+
+  @IsOptional()
+  @IsString()
+  @ValidateIf((o) => o.lastname !== null)
+  @MaxLength(100, { message: 'Lastname must be at most 100 characters long.' })
   @ApiProperty({
     example: 'Lastname',
     description: 'Last name of the new user',
   })
-  lastname: UserAttributes['lastname'];
+  lastname?: UserAttributes['lastname'] | '';
+
+  @ValidateIf((o) => o.lastname === null)
+  @IsNotEmpty({ message: 'Lastname should not be null if provided.' })
+  @ApiProperty({
+    example: 'Lastname',
+    description: 'Last name of the new user',
+  })
+  lastnameNullCheck?: string;
 }

--- a/src/modules/user/dto/update-profile.dto.ts
+++ b/src/modules/user/dto/update-profile.dto.ts
@@ -1,0 +1,19 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty } from 'class-validator';
+import { UserAttributes } from '../user.attributes';
+
+export class UpdateProfileDto {
+  @IsNotEmpty()
+  @ApiProperty({
+    example: 'Internxt',
+    description: 'Name of the new user',
+  })
+  name: UserAttributes['name'];
+
+  @IsNotEmpty()
+  @ApiProperty({
+    example: 'Lastname',
+    description: 'Last name of the new user',
+  })
+  lastname: UserAttributes['lastname'];
+}

--- a/src/modules/user/dto/update-profile.dto.ts
+++ b/src/modules/user/dto/update-profile.dto.ts
@@ -36,7 +36,7 @@ export class UpdateProfileDto {
     example: 'Lastname',
     description: 'Last name of the new user',
   })
-  lastname?: UserAttributes['lastname'] | '';
+  lastname?: UserAttributes['lastname'];
 
   @ValidateIf((o) => o.lastname === null)
   @IsNotEmpty({ message: 'Lastname should not be null if provided.' })

--- a/src/modules/user/user.controller.spec.ts
+++ b/src/modules/user/user.controller.spec.ts
@@ -36,7 +36,7 @@ jest.mock('../../config/configuration', () => {
         secretKey: 'secretKey',
         bucket: 'bucket',
         region: 'region',
-        endpoint: 'http://storage:9000',
+        endpoint: 'http://localhost:9001',
         endpointForSignedUrls: 'http://localhost:9000',
         forcePathStyle: true,
       },

--- a/src/modules/user/user.controller.spec.ts
+++ b/src/modules/user/user.controller.spec.ts
@@ -265,12 +265,73 @@ describe('User Controller', () => {
   });
 
   describe('PATCH /profile', () => {
-    it('When updateProfile is called then it should update the user profile', async () => {
-      const user = newUser();
-      const payload: UpdateProfileDto = { name: 'John', lastname: 'Doe' };
+    const user = newUser();
+    it('When name is provided and valid, then it should call updateProfile with the correct parameters', async () => {
+      const updateProfileDto: UpdateProfileDto = {
+        name: 'Internxt',
+      };
 
-      await userController.updateProfile(user, payload);
-      expect(userUseCases.updateProfile).toHaveBeenCalledWith(user, payload);
+      await userController.updateProfile(user, updateProfileDto);
+
+      expect(userUseCases.updateProfile).toHaveBeenCalledWith(
+        user,
+        updateProfileDto,
+      );
+    });
+
+    it('When lastname is provided as an empty string, then it should call updateProfile with the correct parameters', async () => {
+      const updateProfileDto: UpdateProfileDto = {
+        lastname: '',
+      };
+
+      await userController.updateProfile(user, updateProfileDto);
+
+      expect(userUseCases.updateProfile).toHaveBeenCalledWith(
+        user,
+        updateProfileDto,
+      );
+    });
+
+    it('When both name and lastname are not provided, then it should throw', async () => {
+      const updateProfileDto: UpdateProfileDto = {
+        name: undefined,
+        lastname: undefined,
+      };
+
+      await expect(
+        userController.updateProfile(user, updateProfileDto),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('When name is null, then it should throw', async () => {
+      const updateProfileDto: UpdateProfileDto = {
+        name: null,
+      };
+
+      await expect(
+        userController.updateProfile(user, updateProfileDto),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('When lastname is null, then it should throw', async () => {
+      const updateProfileDto: UpdateProfileDto = {
+        lastname: null,
+      };
+
+      await expect(
+        userController.updateProfile(user, updateProfileDto),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('When both name and lastname are null, then it should throw', async () => {
+      const updateProfileDto: UpdateProfileDto = {
+        name: null,
+        lastname: null,
+      };
+
+      await expect(
+        userController.updateProfile(user, updateProfileDto),
+      ).rejects.toThrow(BadRequestException);
     });
   });
 

--- a/src/modules/user/user.usecase.spec.ts
+++ b/src/modules/user/user.usecase.spec.ts
@@ -1238,15 +1238,12 @@ describe('User use cases', () => {
   describe('upsertAvatar', () => {
     const newAvatarKey = v4();
     const newAvatarURL = `http://localhost:9000/${newAvatarKey}`;
-    it('When avatarKey is not provided then throw BadRequestException', async () => {
-      await expect(userUseCases.upsertAvatar(user, '')).rejects.toThrow(
-        BadRequestException,
-      );
-    });
 
     it('When user has an existing avatar then delete the old avatar', async () => {
       const user = newUser({ attributes: { avatar: v4() } });
 
+      jest.spyOn(avatarService, 'deleteAvatar').mockResolvedValue(undefined);
+      jest.spyOn(userRepository, 'updateById').mockResolvedValue(undefined);
       jest.spyOn(userUseCases, 'getAvatarUrl').mockResolvedValue(newAvatarURL);
 
       const result = await userUseCases.upsertAvatar(user, newAvatarKey);

--- a/src/modules/user/user.usecase.spec.ts
+++ b/src/modules/user/user.usecase.spec.ts
@@ -1275,24 +1275,24 @@ describe('User use cases', () => {
       expect(result).toMatchObject({ avatar: newAvatarURL });
     });
 
-    it('When deleting the old avatar fails then throw InternalServerErrorException', async () => {
+    it('When deleting the old avatar fails then throw', async () => {
       jest
         .spyOn(avatarService, 'deleteAvatar')
         .mockRejectedValue(new Error('Delete failed'));
 
       await expect(
         userUseCases.upsertAvatar(user, newAvatarKey),
-      ).rejects.toThrow(InternalServerErrorException);
+      ).rejects.toThrow();
     });
 
-    it('When updating the user avatar fails then throw InternalServerErrorException', async () => {
+    it('When updating the user avatar fails then throw', async () => {
       jest
         .spyOn(userRepository, 'updateById')
         .mockRejectedValue(new Error('Update failed'));
 
       await expect(
         userUseCases.upsertAvatar(user, newAvatarKey),
-      ).rejects.toThrow(InternalServerErrorException);
+      ).rejects.toThrow();
     });
 
     it('When user has no avatar already, then previous avatar is not deleted', async () => {
@@ -1338,9 +1338,7 @@ describe('User use cases', () => {
         .spyOn(avatarService, 'deleteAvatar')
         .mockRejectedValue(new Error('Delete failed'));
 
-      await expect(userUseCases.deleteAvatar(user)).rejects.toThrow(
-        InternalServerErrorException,
-      );
+      await expect(userUseCases.deleteAvatar(user)).rejects.toThrow();
       expect(userRepository.updateById).not.toHaveBeenCalled();
     });
   });

--- a/src/modules/user/user.usecase.ts
+++ b/src/modules/user/user.usecase.ts
@@ -1383,20 +1383,11 @@ export class UserUseCases {
     user: User,
     avatarKey: string,
   ): Promise<Error | { avatar: string }> {
-    if (!avatarKey) {
-      throw new BadRequestException('Avatar key required');
-    }
-
     if (user.avatar) {
       try {
         await this.avatarService.deleteAvatar(user.avatar);
       } catch (err) {
-        Logger.error(
-          `[USER/SET_AVATAR]Deleting the avatar for the user: ${
-            user.id
-          } has failed. Error: ${(err as Error).message}`,
-        );
-        throw new InternalServerErrorException();
+        throw new InternalServerErrorException('Failed to delete old avatar');
       }
     }
 
@@ -1407,12 +1398,7 @@ export class UserUseCases {
       const avatarUrl = await this.getAvatarUrl(avatarKey);
       return { avatar: avatarUrl };
     } catch (err) {
-      Logger.error(
-        `[USER/SET_AVATAR]Adding the avatar for the user: ${
-          user.id
-        } has failed. Error: ${(err as Error).message}`,
-      );
-      throw new InternalServerErrorException();
+      throw new InternalServerErrorException('Failed to add new avatar');
     }
   }
 
@@ -1424,12 +1410,7 @@ export class UserUseCases {
           avatar: null,
         });
       } catch (err) {
-        Logger.error(
-          `[USER/DELETE_AVATAR]Deleting the avatar for the user: ${
-            user.id
-          } has failed. Error: ${(err as Error).message}`,
-        );
-        throw new InternalServerErrorException();
+        throw new InternalServerErrorException('Failed to delete avatar');
       }
     }
   }

--- a/src/modules/user/user.usecase.ts
+++ b/src/modules/user/user.usecase.ts
@@ -1384,34 +1384,21 @@ export class UserUseCases {
     avatarKey: string,
   ): Promise<Error | { avatar: string }> {
     if (user.avatar) {
-      try {
-        await this.avatarService.deleteAvatar(user.avatar);
-      } catch (err) {
-        throw new InternalServerErrorException('Failed to delete old avatar');
-      }
+      await this.avatarService.deleteAvatar(user.avatar);
     }
-
-    try {
-      await this.userRepository.updateById(user.id, {
-        avatar: avatarKey,
-      });
-      const avatarUrl = await this.getAvatarUrl(avatarKey);
-      return { avatar: avatarUrl };
-    } catch (err) {
-      throw new InternalServerErrorException('Failed to add new avatar');
-    }
+    await this.userRepository.updateById(user.id, {
+      avatar: avatarKey,
+    });
+    const avatarUrl = await this.getAvatarUrl(avatarKey);
+    return { avatar: avatarUrl };
   }
 
   async deleteAvatar(user: User): Promise<Error | void> {
     if (user.avatar) {
-      try {
-        await this.avatarService.deleteAvatar(user.avatar);
-        await this.userRepository.updateById(user.id, {
-          avatar: null,
-        });
-      } catch (err) {
-        throw new InternalServerErrorException('Failed to delete avatar');
-      }
+      await this.avatarService.deleteAvatar(user.avatar);
+      await this.userRepository.updateById(user.id, {
+        avatar: null,
+      });
     }
   }
 

--- a/src/modules/user/user.usecase.ts
+++ b/src/modules/user/user.usecase.ts
@@ -5,6 +5,7 @@ import {
   HttpStatus,
   Inject,
   Injectable,
+  InternalServerErrorException,
   Logger,
   NotFoundException,
   UnauthorizedException,
@@ -74,6 +75,7 @@ import { SequelizeWorkspaceRepository } from '../workspaces/repositories/workspa
 import { UserNotificationTokens } from './user-notification-tokens.domain';
 import { RegisterNotificationTokenDto } from './dto/register-notification-token.dto';
 import { LoginAccessDto } from '../auth/dto/login-access.dto';
+import { UpdateProfileDto } from './dto/update-profile.dto';
 import { isUUID } from 'class-validator';
 
 export class ReferralsNotAvailableError extends Error {
@@ -1375,6 +1377,65 @@ export class UserUseCases {
       MailTypes.EmailVerification,
       mailLimit,
     );
+  }
+
+  async upsertAvatar(
+    user: User,
+    avatarKey: string,
+  ): Promise<Error | { avatar: string }> {
+    if (!avatarKey) {
+      throw new BadRequestException('Avatar key required');
+    }
+
+    if (user.avatar) {
+      try {
+        await this.avatarService.deleteAvatar(user.avatar);
+      } catch (err) {
+        Logger.error(
+          `[USER/SET_AVATAR]Deleting the avatar for the user: ${
+            user.id
+          } has failed. Error: ${(err as Error).message}`,
+        );
+        throw new InternalServerErrorException();
+      }
+    }
+
+    try {
+      await this.userRepository.updateById(user.id, {
+        avatar: avatarKey,
+      });
+      const avatarUrl = await this.getAvatarUrl(avatarKey);
+      return { avatar: avatarUrl };
+    } catch (err) {
+      Logger.error(
+        `[USER/SET_AVATAR]Adding the avatar for the user: ${
+          user.id
+        } has failed. Error: ${(err as Error).message}`,
+      );
+      throw new InternalServerErrorException();
+    }
+  }
+
+  async deleteAvatar(user: User): Promise<Error | void> {
+    if (user.avatar) {
+      try {
+        await this.avatarService.deleteAvatar(user.avatar);
+        await this.userRepository.updateById(user.id, {
+          avatar: null,
+        });
+      } catch (err) {
+        Logger.error(
+          `[USER/DELETE_AVATAR]Deleting the avatar for the user: ${
+            user.id
+          } has failed. Error: ${(err as Error).message}`,
+        );
+        throw new InternalServerErrorException();
+      }
+    }
+  }
+
+  async updateProfile(user: User, payload: UpdateProfileDto) {
+    await this.userRepository.updateByUuid(user.uuid, payload);
   }
 
   logReferralError(userId: number | string, err: unknown) {


### PR DESCRIPTION
### Ticket
- https://inxt.atlassian.net/browse/PB-3601

### Endpoints
- `PUT /api/users/avatar`
- `DELETE /api/users/avatar `
- `PATCH /api/users/profile`

## Note about a Bug
![image](https://github.com/user-attachments/assets/dc1aff2a-fb4a-48fc-b177-d671e7ee6187)
The error that persisted in the tests of `user.controller.spec.ts` that did not allow this task to finish was due to the order of the imports. For some reason, when adding the code related to loading the user's avatar to the controller, the test file (`user.controller.spec.ts`) stopped working. After doing several investigations and changes, it was discovered that moving the imports could solve the problem (the import of `generateBase64PrivateKeyStub` was moved before the configuration one). I leave this here for future similar errors.


