### PR TITLE
[_] feat: add support for multiple keys update password, login, user creation

### DIFF
--- a/migrations/20250127152608-increase-keyserver-public-and-private-keys-length.js
+++ b/migrations/20250127152608-increase-keyserver-public-and-private-keys-length.js
@@ -1,0 +1,22 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface) {
+    await queryInterface.sequelize.query(
+      `ALTER TABLE keyserver ALTER COLUMN public_key TYPE varchar(2000);`,
+    );
+    await queryInterface.sequelize.query(
+      `ALTER TABLE keyserver ALTER COLUMN private_key TYPE varchar(3200);`,
+    );
+  },
+
+  async down(queryInterface) {
+    await queryInterface.sequelize.query(
+      `ALTER TABLE keyserver ALTER COLUMN public_key TYPE varchar(1024);`,
+    );
+    await queryInterface.sequelize.query(
+      `ALTER TABLE keyserver ALTER COLUMN public_key TYPE varchar(2000);`,
+    );
+  },
+};

--- a/src/modules/auth/auth.controller.spec.ts
+++ b/src/modules/auth/auth.controller.spec.ts
@@ -1,4 +1,4 @@
-import { newUser } from './../../../test/fixtures';
+import { newKeyServer, newUser } from './../../../test/fixtures';
 import { AuthController } from './auth.controller';
 import { UserUseCases } from '../user/user.usecase';
 import { KeyServerUseCases } from '../keyserver/key-server.usecase';
@@ -12,7 +12,6 @@ import {
   NotFoundException,
   UnauthorizedException,
 } from '@nestjs/common';
-import { KeyServer } from '../keyserver/key-server.domain';
 import { DeepMocked, createMock } from '@golevelup/ts-jest';
 import { v4 } from 'uuid';
 import { TwoFactorAuthService } from './two-factor-auth.service';
@@ -54,17 +53,12 @@ describe('AuthController', () => {
       user.hKey = 'hKey';
       user.secret_2FA = 'secret_2FA';
 
-      const keys: Omit<
-        KeyServer,
-        'id' | 'userId' | 'encryptVersion' | 'toJSON'
-      > = {
-        publicKey: 'publicKey',
-        privateKey: 'privateKey',
-        revocationKey: 'revocationKey',
-      };
+      const keys = newKeyServer({ userId: user.id });
 
       jest.spyOn(userUseCases, 'findByEmail').mockResolvedValueOnce(user);
-      jest.spyOn(keyServerUseCases, 'findUserKeys').mockResolvedValueOnce(keys);
+      jest
+        .spyOn(keyServerUseCases, 'findUserKeys')
+        .mockResolvedValueOnce({ ecc: keys, kyber: null });
       jest.spyOn(cryptoService, 'encryptText').mockReturnValue('encryptedText');
 
       const res = {
@@ -78,6 +72,8 @@ describe('AuthController', () => {
         hasKeys: true,
         sKey: 'encryptedText',
         tfa: true,
+        hasKyberKeys: false,
+        hasEccKeys: true,
       });
     });
 
@@ -111,7 +107,7 @@ describe('AuthController', () => {
     loginAccessDto.password = v4();
     loginAccessDto.privateKey = 'privateKey';
     loginAccessDto.publicKey = 'publicKey';
-    loginAccessDto.revocateKey = 'revocateKey';
+    loginAccessDto.revocationKey = 'revocationKey';
 
     it('When valid login access details are provided, then it should return the result of loginAccess', async () => {
       jest
@@ -121,7 +117,17 @@ describe('AuthController', () => {
       const result = await authController.loginAccess(loginAccessDto);
 
       expect(userUseCases.loginAccess).toHaveBeenCalledTimes(1);
-      expect(userUseCases.loginAccess).toHaveBeenCalledWith(loginAccessDto);
+      expect(userUseCases.loginAccess).toHaveBeenCalledWith({
+        ...loginAccessDto,
+        keys: {
+          ecc: {
+            publicKey: loginAccessDto.publicKey,
+            privateKey: loginAccessDto.privateKey,
+            revocationKey: loginAccessDto.revocationKey,
+          },
+          kyber: null,
+        },
+      });
       expect(result).toEqual({ success: true });
     });
 
@@ -133,6 +139,65 @@ describe('AuthController', () => {
       await expect(authController.loginAccess(loginAccessDto)).rejects.toThrow(
         Error,
       );
+    });
+
+    it('When revocateKey is sent, then it should rename it to revocationKey', async () => {
+      const revocationKey = 'revocationKey';
+      const inputWithRevocateKey = { ...loginAccessDto };
+      inputWithRevocateKey.revocationKey = undefined;
+      inputWithRevocateKey.revocateKey = revocationKey;
+
+      jest
+        .spyOn(userUseCases, 'loginAccess')
+        .mockResolvedValueOnce({ success: true } as any);
+
+      await authController.loginAccess(inputWithRevocateKey);
+
+      expect(userUseCases.loginAccess).toHaveBeenCalledWith({
+        ...inputWithRevocateKey,
+        keys: {
+          ecc: {
+            publicKey: inputWithRevocateKey.publicKey,
+            privateKey: inputWithRevocateKey.privateKey,
+            revocationKey: revocationKey,
+          },
+          kyber: null,
+        },
+      });
+    });
+
+    it('When new key fields are sent, then it should update keys accordingly', async () => {
+      const inputWithRevocateKey = { ...loginAccessDto };
+      inputWithRevocateKey.keys = {
+        ecc: {
+          publicKey: 'public key',
+          privateKey: ' private key',
+          revocationKey: 'revocation key',
+        },
+        kyber: {
+          publicKey: 'public kyber key',
+          privateKey: ' private kyber key',
+        },
+      };
+
+      jest.spyOn(userUseCases, 'loginAccess');
+
+      await authController.loginAccess(inputWithRevocateKey);
+
+      expect(userUseCases.loginAccess).toHaveBeenCalledWith({
+        ...inputWithRevocateKey,
+        keys: {
+          ecc: {
+            publicKey: 'public key',
+            privateKey: ' private key',
+            revocationKey: 'revocation key',
+          },
+          kyber: {
+            publicKey: 'public kyber key',
+            privateKey: ' private kyber key',
+          },
+        },
+      });
     });
   });
 

--- a/src/modules/auth/auth.controller.ts
+++ b/src/modules/auth/auth.controller.ts
@@ -109,28 +109,15 @@ export class AuthController {
   @Public()
   @WorkspaceLogAction(WorkspaceLogType.Login)
   async loginAccess(@Body() body: LoginAccessDto) {
-    const eccKeys =
-      body.keys?.ecc || body.publicKey
-        ? {
-            publicKey: body.keys?.ecc?.publicKey || body.publicKey,
-            privateKey: body.keys?.ecc?.privateKey || body.privateKey,
-            revocationKey:
-              body.keys?.ecc?.revocationKey ||
-              body.revocationKey ||
-              body.revocateKey,
-          }
-        : null;
-
-    const kyberKeys = body.keys?.kyber
-      ? {
-          publicKey: body.keys.kyber.publicKey,
-          privateKey: body.keys.kyber.privateKey,
-        }
-      : null;
+    const { ecc, kyber } = this.keyServerUseCases.parseKeysInput(body.keys, {
+      privateKey: body.privateKey,
+      publicKey: body.publicKey,
+      revocationKey: body.revocationKey || body.revocateKey,
+    });
 
     return this.userUseCases.loginAccess({
       ...body,
-      keys: { kyber: kyberKeys, ecc: eccKeys },
+      keys: { kyber, ecc },
     });
   }
 

--- a/src/modules/auth/decorators/client.decorator.ts
+++ b/src/modules/auth/decorators/client.decorator.ts
@@ -2,5 +2,7 @@ import { createParamDecorator, ExecutionContext } from '@nestjs/common';
 
 export const Client = createParamDecorator((_, ctx: ExecutionContext) => {
   const req = ctx.switchToHttp().getRequest();
-  return String(req.headers['internxt-client-id']);
+  return String(
+    req.headers['internxt-client-id'] || req.headers['internxt-client'],
+  );
 });

--- a/src/modules/auth/dto/login-access.dto.ts
+++ b/src/modules/auth/dto/login-access.dto.ts
@@ -1,5 +1,15 @@
-import { ApiProperty } from '@nestjs/swagger';
-import { IsEmail, IsNotEmpty, IsOptional, IsString } from 'class-validator';
+import { ApiProperty, PartialType } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import {
+  IsEmail,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  ValidateNested,
+} from 'class-validator';
+import { KeysDto } from '../../keyserver/dto/keys.dto';
+
+class OptionalKeyGroup extends PartialType(KeysDto) {}
 
 export class LoginAccessDto {
   @ApiProperty({
@@ -28,7 +38,8 @@ export class LoginAccessDto {
 
   @ApiProperty({
     example: 'public_key',
-    description: 'Public Key',
+    description: 'Public Key (deprecated in favor of keys object)',
+    deprecated: true,
   })
   @IsOptional()
   @IsString()
@@ -36,7 +47,8 @@ export class LoginAccessDto {
 
   @ApiProperty({
     example: 'private_key',
-    description: 'Private Key',
+    description: 'Private Key (deprecated in favor of keys object)',
+    deprecated: true,
   })
   @IsOptional()
   @IsString()
@@ -44,9 +56,28 @@ export class LoginAccessDto {
 
   @ApiProperty({
     example: 'revocate_key',
-    description: 'Revocate Key',
+    description: 'Revocate Key (deprecated in favor of keys object)',
+    deprecated: true,
   })
   @IsOptional()
   @IsString()
   revocateKey?: string;
+
+  @ApiProperty({
+    example: 'revocation_key',
+    description: 'Revocation Key (deprecated in favor of keys object)',
+    deprecated: true,
+  })
+  @IsOptional()
+  @IsString()
+  revocationKey?: string;
+
+  @Type(() => OptionalKeyGroup)
+  @IsOptional()
+  @ValidateNested()
+  @ApiProperty({
+    example: 'newKeys',
+    description: 'keys',
+  })
+  keys?: OptionalKeyGroup;
 }

--- a/src/modules/keyserver/dto/keys.dto.ts
+++ b/src/modules/keyserver/dto/keys.dto.ts
@@ -1,0 +1,54 @@
+import { ApiProperty, PickType } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import { IsString, IsNotEmpty, ValidateNested } from 'class-validator';
+
+export class BaseKeysDto {
+  @IsString()
+  @IsNotEmpty()
+  @ApiProperty({
+    example: 'publicKeyExample',
+    description: 'Public key',
+  })
+  publicKey: string;
+
+  @IsString()
+  @IsNotEmpty()
+  @ApiProperty({
+    example: 'privateKeyExample',
+    description: 'Private key',
+  })
+  privateKey: string;
+
+  @IsString()
+  @IsNotEmpty()
+  @ApiProperty({
+    example: 'revocationKeyExample',
+    description: 'Revocation key',
+  })
+  revocationKey: string;
+}
+
+export class KyberKeysDto extends PickType(BaseKeysDto, [
+  'publicKey',
+  'privateKey',
+] as const) {}
+
+export class EccKeysDto extends BaseKeysDto {}
+
+export class KeysDto {
+  @Type(() => EccKeysDto)
+  @ValidateNested()
+  @ApiProperty({
+    type: EccKeysDto,
+    description: 'ECC keys',
+  })
+  ecc: EccKeysDto;
+
+  @Type(() => KyberKeysDto)
+  @ValidateNested()
+  @ApiProperty({
+    type: KyberKeysDto,
+    description: 'Kyber keys',
+  })
+  kyber: KyberKeysDto;
+}

--- a/src/modules/keyserver/dto/keys.dto.ts
+++ b/src/modules/keyserver/dto/keys.dto.ts
@@ -1,8 +1,31 @@
-import { ApiProperty, PickType } from '@nestjs/swagger';
+import { ApiProperty } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
-import { IsString, IsNotEmpty, ValidateNested } from 'class-validator';
+import {
+  IsString,
+  IsNotEmpty,
+  ValidateNested,
+  IsOptional,
+} from 'class-validator';
 
-export class BaseKeysDto {
+export class KyberKeysDto {
+  @IsString()
+  @IsNotEmpty()
+  @ApiProperty({
+    example: 'publicKeyExample',
+    description: 'Public key',
+  })
+  publicKey: string;
+
+  @IsString()
+  @IsNotEmpty()
+  @ApiProperty({
+    example: 'privateKeyExample',
+    description: 'Private key',
+  })
+  privateKey: string;
+}
+
+export class EccKeysDto {
   @IsString()
   @IsNotEmpty()
   @ApiProperty({
@@ -20,20 +43,13 @@ export class BaseKeysDto {
   privateKey: string;
 
   @IsString()
-  @IsNotEmpty()
+  @IsOptional()
   @ApiProperty({
     example: 'revocationKeyExample',
     description: 'Revocation key',
   })
-  revocationKey: string;
+  revocationKey?: string;
 }
-
-export class KyberKeysDto extends PickType(BaseKeysDto, [
-  'publicKey',
-  'privateKey',
-] as const) {}
-
-export class EccKeysDto extends BaseKeysDto {}
 
 export class KeysDto {
   @Type(() => EccKeysDto)
@@ -44,8 +60,9 @@ export class KeysDto {
   })
   ecc: EccKeysDto;
 
-  @Type(() => KyberKeysDto)
-  @ValidateNested()
+  // TODO: uncomment validations when frontend stops sending kyber object as {privateKey: null, publicKey: null}
+  //@Type(() => KyberKeysDto)
+  //@ValidateNested()
   @ApiProperty({
     type: KyberKeysDto,
     description: 'Kyber keys',

--- a/src/modules/keyserver/key-server.domain.spec.ts
+++ b/src/modules/keyserver/key-server.domain.spec.ts
@@ -1,0 +1,81 @@
+import {
+  KeyServer,
+  KeyServerAttributes,
+  UserKeysEncryptVersions,
+} from './key-server.domain';
+
+describe('KeyServer Domain', () => {
+  it('When ECC keys are validated, then it should validate successfully', () => {
+    const eccKeyData = {
+      id: 1,
+      userId: 101,
+      publicKey: 'eccPublicKey',
+      privateKey: 'eccPrivateKey',
+      revocationKey: 'eccRevocationKey',
+      encryptVersion: UserKeysEncryptVersions.Ecc,
+    };
+
+    const isValid = KeyServer.validate(eccKeyData.encryptVersion, eccKeyData);
+
+    expect(isValid).toEqual(true);
+  });
+
+  it('When Kyber keys are validated, then it should validate successfully', () => {
+    const kyberKeyData = {
+      id: 2,
+      userId: 102,
+      publicKey: 'kyberPublicKey',
+      privateKey: 'kyberPrivateKey',
+      encryptVersion: UserKeysEncryptVersions.Kyber,
+    };
+
+    const isValid = KeyServer.validate(
+      kyberKeyData.encryptVersion,
+      kyberKeyData,
+    );
+
+    expect(isValid).toEqual(true);
+  });
+
+  it('When Ecc keys have required fields missing, then it should throw', () => {
+    const invalidEccKeyData = {
+      id: 3,
+      userId: 103,
+      encryptVersion: UserKeysEncryptVersions.Ecc,
+    };
+
+    expect(() => {
+      KeyServer.validate(
+        invalidEccKeyData.encryptVersion,
+        invalidEccKeyData as KeyServerAttributes,
+      );
+    }).toThrow();
+  });
+
+  it('When Kyber keys have missing required fields, then it should throw', () => {
+    const kyberKeyData = {
+      id: 5,
+      userId: 105,
+      privateKey: 'kyberPrivateKey',
+      encryptVersion: UserKeysEncryptVersions.Kyber,
+    };
+
+    expect(() => {
+      KeyServer.validate(kyberKeyData.encryptVersion, kyberKeyData);
+    }).toThrow();
+  });
+
+  it('When unsupported encryption version is used, then it should throw', () => {
+    const unsupportedKeyData = {
+      id: 4,
+      userId: 104,
+      publicKey: 'unsupportedPublicKey',
+      privateKey: 'unsupportedPrivateKey',
+      encryptVersion: 'unsupported' as UserKeysEncryptVersions,
+    };
+
+    expect(() => {
+      KeyServer.validate(unsupportedKeyData.encryptVersion, unsupportedKeyData);
+    }).toThrow();
+  });
+});

--- a/src/modules/keyserver/key-server.domain.ts
+++ b/src/modules/keyserver/key-server.domain.ts
@@ -45,12 +45,9 @@ export class KeyServer implements KeyServerAttributes {
 
   toJSON() {
     return {
-      id: this.id,
-      userId: this.userId,
       publicKey: this.publicKey,
       privateKey: this.privateKey,
       revocationKey: this.revocationKey,
-      encryptVersion: this.encryptVersion,
     };
   }
 
@@ -64,11 +61,7 @@ export class KeyServer implements KeyServerAttributes {
   ) {
     const requiredFields = {
       [UserKeysEncryptVersions.Kyber]: ['publicKey', 'privateKey'],
-      [UserKeysEncryptVersions.Ecc]: [
-        'publicKey',
-        'privateKey',
-        'revocationKey',
-      ],
+      [UserKeysEncryptVersions.Ecc]: ['publicKey', 'privateKey'],
     };
 
     const required = requiredFields[encryptVersion];

--- a/src/modules/keyserver/key-server.model.ts
+++ b/src/modules/keyserver/key-server.model.ts
@@ -7,7 +7,10 @@ import {
   PrimaryKey,
   Table,
 } from 'sequelize-typescript';
-import { KeyServerAttributes } from './key-server.domain';
+import {
+  UserKeysEncryptVersions,
+  KeyServerAttributes,
+} from './key-server.domain';
 import { UserModel } from '../user/user.model';
 
 @Table({
@@ -35,5 +38,5 @@ export class KeyServerModel extends Model implements KeyServerAttributes {
   revocationKey: string;
 
   @Column(DataType.STRING)
-  encryptVersion: string;
+  encryptVersion: UserKeysEncryptVersions;
 }

--- a/src/modules/keyserver/key-server.usecase.spec.ts
+++ b/src/modules/keyserver/key-server.usecase.spec.ts
@@ -1,7 +1,10 @@
 import { createMock, DeepMocked } from '@golevelup/ts-jest';
-import { Keys, KeyServer } from './key-server.domain';
+import { Keys, KeyServer, UserKeysEncryptVersions } from './key-server.domain';
 import { SequelizeKeyServerRepository } from './key-server.repository';
-import { KeyServerUseCases } from './key-server.usecase';
+import {
+  InvalidKeyServerException,
+  KeyServerUseCases,
+} from './key-server.usecase';
 
 describe('Key Server Use Cases', () => {
   let service: KeyServerUseCases;
@@ -34,14 +37,14 @@ describe('Key Server Use Cases', () => {
         id: 430,
         userId,
         ...keys,
-        encryptVersion: '',
+        encryptVersion: UserKeysEncryptVersions.Ecc,
       });
 
       jest
         .spyOn(keyServerRepository, 'findUserKeysOrCreate')
         .mockResolvedValue([keyServer, true]);
 
-      await service.addKeysToUser(userId, keys);
+      await service.addKeysToUser(userId, { ecc: keys });
 
       expect(keyServerRepository.findUserKeysOrCreate).toHaveBeenCalledTimes(1);
       expect(keyServerRepository.findUserKeysOrCreate).toHaveBeenCalledWith(
@@ -84,7 +87,7 @@ describe('Key Server Use Cases', () => {
 
         const keys = incompleteKeySet as Keys;
 
-        await service.addKeysToUser(userId, keys);
+        await service.addKeysToUser(userId, { ecc: keys });
 
         expect(keyServerRepository.findUserKeysOrCreate).toHaveBeenCalledTimes(
           0,
@@ -93,29 +96,155 @@ describe('Key Server Use Cases', () => {
     );
   });
 
-  describe('getPublicKey', () => {
-    it('When a public key is found, then it should return the public key', async () => {
-      const userId = 123;
-      const mockPublicKey = 'mockPublicKey';
+  describe('findOrCreateKeysForUser', () => {
+    const userId = 234059;
 
-      jest
-        .spyOn(keyServerRepository, 'findPublicKey')
-        .mockResolvedValue(mockPublicKey);
+    it('When invalid ecc keys are provided, it should throw', async () => {
+      const invalidEccKeys = {
+        privateKey:
+          'gMWcRQZTAnrLMlFgAfGyukRICiLBKFqndsuEzMKuJuPlHlhbyVxPDxuWeZpI',
+        publicKey:
+          'lSWpfeTYwKqrMmfmTgqjQmInalzEDSrMRCNOOVOsrTuGWlbfMTThJHEBPmcV',
+        encryptVersion: UserKeysEncryptVersions.Ecc,
+      };
 
-      const result = await service.getPublicKey(userId);
-
-      expect(result).toEqual(mockPublicKey);
-      expect(keyServerRepository.findPublicKey).toHaveBeenCalledWith(userId);
+      await expect(
+        service.findOrCreateKeysForUser(userId, invalidEccKeys),
+      ).rejects.toThrow(InvalidKeyServerException);
     });
 
-    it('When no public key is found, then it should return undefined', async () => {
-      const userId = 123;
-      jest
-        .spyOn(keyServerRepository, 'findPublicKey')
-        .mockResolvedValue(undefined);
+    it('When invalid kyber keys are provided, it should throw', async () => {
+      const invalidKyberKeys = {
+        privateKey:
+          'gMWcRQZTAnrLMlFgAfGyukRICiLBKFqndsuEzMKuJuPlHlhbyVxPDxuWeZpI',
+        encryptVersion: UserKeysEncryptVersions.Kyber,
+      };
 
-      await service.getPublicKey(userId);
-      expect(keyServerRepository.findPublicKey).toHaveBeenCalledWith(userId);
+      await expect(
+        service.findOrCreateKeysForUser(userId, invalidKyberKeys),
+      ).rejects.toThrow(InvalidKeyServerException);
+    });
+
+    it('When valid keys are provided, then it should create them', async () => {
+      const validEccKey = {
+        privateKey:
+          'gMWcRQZTAnrLMlFgAfGyukRICiLBKFqndsuEzMKuJuPlHlhbyVxPDxuWeZpI',
+        publicKey:
+          'lSWpfeTYwKqrMmfmTgqjQmInalzEDSrMRCNOOVOsrTuGWlbfMTThJHEBPmcV',
+        revocationKey:
+          'WtPCEiOBbBTKIcOsePFyUCwCbfFmuoJsZKHnuKnjMbvWSPJxOdDFtaNRvwCB',
+        encryptVersion: UserKeysEncryptVersions.Ecc,
+      };
+
+      const keyServer = new KeyServer({
+        id: 430,
+        userId,
+        ...validEccKey,
+      });
+
+      jest
+        .spyOn(keyServerRepository, 'findUserKeysOrCreate')
+        .mockResolvedValue([keyServer, true]);
+
+      await service.findOrCreateKeysForUser(userId, validEccKey);
+
+      expect(keyServerRepository.findUserKeysOrCreate).toHaveBeenCalledTimes(1);
+      expect(keyServerRepository.findUserKeysOrCreate).toHaveBeenCalledWith(
+        userId,
+        {
+          userId,
+          ...validEccKey,
+        },
+      );
+    });
+  });
+
+  describe('updateByUserAndEncryptVersion', () => {
+    const userId = 234059;
+
+    it('When keys need to be update, then it should update them accordingly', async () => {
+      const validEccKey = {
+        privateKey:
+          'gMWcRQZTAnrLMlFgAfGyukRICiLBKFqndsuEzMKuJuPlHlhbyVxPDxuWeZpI',
+        publicKey:
+          'lSWpfeTYwKqrMmfmTgqjQmInalzEDSrMRCNOOVOsrTuGWlbfMTThJHEBPmcV',
+        revocationKey:
+          'WtPCEiOBbBTKIcOsePFyUCwCbfFmuoJsZKHnuKnjMbvWSPJxOdDFtaNRvwCB',
+      };
+
+      await expect(
+        service.updateByUserAndEncryptVersion(
+          userId,
+          UserKeysEncryptVersions.Ecc,
+          validEccKey,
+        ),
+      ).resolves.toBeUndefined();
+    });
+  });
+
+  describe('getPublicKeys', () => {
+    const userId = 234059;
+    const KeysData = {
+      privateKey:
+        'gMWcRQZTAnrLMlFgAfGyukRICiLBKFqndsuEzMKuJuPlHlhbyVxPDxuWeZpI',
+      publicKey: 'lSWpfeTYwKqrMmfmTgqjQmInalzEDSrMRCNOOVOsrTuGWlbfMTThJHEBPmcV',
+      revocationKey:
+        'WtPCEiOBbBTKIcOsePFyUCwCbfFmuoJsZKHnuKnjMbvWSPJxOdDFtaNRvwCB',
+    };
+
+    it('When user public keys are retrieved, it should return them successfully', async () => {
+      const eccKey = new KeyServer({
+        id: 430,
+        userId,
+        ...KeysData,
+        encryptVersion: UserKeysEncryptVersions.Ecc,
+      });
+
+      const kyberKey = new KeyServer({
+        id: 431,
+        userId,
+        ...KeysData,
+        encryptVersion: UserKeysEncryptVersions.Kyber,
+      });
+
+      jest
+        .spyOn(keyServerRepository, 'findUserKeys')
+        .mockResolvedValue([eccKey, kyberKey]);
+
+      const userKeys = await service.getPublicKeys(userId);
+
+      expect(userKeys).toEqual({
+        kyber: kyberKey.publicKey,
+        ecc: eccKey.publicKey,
+      });
+    });
+
+    it('When user public keys are retrieved there are keys missing, it should them as empty', async () => {
+      const eccKey = new KeyServer({
+        id: 430,
+        userId,
+        ...KeysData,
+        encryptVersion: UserKeysEncryptVersions.Ecc,
+      });
+
+      jest
+        .spyOn(keyServerRepository, 'findUserKeys')
+        .mockResolvedValueOnce([eccKey]);
+
+      jest.spyOn(keyServerRepository, 'findUserKeys').mockResolvedValueOnce([]);
+
+      const userKeys = await service.getPublicKeys(userId);
+      const noKeys = await service.getPublicKeys(userId);
+
+      expect(userKeys).toEqual({
+        kyber: null,
+        ecc: eccKey.publicKey,
+      });
+
+      expect(noKeys).toEqual({
+        kyber: null,
+        ecc: null,
+      });
     });
   });
 
@@ -132,20 +261,27 @@ describe('Key Server Use Cases', () => {
           'WtPCEiOBbBTKIcOsePFyUCwCbfFmuoJsZKHnuKnjMbvWSPJxOdDFtaNRvwCB',
       };
 
-      const keyServer = new KeyServer({
+      const ecc = new KeyServer({
         id: 430,
         userId,
         ...keys,
-        encryptVersion: '',
+        encryptVersion: UserKeysEncryptVersions.Ecc,
+      });
+
+      const kyber = new KeyServer({
+        id: 431,
+        userId,
+        ...keys,
+        encryptVersion: UserKeysEncryptVersions.Kyber,
       });
 
       jest
         .spyOn(keyServerRepository, 'findUserKeys')
-        .mockResolvedValue(keyServer);
+        .mockResolvedValue([ecc, kyber]);
 
       const result = await service.findUserKeys(userId);
 
-      expect(result).toEqual(keys);
+      expect(result).toEqual({ kyber, ecc });
       expect(keyServerRepository.findUserKeys).toHaveBeenCalledWith(userId);
     });
   });

--- a/src/modules/keyserver/key-server.usecase.spec.ts
+++ b/src/modules/keyserver/key-server.usecase.spec.ts
@@ -61,8 +61,6 @@ describe('Key Server Use Cases', () => {
       {
         privateKey:
           'gMWcRQZTAnrLMlFgAfGyukRICiLBKFqndsuEzMKuJuPlHlhbyVxPDxuWeZpI',
-        publicKey:
-          'lSWpfeTYwKqrMmfmTgqjQmInalzEDSrMRCNOOVOsrTuGWlbfMTThJHEBPmcV',
       },
       {
         privateKey:
@@ -103,8 +101,6 @@ describe('Key Server Use Cases', () => {
       const invalidEccKeys = {
         privateKey:
           'gMWcRQZTAnrLMlFgAfGyukRICiLBKFqndsuEzMKuJuPlHlhbyVxPDxuWeZpI',
-        publicKey:
-          'lSWpfeTYwKqrMmfmTgqjQmInalzEDSrMRCNOOVOsrTuGWlbfMTThJHEBPmcV',
         encryptVersion: UserKeysEncryptVersions.Ecc,
       };
 
@@ -283,6 +279,104 @@ describe('Key Server Use Cases', () => {
 
       expect(result).toEqual({ kyber, ecc });
       expect(keyServerRepository.findUserKeys).toHaveBeenCalledWith(userId);
+    });
+  });
+
+  describe('parseKeysInput', () => {
+    it('When both ecc and kyber keys are provided, then it should return the parsed keys', () => {
+      const inputKeys = {
+        ecc: {
+          publicKey: 'eccPublicKey',
+          privateKey: 'eccPrivateKey',
+          revocationKey: 'eccRevocationKey',
+        },
+        kyber: {
+          publicKey: 'kyberPublicKey',
+          privateKey: 'kyberPrivateKey',
+        },
+      };
+
+      const result = service.parseKeysInput(inputKeys);
+
+      expect(result).toEqual({
+        ecc: {
+          publicKey: 'eccPublicKey',
+          privateKey: 'eccPrivateKey',
+          revocationKey: 'eccRevocationKey',
+        },
+        kyber: {
+          publicKey: 'kyberPublicKey',
+          privateKey: 'kyberPrivateKey',
+        },
+      });
+    });
+
+    it('When only ecc keys are provided, then it should return only ecc keys with null kyber keys', () => {
+      const inputKeys = {
+        ecc: {
+          publicKey: 'eccPublicKey',
+          privateKey: 'eccPrivateKey',
+          revocationKey: 'eccRevocationKey',
+        },
+      };
+
+      const result = service.parseKeysInput(inputKeys);
+
+      expect(result).toEqual({
+        ecc: {
+          publicKey: 'eccPublicKey',
+          privateKey: 'eccPrivateKey',
+          revocationKey: 'eccRevocationKey',
+        },
+        kyber: null,
+      });
+    });
+
+    it('When only kyber keys are provided, then it should return only kyber keys with null ecc keys', () => {
+      const inputKeys = {
+        kyber: {
+          publicKey: 'kyberPublicKey',
+          privateKey: 'kyberPrivateKey',
+        },
+      };
+
+      const result = service.parseKeysInput(inputKeys);
+
+      expect(result).toEqual({
+        ecc: null,
+        kyber: {
+          publicKey: 'kyberPublicKey',
+          privateKey: 'kyberPrivateKey',
+        },
+      });
+    });
+
+    it('When no keys are provided, then it should return both ecc and kyber as null', () => {
+      const result = service.parseKeysInput({});
+
+      expect(result).toEqual({
+        ecc: null,
+        kyber: null,
+      });
+    });
+
+    it('When old keys are provided and new keys are missing, it should fall back to old keys', () => {
+      const oldKeys = {
+        publicKey: 'oldPublicKey',
+        privateKey: 'oldPrivateKey',
+        revocationKey: 'oldRevocationKey',
+      };
+
+      const result = service.parseKeysInput({}, oldKeys);
+
+      expect(result).toEqual({
+        ecc: {
+          publicKey: 'oldPublicKey',
+          privateKey: 'oldPrivateKey',
+          revocationKey: 'oldRevocationKey',
+        },
+        kyber: null,
+      });
     });
   });
 });

--- a/src/modules/keyserver/key-server.usecase.ts
+++ b/src/modules/keyserver/key-server.usecase.ts
@@ -1,46 +1,132 @@
 import { Injectable } from '@nestjs/common';
 import { UserAttributes } from '../user/user.attributes';
-import { Keys } from './key-server.domain';
+import {
+  KeyServer,
+  KeyServerAttributes,
+  UserKeysEncryptVersions,
+} from './key-server.domain';
 import { SequelizeKeyServerRepository } from './key-server.repository';
+
+export class InvalidKeyServerException extends Error {
+  constructor(public validationMessage: string) {
+    super(validationMessage);
+    Object.setPrototypeOf(this, InvalidKeyServerException.prototype);
+  }
+}
+
+type PartialKeys = Partial<Omit<KeyServerAttributes, 'id' | 'userId'>>;
 
 @Injectable()
 export class KeyServerUseCases {
   constructor(private repository: SequelizeKeyServerRepository) {}
 
-  async addKeysToUser(userId: UserAttributes['id'], keys: Keys): Promise<Keys> {
-    if (!keys.privateKey || !keys.publicKey || !keys.revocationKey) {
-      return;
-    }
+  async addKeysToUser(
+    userId: UserAttributes['id'],
+    keys: {
+      kyber?: Omit<PartialKeys, 'encryptVersion'>;
+      ecc?: Omit<PartialKeys, 'encryptVersion'>;
+    },
+  ): Promise<{ kyber: KeyServer | null; ecc: KeyServer | null }> {
+    const processKey = async (
+      encryptVersion: UserKeysEncryptVersions,
+      keyData?: Omit<PartialKeys, 'encryptVersion'>,
+    ): Promise<KeyServer | null> => {
+      if (!keyData) return null;
 
-    const [{ publicKey, privateKey, revocationKey }] =
-      await this.repository.findUserKeysOrCreate(userId, {
-        userId,
-        publicKey: keys.publicKey,
-        privateKey: keys.privateKey,
-        revocationKey: keys.revocationKey,
-        encryptVersion: 'ecc',
-      });
+      try {
+        return await this.findOrCreateKeysForUser(userId, {
+          publicKey: keyData.publicKey,
+          privateKey: keyData.privateKey,
+          revocationKey: keyData.revocationKey,
+          encryptVersion,
+        });
+      } catch {
+        return null;
+      }
+    };
 
-    return { publicKey, privateKey, revocationKey };
+    const [kyberKey, eccKey] = await Promise.all([
+      processKey(UserKeysEncryptVersions.Kyber, keys.kyber),
+      processKey(UserKeysEncryptVersions.Ecc, keys.ecc),
+    ]);
+
+    return { kyber: kyberKey, ecc: eccKey };
   }
 
-  async getPublicKey(userId: UserAttributes['id']): Promise<string> {
-    const publicKey = await this.repository.findPublicKey(userId);
-
-    return publicKey;
-  }
-
-  async findUserKeys(userId: UserAttributes['id']): Promise<Keys | null> {
-    const keys = await this.repository.findUserKeys(userId);
-
-    if (!keys) {
-      return null;
+  async findOrCreateKeysForUser(
+    userId: UserAttributes['id'],
+    keys: PartialKeys,
+  ): Promise<KeyServer> {
+    try {
+      KeyServer.validate(keys.encryptVersion, keys);
+    } catch (error) {
+      throw new InvalidKeyServerException(error.message);
     }
 
-    return {
+    const [createdKeys] = await this.repository.findUserKeysOrCreate(userId, {
+      userId,
       publicKey: keys.publicKey,
       privateKey: keys.privateKey,
       revocationKey: keys.revocationKey,
+      encryptVersion: keys.encryptVersion,
+    });
+
+    return createdKeys;
+  }
+
+  async updateByUserAndEncryptVersion(
+    userId: UserAttributes['id'],
+    encryptVersion: KeyServerAttributes['encryptVersion'],
+    data: Partial<Omit<KeyServerAttributes, 'id'>>,
+  ): Promise<void> {
+    await this.repository.updateByUserAndEncryptVersion(
+      userId,
+      encryptVersion,
+      data,
+    );
+  }
+
+  async getPublicKeys(userId: UserAttributes['id']): Promise<{
+    kyber: string | null;
+    ecc: string | null;
+  }> {
+    const userKeys = await this.repository.findUserKeys(userId);
+
+    const eccKeys = this.findKeyByEncryptionMethod(
+      userKeys,
+      UserKeysEncryptVersions.Ecc,
+    );
+
+    const kyberKeys = this.findKeyByEncryptionMethod(
+      userKeys,
+      UserKeysEncryptVersions.Kyber,
+    );
+
+    return {
+      kyber: kyberKeys?.publicKey || null,
+      ecc: eccKeys?.publicKey || null,
     };
+  }
+
+  async deleteByUserId(userId: UserAttributes['id']): Promise<void> {
+    await this.repository.deleteByUserId(userId);
+  }
+
+  async findUserKeys(
+    userId: UserAttributes['id'],
+  ): Promise<{ kyber: KeyServer | null; ecc: KeyServer | null }> {
+    const keys = await this.repository.findUserKeys(userId);
+
+    const kyber = keys.find((key) => key.encryptVersion === 'kyber');
+    const ecc = keys.find((key) => key.encryptVersion === 'ecc');
+
+    return { kyber, ecc };
+  }
+
+  private findKeyByEncryptionMethod(
+    userKeys: KeyServer[],
+    version: UserKeysEncryptVersions,
+  ): KeyServer | null {
+    return userKeys.find((key) => key.encryptVersion === version) || null;
   }
 }

--- a/src/modules/user/dto/create-user.dto.ts
+++ b/src/modules/user/dto/create-user.dto.ts
@@ -2,7 +2,6 @@ import {
   IsNotEmpty,
   IsOptional,
   IsString,
-  ValidateIf,
   ValidateNested,
 } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
@@ -20,9 +19,10 @@ class KeysDto {
   })
   ecc: EccKeysDto;
 
-  @Type(() => KyberKeysDto)
+  // TODO: uncomment validations when frontend stops sending kyber object as {privateKey: null, publicKey: null}
+  //@Type(() => KyberKeysDto)
   @IsOptional()
-  @ValidateNested()
+  //@ValidateNested()
   @ApiProperty({
     type: KyberKeysDto,
     description: 'Kyber keys',
@@ -115,9 +115,9 @@ export class CreateUserDto {
   })
   registerCompleted?: UserAttributes['registerCompleted'];
 
+  @Type(() => KeysDto)
   @IsOptional()
   @ValidateNested()
-  @Type(() => KeysDto)
   @ApiProperty({
     type: KeysDto,
     description:

--- a/src/modules/user/dto/create-user.dto.ts
+++ b/src/modules/user/dto/create-user.dto.ts
@@ -1,6 +1,34 @@
-import { IsNotEmpty, IsOptional } from 'class-validator';
+import {
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  ValidateIf,
+  ValidateNested,
+} from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
 import { UserAttributes } from '../user.attributes';
+import { Type } from 'class-transformer';
+import { EccKeysDto, KyberKeysDto } from '../../keyserver/dto/keys.dto';
+
+class KeysDto {
+  @Type(() => EccKeysDto)
+  @IsOptional()
+  @ValidateNested()
+  @ApiProperty({
+    type: EccKeysDto,
+    description: 'ECC keys',
+  })
+  ecc: EccKeysDto;
+
+  @Type(() => KyberKeysDto)
+  @IsOptional()
+  @ValidateNested()
+  @ApiProperty({
+    type: KyberKeysDto,
+    description: 'Kyber keys',
+  })
+  kyber: KyberKeysDto;
+}
 
 export class CreateUserDto {
   @IsNotEmpty()
@@ -47,37 +75,53 @@ export class CreateUserDto {
   salt: string;
 
   @IsOptional()
+  @IsString()
   @ApiProperty({
     example: '',
     description: '',
+    deprecated: true,
   })
-  privateKey: string;
+  privateKey?: string;
+
+  @IsOptional()
+  @IsString()
+  @ApiProperty({
+    example: '',
+    description: '',
+    deprecated: true,
+  })
+  publicKey?: string;
+
+  @IsOptional()
+  @IsString()
+  @ApiProperty({
+    example: '',
+    description: '',
+    deprecated: true,
+  })
+  revocationKey?: string;
 
   @IsOptional()
   @ApiProperty({
     example: '',
     description: '',
   })
-  publicKey: string;
+  referrer?: UserAttributes['referrer'];
 
   @IsOptional()
   @ApiProperty({
     example: '',
     description: '',
   })
-  revocationKey: string;
+  registerCompleted?: UserAttributes['registerCompleted'];
 
   @IsOptional()
+  @ValidateNested()
+  @Type(() => KeysDto)
   @ApiProperty({
-    example: '',
-    description: '',
+    type: KeysDto,
+    description:
+      'Keys, if provided, will update the user keys. This object replaces the need for privateKey and encryptVersion.',
   })
-  referrer: UserAttributes['referrer'];
-
-  @IsOptional()
-  @ApiProperty({
-    example: '',
-    description: '',
-  })
-  registerCompleted: UserAttributes['registerCompleted'];
+  keys?: KeysDto;
 }

--- a/src/modules/user/dto/recover-account.dto.ts
+++ b/src/modules/user/dto/recover-account.dto.ts
@@ -1,5 +1,20 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsNotEmpty } from 'class-validator';
+import { Type } from 'class-transformer';
+import { IsNotEmpty, IsOptional, ValidateNested } from 'class-validator';
+
+class PrivateKeysDto {
+  @IsNotEmpty()
+  @ApiProperty({
+    description: 'ECC key',
+  })
+  ecc: string;
+
+  @IsNotEmpty()
+  @ApiProperty({
+    description: 'Kyber keys',
+  })
+  kyber: string;
+}
 
 export class RecoverAccountDto {
   @ApiProperty({
@@ -29,6 +44,11 @@ export class RecoverAccountDto {
   })
   // @IsNotEmpty()
   privateKey: string;
+
+  @Type(() => PrivateKeysDto)
+  @ValidateNested()
+  @IsOptional()
+  privateKeys?: PrivateKeysDto;
 }
 
 export class ResetAccountDto {

--- a/src/modules/user/dto/update-password.dto.ts
+++ b/src/modules/user/dto/update-password.dto.ts
@@ -7,28 +7,32 @@ import {
   ValidateIf,
   ValidateNested,
 } from 'class-validator';
-import { BaseKeysDto } from '../../keyserver/dto/keys.dto';
+import { EccKeysDto, KyberKeysDto } from '../../keyserver/dto/keys.dto';
 
-class BasePrivateKey extends PickType(BaseKeysDto, ['privateKey'] as const) {}
+class KyberPrivateKeyDto extends PickType(KyberKeysDto, [
+  'privateKey',
+] as const) {}
+
+class EccPrivateKeyDto extends PickType(EccKeysDto, ['privateKey'] as const) {}
 
 class PrivateKeysDto {
-  @Type(() => BasePrivateKey)
+  @Type(() => EccPrivateKeyDto)
   @ValidateNested()
   @IsNotEmpty()
   @ApiProperty({
-    type: BasePrivateKey,
+    type: EccPrivateKeyDto,
     description: 'ECC keys',
   })
-  ecc: BasePrivateKey;
+  ecc: EccPrivateKeyDto;
 
-  @Type(() => BasePrivateKey)
-  @ValidateNested()
-  @IsNotEmpty()
+  // TODO: uncomment validations when frontend stops sending kyber object as {privateKey: null, publicKey: null}
+  //@Type(() => KyberPrivateKeyDto)
+  //@ValidateNested()
   @ApiProperty({
-    type: BasePrivateKey,
+    type: KyberPrivateKeyDto,
     description: 'Kyber keys',
   })
-  kyber: BasePrivateKey;
+  kyber?: KyberPrivateKeyDto;
 }
 
 export class UpdatePasswordDto {
@@ -61,9 +65,6 @@ export class UpdatePasswordDto {
   mnemonic: string;
 
   @ValidateIf((dto) => !dto.keys)
-  @IsNotEmpty({
-    message: 'PrivateKey must be defined if keys object is not provided.',
-  })
   @IsString()
   @ApiProperty({
     example: 'newPrivateKey',

--- a/src/modules/user/dto/update-password.dto.ts
+++ b/src/modules/user/dto/update-password.dto.ts
@@ -1,5 +1,35 @@
-import { ApiProperty } from '@nestjs/swagger';
-import { IsString } from 'class-validator';
+import { ApiProperty, PickType } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import {
+  IsNotEmpty,
+  IsObject,
+  IsString,
+  ValidateIf,
+  ValidateNested,
+} from 'class-validator';
+import { BaseKeysDto } from '../../keyserver/dto/keys.dto';
+
+class BasePrivateKey extends PickType(BaseKeysDto, ['privateKey'] as const) {}
+
+class PrivateKeysDto {
+  @Type(() => BasePrivateKey)
+  @ValidateNested()
+  @IsNotEmpty()
+  @ApiProperty({
+    type: BasePrivateKey,
+    description: 'ECC keys',
+  })
+  ecc: BasePrivateKey;
+
+  @Type(() => BasePrivateKey)
+  @ValidateNested()
+  @IsNotEmpty()
+  @ApiProperty({
+    type: BasePrivateKey,
+    description: 'Kyber keys',
+  })
+  kyber: BasePrivateKey;
+}
 
 export class UpdatePasswordDto {
   @IsString()
@@ -30,17 +60,42 @@ export class UpdatePasswordDto {
   })
   mnemonic: string;
 
+  @ValidateIf((dto) => !dto.keys)
+  @IsNotEmpty({
+    message: 'PrivateKey must be defined if keys object is not provided.',
+  })
   @IsString()
   @ApiProperty({
     example: 'newPrivateKey',
     description: 'New private key',
+    deprecated: true,
   })
   privateKey: string;
 
+  @ValidateIf((dto) => !dto.keys)
+  @IsNotEmpty({
+    message: 'EncryptVersion must be defined if keys object is not provided.',
+  })
   @IsString()
   @ApiProperty({
     example: 'encryptVersion',
     description: 'Encrypt version',
+    deprecated: true,
   })
   encryptVersion: string;
+
+  @ValidateIf((dto) => !dto.privateKey || !!dto.keys)
+  @IsNotEmpty({
+    message:
+      'Keys object must be provided if privateKey and encryptVersion are not defined.',
+  })
+  @ValidateNested()
+  @Type(() => PrivateKeysDto)
+  @IsObject()
+  @ApiProperty({
+    type: PrivateKeysDto,
+    description:
+      'Keys, if provided, will update the user keys. This object replaces the need for privateKey and encryptVersion.',
+  })
+  keys?: PrivateKeysDto;
 }

--- a/src/modules/user/pre-created-user.domain.ts
+++ b/src/modules/user/pre-created-user.domain.ts
@@ -1,3 +1,4 @@
+import { UserKeysEncryptVersions } from '../keyserver/key-server.domain';
 import { PreCreatedUserAttributes } from './pre-created-users.attributes';
 
 export class PreCreatedUser implements PreCreatedUserAttributes {
@@ -11,7 +12,7 @@ export class PreCreatedUser implements PreCreatedUserAttributes {
   publicKey: string;
   privateKey: string;
   revocationKey: string;
-  encryptVersion: string;
+  encryptVersion: UserKeysEncryptVersions;
   constructor({
     id,
     email,

--- a/src/modules/user/pre-created-users.model.ts
+++ b/src/modules/user/pre-created-users.model.ts
@@ -9,6 +9,7 @@ import {
   Unique,
 } from 'sequelize-typescript';
 import { PreCreatedUserAttributes } from './pre-created-users.attributes';
+import { KeyServerAttributes } from '../keyserver/key-server.domain';
 
 @Table({
   underscored: true,
@@ -45,7 +46,7 @@ export class PreCreatedUserModel
   revocationKey: string;
 
   @Column(DataType.STRING)
-  encryptVersion: string;
+  encryptVersion: KeyServerAttributes['encryptVersion'];
 
   @Column
   password: string;

--- a/src/modules/user/user.usecase.spec.ts
+++ b/src/modules/user/user.usecase.spec.ts
@@ -43,6 +43,7 @@ import {
   newNotificationToken,
   newFile,
   newFolder,
+  newKeyServer,
 } from '../../../test/fixtures';
 import { MailTypes } from '../security/mail-limit/mailTypes';
 import { SequelizeWorkspaceRepository } from '../workspaces/repositories/workspaces.repository';
@@ -54,12 +55,13 @@ import {
 } from './dto/register-notification-token.dto';
 import { UserNotificationTokens } from './user-notification-tokens.domain';
 import { v4 } from 'uuid';
-import { SequelizeKeyServerRepository } from '../keyserver/key-server.repository';
-import { KeyServerModel } from '../keyserver/key-server.model';
 import * as speakeasy from 'speakeasy';
 import { MailerService } from '../../externals/mailer/mailer.service';
 import { LoginAccessDto } from '../auth/dto/login-access.dto';
 import { UpdateProfileDto } from './dto/update-profile.dto';
+import { KeyServerUseCases } from '../keyserver/key-server.usecase';
+import { UserKeysEncryptVersions } from '../keyserver/key-server.domain';
+import { UpdatePasswordDto } from './dto/update-password.dto';
 
 jest.mock('../../middlewares/passport', () => {
   const originalModule = jest.requireActual('../../middlewares/passport');
@@ -78,7 +80,6 @@ describe('User use cases', () => {
   let folderUseCases: FolderUseCases;
   let fileUseCases: FileUseCases;
   let userRepository: SequelizeUserRepository;
-  let keyServerRepository: SequelizeKeyServerRepository;
   let bridgeService: BridgeService;
   let sharedWorkspaceRepository: SequelizeSharedWorkspaceRepository;
   let cryptoService: CryptoService;
@@ -88,6 +89,8 @@ describe('User use cases', () => {
   let workspaceRepository: SequelizeWorkspaceRepository;
   let mailerService: MailerService;
   let avatarService: AvatarService;
+  let keyServerUseCases: KeyServerUseCases;
+
   const loggerErrorSpy = jest.spyOn(Logger, 'error').mockImplementation();
 
   const user = User.build({
@@ -131,9 +134,6 @@ describe('User use cases', () => {
     userRepository = moduleRef.get<SequelizeUserRepository>(
       SequelizeUserRepository,
     );
-    keyServerRepository = moduleRef.get<SequelizeKeyServerRepository>(
-      SequelizeKeyServerRepository,
-    );
     bridgeService = moduleRef.get<BridgeService>(BridgeService);
     userRepository = moduleRef.get<SequelizeUserRepository>(
       SequelizeUserRepository,
@@ -154,6 +154,7 @@ describe('User use cases', () => {
     workspaceRepository = moduleRef.get<SequelizeWorkspaceRepository>(
       SequelizeWorkspaceRepository,
     );
+    keyServerUseCases = moduleRef.get<KeyServerUseCases>(KeyServerUseCases);
     mailerService = moduleRef.get<MailerService>(MailerService);
     avatarService = moduleRef.get<AvatarService>(AvatarService);
     jest.clearAllMocks();
@@ -833,11 +834,7 @@ describe('User use cases', () => {
   });
 
   describe('loginAccess', () => {
-    const keys = {
-      publicKey: 'publicKey',
-      privateKey: 'privateKey',
-      revocateKey: 'revocateKey',
-    };
+    const keys = newKeyServer();
 
     it('When an email in uppercase is provided, then it should be transformed to lowercase', async () => {
       const loginAccessDto: LoginAccessDto = {
@@ -863,7 +860,7 @@ describe('User use cases', () => {
         email: 'nonexistent@example.com',
         password: v4(),
         tfa: '',
-        ...keys,
+        ...keys.toJSON(),
       };
       jest.spyOn(userRepository, 'findByUsername').mockResolvedValue(null);
 
@@ -877,7 +874,7 @@ describe('User use cases', () => {
         email: 'test@example.com',
         password: v4(),
         tfa: '',
-        ...keys,
+        ...keys.toJSON(),
       };
       const user = newUser({
         attributes: {
@@ -899,7 +896,7 @@ describe('User use cases', () => {
         email: 'test@example.com',
         password: wrongPassword,
         tfa: '',
-        ...keys,
+        ...keys.toJSON(),
       };
       const user = newUser({
         attributes: {
@@ -918,12 +915,6 @@ describe('User use cases', () => {
 
     it('When login is successful, then it should return user and tokens', async () => {
       const hashedPassword = v4();
-      const loginAccessDto = {
-        email: 'test@example.com',
-        password: v4(),
-        tfa: '',
-        ...keys,
-      };
       const user = newUser({
         attributes: {
           email: 'test@example.com',
@@ -932,11 +923,13 @@ describe('User use cases', () => {
           secret_2FA: null,
         },
       });
-      const keyServer = {
-        ...keys,
-        revocationKey: keys.revocateKey,
-        userId: user.id,
-      } as unknown as KeyServerModel;
+      const keyServer = newKeyServer({ userId: user.id, ...keys.toJSON() });
+      const loginAccessDto = {
+        email: 'test@example.com',
+        password: v4(),
+        tfa: '',
+        ...keyServer.toJSON(),
+      };
 
       const folder = newFolder({ owner: user, attributes: { bucket: v4() } });
 
@@ -947,8 +940,12 @@ describe('User use cases', () => {
         .mockReturnValue({ token: 'authToken', newToken: 'newAuthToken' });
       jest.spyOn(userUseCases, 'updateByUuid').mockResolvedValue(undefined);
       jest.spyOn(folderUseCases, 'getFolderById').mockResolvedValueOnce(folder);
-      jest.spyOn(keyServerRepository, 'findUserKeys').mockResolvedValue(null);
-      jest.spyOn(keyServerRepository, 'create').mockResolvedValue(keyServer);
+      jest
+        .spyOn(keyServerUseCases, 'findUserKeys')
+        .mockResolvedValue({ ecc: null, kyber: null });
+      jest
+        .spyOn(keyServerUseCases, 'findOrCreateKeysForUser')
+        .mockResolvedValue(keyServer);
 
       const result = await userUseCases.loginAccess(loginAccessDto);
 
@@ -965,7 +962,7 @@ describe('User use cases', () => {
         email: 'test@example.com',
         password: v4(),
         tfa: 'wrongTfa',
-        ...keys,
+        ...keys.toJSON(),
       };
       const user = newUser({
         attributes: {
@@ -990,8 +987,9 @@ describe('User use cases', () => {
         email: 'test@example.com',
         password: v4(),
         tfa: 'okTfa',
-        ...keys,
+        ...keys.toJSON(),
       };
+
       const user = newUser({
         attributes: {
           email: 'test@example.com',
@@ -1000,11 +998,8 @@ describe('User use cases', () => {
           secret_2FA: 'secret',
         },
       });
-      const keyServer = {
-        ...keys,
-        revocationKey: keys.revocateKey,
-        userId: user.id,
-      } as unknown as KeyServerModel;
+      const keyServer = newKeyServer({ userId: user.id, ...keys.toJSON() });
+
       const folder = newFolder({ owner: user, attributes: { bucket: v4() } });
 
       jest.spyOn(userRepository, 'findByUsername').mockResolvedValue(user);
@@ -1017,9 +1012,12 @@ describe('User use cases', () => {
         .mockReturnValue({ token: 'authToken', newToken: 'newAuthToken' });
       jest.spyOn(userUseCases, 'updateByUuid').mockResolvedValue(undefined);
       jest.spyOn(folderUseCases, 'getFolderById').mockResolvedValueOnce(folder);
-      jest.spyOn(keyServerRepository, 'findUserKeys').mockResolvedValue(null);
-      jest.spyOn(keyServerRepository, 'create').mockResolvedValue(keyServer);
-
+      jest
+        .spyOn(keyServerUseCases, 'findUserKeys')
+        .mockResolvedValue({ ecc: null, kyber: null });
+      jest
+        .spyOn(keyServerUseCases, 'findOrCreateKeysForUser')
+        .mockResolvedValue(keyServer);
       const result = await userUseCases.loginAccess(loginAccessDto);
 
       expect(result).toHaveProperty('user');
@@ -1027,6 +1025,276 @@ describe('User use cases', () => {
       expect(result.user).toHaveProperty('bucket', folder.bucket);
       expect(result).toHaveProperty('token', 'authToken');
       expect(result).toHaveProperty('newToken', 'newAuthToken');
+    });
+
+    it('When user without ecc keys logs in and keys are sent, then it should save keys', async () => {
+      const hashedPassword = 'hashedPassword';
+      const user = newUser({
+        attributes: {
+          password: hashedPassword,
+          errorLoginCount: 0,
+          secret_2FA: null,
+        },
+      });
+      const keyServer = newKeyServer({ userId: user.id, ...keys.toJSON() });
+      const loginAccessDto: LoginAccessDto = {
+        email: user.email,
+        password: hashedPassword,
+        tfa: '',
+        keys: { ecc: { ...keyServer.toJSON() } },
+      };
+
+      const folder = newFolder({ owner: user, attributes: { bucket: v4() } });
+
+      jest.spyOn(userRepository, 'findByUsername').mockResolvedValue(user);
+      jest.spyOn(cryptoService, 'decryptText').mockReturnValue(hashedPassword);
+      jest
+        .spyOn(userUseCases, 'getAuthTokens')
+        .mockReturnValue({ token: 'authToken', newToken: 'newAuthToken' });
+      jest.spyOn(userUseCases, 'updateByUuid').mockResolvedValue(undefined);
+      jest.spyOn(folderUseCases, 'getFolderById').mockResolvedValueOnce(folder);
+      jest
+        .spyOn(keyServerUseCases, 'findUserKeys')
+        .mockResolvedValue({ ecc: null, kyber: null });
+      jest
+        .spyOn(keyServerUseCases, 'findOrCreateKeysForUser')
+        .mockResolvedValue(keyServer);
+
+      const result = await userUseCases.loginAccess(loginAccessDto);
+
+      expect(keyServerUseCases.findOrCreateKeysForUser).toHaveBeenCalledWith(
+        user.id,
+        {
+          publicKey: keyServer.publicKey,
+          privateKey: keyServer.privateKey,
+          revocationKey: keyServer.revocationKey,
+          encryptVersion: keyServer.encryptVersion,
+        },
+      );
+      expect(result.user).toHaveProperty('keys', {
+        ecc: {
+          privateKey: keyServer.privateKey,
+          publicKey: keyServer.publicKey,
+          revocationKey: keyServer.revocationKey,
+        },
+        kyber: {
+          privateKey: null,
+          publicKey: null,
+        },
+      });
+    });
+
+    it('When user without kyber keys logs in and keys are sent, then it should save keys', async () => {
+      const hashedPassword = 'hashedPassword';
+      const user = newUser({
+        attributes: {
+          password: hashedPassword,
+          errorLoginCount: 0,
+          secret_2FA: null,
+        },
+      });
+      const keyServer = newKeyServer({
+        userId: user.id,
+        encryptVersion: UserKeysEncryptVersions.Kyber,
+      });
+      const loginAccessDto: LoginAccessDto = {
+        email: user.email,
+        password: hashedPassword,
+        tfa: '',
+        keys: { kyber: { ...keyServer.toJSON() } },
+      };
+
+      const folder = newFolder({ owner: user, attributes: { bucket: v4() } });
+
+      jest.spyOn(userRepository, 'findByUsername').mockResolvedValue(user);
+      jest.spyOn(cryptoService, 'decryptText').mockReturnValue(hashedPassword);
+      jest
+        .spyOn(userUseCases, 'getAuthTokens')
+        .mockReturnValue({ token: 'authToken', newToken: 'newAuthToken' });
+      jest.spyOn(userUseCases, 'updateByUuid').mockResolvedValue(undefined);
+      jest.spyOn(folderUseCases, 'getFolderById').mockResolvedValueOnce(folder);
+      jest
+        .spyOn(keyServerUseCases, 'findUserKeys')
+        .mockResolvedValue({ ecc: null, kyber: null });
+      jest
+        .spyOn(keyServerUseCases, 'findOrCreateKeysForUser')
+        .mockResolvedValue(keyServer);
+
+      const result = await userUseCases.loginAccess(loginAccessDto);
+
+      expect(keyServerUseCases.findOrCreateKeysForUser).toHaveBeenCalledTimes(
+        1,
+      );
+
+      expect(keyServerUseCases.findOrCreateKeysForUser).toHaveBeenCalledWith(
+        user.id,
+        {
+          publicKey: keyServer.publicKey,
+          privateKey: keyServer.privateKey,
+          revocationKey: keyServer.revocationKey,
+          encryptVersion: keyServer.encryptVersion,
+        },
+      );
+
+      expect(result.user).toHaveProperty('keys', {
+        ecc: {
+          privateKey: null,
+          publicKey: null,
+          revocationKey: null,
+        },
+        kyber: {
+          privateKey: keyServer.privateKey,
+          publicKey: keyServer.publicKey,
+        },
+      });
+    });
+
+    it('When user is missing one of the keys and both were sent, then it should save missing keys', async () => {
+      const hashedPassword = 'hashedPassword';
+      const user = newUser({
+        attributes: {
+          password: hashedPassword,
+          errorLoginCount: 0,
+          secret_2FA: null,
+        },
+      });
+      const eccKey = newKeyServer({
+        userId: user.id,
+      });
+      const kyberKey = newKeyServer({
+        userId: user.id,
+        encryptVersion: UserKeysEncryptVersions.Kyber,
+      });
+      const alreadyExistentEccKey = newKeyServer({
+        userId: user.id,
+      });
+      const loginAccessDto: LoginAccessDto = {
+        email: user.email,
+        password: hashedPassword,
+        tfa: '',
+        keys: { kyber: { ...kyberKey.toJSON() }, ecc: { ...eccKey.toJSON() } },
+      };
+
+      const folder = newFolder({ owner: user, attributes: { bucket: v4() } });
+
+      jest.spyOn(userRepository, 'findByUsername').mockResolvedValue(user);
+      jest.spyOn(cryptoService, 'decryptText').mockReturnValue(hashedPassword);
+      jest
+        .spyOn(userUseCases, 'getAuthTokens')
+        .mockReturnValue({ token: 'authToken', newToken: 'newAuthToken' });
+      jest.spyOn(userUseCases, 'updateByUuid').mockResolvedValue(undefined);
+      jest.spyOn(folderUseCases, 'getFolderById').mockResolvedValueOnce(folder);
+      jest
+        .spyOn(keyServerUseCases, 'findUserKeys')
+        .mockResolvedValue({ ecc: alreadyExistentEccKey, kyber: null });
+      jest
+        .spyOn(keyServerUseCases, 'findOrCreateKeysForUser')
+        .mockResolvedValue(kyberKey);
+
+      const result = await userUseCases.loginAccess(loginAccessDto);
+
+      expect(keyServerUseCases.findOrCreateKeysForUser).toHaveBeenCalledTimes(
+        1,
+      );
+
+      expect(keyServerUseCases.findOrCreateKeysForUser).toHaveBeenCalledWith(
+        user.id,
+        {
+          publicKey: kyberKey.publicKey,
+          privateKey: kyberKey.privateKey,
+          encryptVersion: kyberKey.encryptVersion,
+        },
+      );
+
+      expect(result.user).toHaveProperty('keys', {
+        ecc: {
+          privateKey: alreadyExistentEccKey.privateKey,
+          publicKey: alreadyExistentEccKey.publicKey,
+          revocationKey: alreadyExistentEccKey.revocationKey,
+        },
+        kyber: {
+          privateKey: kyberKey.privateKey,
+          publicKey: kyberKey.publicKey,
+        },
+      });
+    });
+  });
+
+  describe('updatePassword', () => {
+    const fixedSystemCurrentDate = new Date();
+
+    beforeAll(() => {
+      jest.useFakeTimers();
+      jest.setSystemTime(fixedSystemCurrentDate);
+    });
+
+    afterAll(() => {
+      jest.useRealTimers();
+    });
+
+    it('When user updates their password, then it should update password and privateKeys successfully', async () => {
+      const updatePasswordDto: UpdatePasswordDto = {
+        currentPassword: 'currentHashedPassword',
+        newPassword: 'newHashedPassword',
+        newSalt: 'newSalt',
+        mnemonic: 'mnemonic',
+        privateKey: 'encryptedPrivateKey',
+        encryptVersion: UserKeysEncryptVersions.Ecc,
+      };
+
+      await userUseCases.updatePassword(user, updatePasswordDto);
+
+      jest.spyOn(userRepository, 'updateById');
+
+      expect(userRepository.updateById).toHaveBeenCalledWith(user.id, {
+        password: updatePasswordDto.newPassword,
+        hKey: Buffer.from(updatePasswordDto.newSalt),
+        mnemonic: updatePasswordDto.mnemonic,
+        lastPasswordChangedAt: fixedSystemCurrentDate,
+      });
+
+      expect(
+        keyServerUseCases.updateByUserAndEncryptVersion,
+      ).toHaveBeenCalledWith(user.id, UserKeysEncryptVersions.Ecc, {
+        privateKey: updatePasswordDto.privateKey,
+      });
+    });
+
+    it('When user updates their password along with new kyber keys, then it should update successfully', async () => {
+      const newKeys = {
+        ecc: { privateKey: 'privateEccKey' },
+        kyber: { privateKey: 'privateKyberKey' },
+      };
+
+      const updatePasswordDto: UpdatePasswordDto = {
+        currentPassword: 'currentHashedPassword',
+        newPassword: 'newHashedPassword',
+        newSalt: 'newSalt',
+        mnemonic: 'mnemonic',
+        privateKey: 'encryptedPrivateKey',
+        encryptVersion: UserKeysEncryptVersions.Ecc,
+        keys: newKeys,
+      };
+
+      await userUseCases.updatePassword(user, updatePasswordDto);
+
+      expect(userRepository.updateById).toHaveBeenCalledWith(user.id, {
+        password: updatePasswordDto.newPassword,
+        hKey: Buffer.from(updatePasswordDto.newSalt),
+        mnemonic: updatePasswordDto.mnemonic,
+        lastPasswordChangedAt: fixedSystemCurrentDate,
+      });
+
+      expect(
+        keyServerUseCases.updateByUserAndEncryptVersion,
+      ).toHaveBeenCalledWith(user.id, UserKeysEncryptVersions.Ecc, {
+        privateKey: newKeys.ecc.privateKey,
+      });
+      expect(
+        keyServerUseCases.updateByUserAndEncryptVersion,
+      ).toHaveBeenCalledWith(user.id, UserKeysEncryptVersions.Kyber, {
+        privateKey: newKeys.kyber.privateKey,
+      });
     });
   });
 

--- a/src/modules/user/user.usecase.ts
+++ b/src/modules/user/user.usecase.ts
@@ -104,13 +104,6 @@ export class UserAlreadyRegisteredError extends Error {
   }
 }
 
-export class KeyServerNotFoundError extends Error {
-  constructor() {
-    super('Key server not found');
-
-    Object.setPrototypeOf(this, KeyServerNotFoundError.prototype);
-  }
-}
 export class UserNotFoundError extends Error {
   constructor() {
     super('User not found');

--- a/test/fixtures.spec.ts
+++ b/test/fixtures.spec.ts
@@ -10,6 +10,7 @@ import {
 } from '../src/modules/workspaces/attributes/workspace-items-users.attributes';
 import * as fixtures from './fixtures';
 import { SharingActionName } from '../src/modules/sharing/sharing.domain';
+import { UserKeysEncryptVersions } from '../src/modules/keyserver/key-server.domain';
 
 describe('Testing fixtures tests', () => {
   describe("User's fixture", () => {
@@ -580,6 +581,57 @@ describe('Testing fixtures tests', () => {
       const role = fixtures.newRole(customName);
 
       expect(role.name).toBe(customName);
+    });
+  });
+
+  describe('KeyServer fixture', () => {
+    it('When it generates a KeyServer, then the attributes should be random', () => {
+      const keyServer1 = fixtures.newKeyServer();
+      const keyServer2 = fixtures.newKeyServer();
+
+      expect(keyServer1.publicKey).not.toBe(keyServer2.publicKey);
+      expect(keyServer1.privateKey).not.toBe(keyServer2.privateKey);
+    });
+
+    it('When it generates a KeyServer with ECC encryption, then the revocationKey should be present', () => {
+      const keyServer = fixtures.newKeyServer({
+        encryptVersion: UserKeysEncryptVersions.Ecc,
+      });
+
+      expect(keyServer.revocationKey).toBeTruthy();
+    });
+
+    it('When it generates a KeyServer with Kyber encryption, then the revocationKey should be undefined', () => {
+      const keyServer = fixtures.newKeyServer({
+        encryptVersion: UserKeysEncryptVersions.Kyber,
+      });
+
+      expect(keyServer.revocationKey).toBeUndefined();
+    });
+
+    it('When it generates a KeyServer with custom attributes, then those attributes should be set', () => {
+      const customAttributes = {
+        id: 123,
+        userId: 456,
+        publicKey: 'customPublicKey',
+        privateKey: 'customPrivateKey',
+        revocationKey: 'customRevocationKey',
+        encryptVersion: UserKeysEncryptVersions.Ecc,
+      };
+      const keyServer = fixtures.newKeyServer(customAttributes);
+
+      expect(keyServer.id).toBe(customAttributes.id);
+      expect(keyServer.userId).toBe(customAttributes.userId);
+      expect(keyServer.publicKey).toBe(customAttributes.publicKey);
+      expect(keyServer.privateKey).toBe(customAttributes.privateKey);
+      expect(keyServer.revocationKey).toBe(customAttributes.revocationKey);
+      expect(keyServer.encryptVersion).toBe(customAttributes.encryptVersion);
+    });
+
+    it('When it generates a KeyServer, then the default encryption version should be ECC', () => {
+      const keyServer = fixtures.newKeyServer();
+
+      expect(keyServer.encryptVersion).toBe(UserKeysEncryptVersions.Ecc);
     });
   });
 });

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -34,6 +34,11 @@ import { WorkspaceItemUser } from '../src/modules/workspaces/domains/workspace-i
 import { PreCreatedUser } from '../src/modules/user/pre-created-user.domain';
 import { UserNotificationTokens } from '../src/modules/user/user-notification-tokens.domain';
 import { UserNotificationTokenAttributes } from '../src/modules/user/user-notification-tokens.attribute';
+import {
+  KeyServer,
+  KeyServerAttributes,
+  UserKeysEncryptVersions,
+} from '../src/modules/keyserver/key-server.domain';
 
 export const constants = {
   BUCKET_ID_LENGTH: 24,
@@ -220,7 +225,7 @@ export const newPreCreatedUser = (): PreCreatedUser => {
     publicKey: '',
     privateKey: '',
     revocationKey: '',
-    encryptVersion: '03-aes',
+    encryptVersion: UserKeysEncryptVersions.Ecc,
   });
 };
 
@@ -539,4 +544,25 @@ export const newNotificationToken = (
       token[key] = params.attributes[key];
     });
   return token;
+};
+
+export const newKeyServer = (
+  params?: Partial<KeyServerAttributes>,
+): KeyServer => {
+  const defaultAttributes: KeyServerAttributes = {
+    id: randomDataGenerator.natural({ min: 1 }),
+    userId: randomDataGenerator.natural({ min: 1 }),
+    publicKey: randomDataGenerator.string({ length: 64 }),
+    privateKey: randomDataGenerator.string({ length: 64 }),
+    revocationKey: randomDataGenerator.string({ length: 64 }),
+    encryptVersion: UserKeysEncryptVersions.Ecc,
+  };
+
+  const attributes: KeyServerAttributes = { ...defaultAttributes, ...params };
+
+  if (attributes.encryptVersion !== UserKeysEncryptVersions.Ecc) {
+    attributes.revocationKey = undefined;
+  }
+
+  return KeyServer.build(attributes);
 };


### PR DESCRIPTION
This reverts commit adcd1d014c5cdc51fc24159151333cce624a9f7f, reversing changes made to aa9f82d97dc3aa013667c24bd10d8c72986056b6.

Adds again the multi key support. 

New changes besides the revert:

1. Kyber keys object enforced validation has been removed temporarily
2. Keys nested validation is not enforced temporarily
3. Added temporarily validation on the controllers 
4. Update password now fails if user has kyber keys and the client does not send any kyber key.
5. Increased public_key and private_key fields length on the database

TODO comments mark the parts we need to reverse when the frontend aligns with the backend expected object.

For extra information you can check https://github.com/internxt/drive-server-wip/pull/450, which is the PR we intend to merge again.