### PR TITLE
[PB-3625] feat: add kyber keys support to update password

### DIFF
--- a/src/modules/auth/auth.controller.spec.ts
+++ b/src/modules/auth/auth.controller.spec.ts
@@ -1,4 +1,4 @@
-import { newUser } from './../../../test/fixtures';
+import { newKeyServer, newUser } from './../../../test/fixtures';
 import { AuthController } from './auth.controller';
 import { UserUseCases } from '../user/user.usecase';
 import { KeyServerUseCases } from '../keyserver/key-server.usecase';
@@ -12,7 +12,6 @@ import {
   NotFoundException,
   UnauthorizedException,
 } from '@nestjs/common';
-import { KeyServer } from '../keyserver/key-server.domain';
 import { DeepMocked, createMock } from '@golevelup/ts-jest';
 import { v4 } from 'uuid';
 import { TwoFactorAuthService } from './two-factor-auth.service';
@@ -54,17 +53,12 @@ describe('AuthController', () => {
       user.hKey = 'hKey';
       user.secret_2FA = 'secret_2FA';
 
-      const keys: Omit<
-        KeyServer,
-        'id' | 'userId' | 'encryptVersion' | 'toJSON'
-      > = {
-        publicKey: 'publicKey',
-        privateKey: 'privateKey',
-        revocationKey: 'revocationKey',
-      };
+      const keys = newKeyServer({ userId: user.id });
 
       jest.spyOn(userUseCases, 'findByEmail').mockResolvedValueOnce(user);
-      jest.spyOn(keyServerUseCases, 'findUserKeys').mockResolvedValueOnce(keys);
+      jest
+        .spyOn(keyServerUseCases, 'findUserKeys')
+        .mockResolvedValueOnce({ ecc: keys, kyber: null });
       jest.spyOn(cryptoService, 'encryptText').mockReturnValue('encryptedText');
 
       const res = {

--- a/src/modules/auth/auth.controller.ts
+++ b/src/modules/auth/auth.controller.ts
@@ -77,7 +77,7 @@ export class AuthController {
       );
       const keys = await this.keyServerUseCases.findUserKeys(user.id);
 
-      return { hasKeys: !!keys, sKey: encryptedSalt, tfa: required2FA };
+      return { hasKeys: !!keys.ecc, sKey: encryptedSalt, tfa: required2FA };
     } catch (err) {
       if (!(err instanceof HttpException)) {
         Logger.error(

--- a/src/modules/auth/decorators/client.decorator.ts
+++ b/src/modules/auth/decorators/client.decorator.ts
@@ -2,5 +2,7 @@ import { createParamDecorator, ExecutionContext } from '@nestjs/common';
 
 export const Client = createParamDecorator((_, ctx: ExecutionContext) => {
   const req = ctx.switchToHttp().getRequest();
-  return String(req.headers['internxt-client-id']);
+  return String(
+    req.headers['internxt-client-id'] || req.headers['internxt-client'],
+  );
 });

--- a/src/modules/keyserver/key-server.domain.spec.ts
+++ b/src/modules/keyserver/key-server.domain.spec.ts
@@ -1,0 +1,81 @@
+import {
+  KeyServer,
+  KeyServerAttributes,
+  UserKeysEncryptVersions,
+} from './key-server.domain';
+
+describe('KeyServer Domain', () => {
+  it('When ECC keys are validated, then it should validate successfully', () => {
+    const eccKeyData = {
+      id: 1,
+      userId: 101,
+      publicKey: 'eccPublicKey',
+      privateKey: 'eccPrivateKey',
+      revocationKey: 'eccRevocationKey',
+      encryptVersion: UserKeysEncryptVersions.Ecc,
+    };
+
+    const isValid = KeyServer.validate(eccKeyData.encryptVersion, eccKeyData);
+
+    expect(isValid).toEqual(true);
+  });
+
+  it('When Kyber keys are validated, then it should validate successfully', () => {
+    const kyberKeyData = {
+      id: 2,
+      userId: 102,
+      publicKey: 'kyberPublicKey',
+      privateKey: 'kyberPrivateKey',
+      encryptVersion: UserKeysEncryptVersions.Kyber,
+    };
+
+    const isValid = KeyServer.validate(
+      kyberKeyData.encryptVersion,
+      kyberKeyData,
+    );
+
+    expect(isValid).toEqual(true);
+  });
+
+  it('When Ecc keys have required fields missing, then it should throw', () => {
+    const invalidEccKeyData = {
+      id: 3,
+      userId: 103,
+      encryptVersion: UserKeysEncryptVersions.Ecc,
+    };
+
+    expect(() => {
+      KeyServer.validate(
+        invalidEccKeyData.encryptVersion,
+        invalidEccKeyData as KeyServerAttributes,
+      );
+    }).toThrow();
+  });
+
+  it('When Kyber keys have missing required fields, then it should throw', () => {
+    const kyberKeyData = {
+      id: 5,
+      userId: 105,
+      privateKey: 'kyberPrivateKey',
+      encryptVersion: UserKeysEncryptVersions.Kyber,
+    };
+
+    expect(() => {
+      KeyServer.validate(kyberKeyData.encryptVersion, kyberKeyData);
+    }).toThrow();
+  });
+
+  it('When unsupported encryption version is used, then it should throw', () => {
+    const unsupportedKeyData = {
+      id: 4,
+      userId: 104,
+      publicKey: 'unsupportedPublicKey',
+      privateKey: 'unsupportedPrivateKey',
+      encryptVersion: 'unsupported' as UserKeysEncryptVersions,
+    };
+
+    expect(() => {
+      KeyServer.validate(unsupportedKeyData.encryptVersion, unsupportedKeyData);
+    }).toThrow();
+  });
+});

--- a/src/modules/keyserver/key-server.domain.ts
+++ b/src/modules/keyserver/key-server.domain.ts
@@ -1,13 +1,18 @@
+export enum UserKeysEncryptVersions {
+  Ecc = 'ecc',
+  Kyber = 'kyber',
+}
+
 export interface Keys {
   publicKey: string;
   privateKey: string;
-  revocationKey: string;
+  revocationKey?: string;
 }
 
 export interface KeyServerAttributes extends Keys {
   id: number;
   userId: number;
-  encryptVersion: string;
+  encryptVersion: UserKeysEncryptVersions;
 }
 
 export class KeyServer implements KeyServerAttributes {
@@ -15,8 +20,8 @@ export class KeyServer implements KeyServerAttributes {
   userId: number;
   publicKey: string;
   privateKey: string;
-  revocationKey: string;
-  encryptVersion: string;
+  revocationKey?: string;
+  encryptVersion: UserKeysEncryptVersions;
 
   constructor({
     id,
@@ -40,12 +45,39 @@ export class KeyServer implements KeyServerAttributes {
 
   toJSON() {
     return {
-      id: this.id,
-      userId: this.userId,
       publicKey: this.publicKey,
       privateKey: this.privateKey,
       revocationKey: this.revocationKey,
-      encryptVersion: this.encryptVersion,
     };
+  }
+
+  validate() {
+    return KeyServer.validate(this.encryptVersion, this);
+  }
+
+  static validate(
+    encryptVersion: UserKeysEncryptVersions,
+    keyData: Partial<Keys>,
+  ) {
+    const requiredFields = {
+      [UserKeysEncryptVersions.Kyber]: ['publicKey', 'privateKey'],
+      [UserKeysEncryptVersions.Ecc]: ['publicKey', 'privateKey'],
+    };
+
+    const required = requiredFields[encryptVersion];
+
+    if (!required) {
+      throw new Error(`Unsupported encryption version: ${encryptVersion}`);
+    }
+
+    for (const field of required) {
+      if (!keyData[field]) {
+        throw new Error(
+          `${field} is required for encryption version ${encryptVersion}.`,
+        );
+      }
+    }
+
+    return true;
   }
 }

--- a/src/modules/keyserver/key-server.model.ts
+++ b/src/modules/keyserver/key-server.model.ts
@@ -7,7 +7,10 @@ import {
   PrimaryKey,
   Table,
 } from 'sequelize-typescript';
-import { KeyServerAttributes } from './key-server.domain';
+import {
+  UserKeysEncryptVersions,
+  KeyServerAttributes,
+} from './key-server.domain';
 import { UserModel } from '../user/user.model';
 
 @Table({
@@ -25,15 +28,15 @@ export class KeyServerModel extends Model implements KeyServerAttributes {
   @Column(DataType.INTEGER)
   userId: number;
 
-  @Column(DataType.STRING(920))
+  @Column(DataType.STRING(2000))
   publicKey: string;
 
-  @Column(DataType.STRING(1356))
+  @Column(DataType.STRING(3200))
   privateKey: string;
 
   @Column(DataType.STRING(476))
   revocationKey: string;
 
   @Column(DataType.STRING)
-  encryptVersion: string;
+  encryptVersion: UserKeysEncryptVersions;
 }

--- a/src/modules/keyserver/key-server.repository.ts
+++ b/src/modules/keyserver/key-server.repository.ts
@@ -4,39 +4,38 @@ import { UserAttributes } from '../user/user.attributes';
 import { KeyServer, KeyServerAttributes } from './key-server.domain';
 import { KeyServerModel } from './key-server.model';
 
-interface KeyServerRepository {
-  findUserKeysOrCreate(
-    userId: UserAttributes['id'],
-    data: Partial<KeyServerAttributes>,
-  ): Promise<[KeyServer | null, boolean]>;
-  findUserKeys(userId: UserAttributes['id']): Promise<KeyServer>;
-  findPublicKey(
-    userId: UserAttributes['id'],
-  ): Promise<KeyServerAttributes['publicKey']>;
-  deleteByUserId(userId: UserAttributes['id']): Promise<void>;
-}
-
 @Injectable()
-export class SequelizeKeyServerRepository implements KeyServerRepository {
+export class SequelizeKeyServerRepository {
   constructor(
     @InjectModel(KeyServerModel)
     private model: typeof KeyServerModel,
   ) {}
 
-  findUserKeysOrCreate(
+  async findUserKeysOrCreate(
     userId: UserAttributes['id'],
     data: Partial<KeyServerAttributes>,
   ): Promise<[KeyServer | null, boolean]> {
-    return this.model.findOrCreate({
-      where: { userId },
+    const optionalWhere = {};
+
+    if (data.encryptVersion) {
+      optionalWhere['encryptVersion'] = data.encryptVersion;
+    }
+
+    const [userKeys, wasCreated] = await this.model.findOrCreate({
+      where: { userId, ...optionalWhere },
       defaults: data,
     });
+
+    return userKeys
+      ? [this.toDomain(userKeys), wasCreated]
+      : [null, wasCreated];
   }
 
-  findUserKeys(userId: UserAttributes['id']): Promise<KeyServer> {
-    return this.model.findOne({
+  async findUserKeys(userId: UserAttributes['id']): Promise<KeyServer[]> {
+    const userKeys = await this.model.findAll({
       where: { userId },
     });
+    return userKeys ? userKeys.map(this.toDomain.bind(this)) : null;
   }
 
   async update(
@@ -46,18 +45,29 @@ export class SequelizeKeyServerRepository implements KeyServerRepository {
     await this.model.update(data, { where: { userId } });
   }
 
-  async findPublicKey(
+  async updateByUserAndEncryptVersion(
     userId: UserAttributes['id'],
-  ): Promise<KeyServerAttributes['publicKey']> {
-    const keyServer = await this.model.findOne({ where: { userId } });
-    return keyServer.publicKey;
+    encryptVersion: KeyServerAttributes['encryptVersion'],
+    data: Partial<KeyServerAttributes>,
+  ): Promise<void> {
+    await this.model.update(data, {
+      where: { userId, encryptVersion },
+    });
   }
 
   async deleteByUserId(userId: UserAttributes['id']): Promise<void> {
     await this.model.destroy({ where: { userId } });
   }
 
-  create(userId: UserAttributes['id'], data: Partial<KeyServerAttributes>) {
-    return this.model.create({ userId, ...data });
+  async create(
+    userId: UserAttributes['id'],
+    data: Partial<KeyServerAttributes>,
+  ) {
+    const newUserKeys = await this.model.create({ userId, ...data });
+    return newUserKeys ? this.toDomain(newUserKeys) : null;
+  }
+
+  toDomain(keyServer: KeyServerModel): KeyServer {
+    return KeyServer.build(keyServer.toJSON());
   }
 }

--- a/src/modules/keyserver/key-server.usecase.spec.ts
+++ b/src/modules/keyserver/key-server.usecase.spec.ts
@@ -1,7 +1,10 @@
 import { createMock, DeepMocked } from '@golevelup/ts-jest';
-import { Keys, KeyServer } from './key-server.domain';
+import { Keys, KeyServer, UserKeysEncryptVersions } from './key-server.domain';
 import { SequelizeKeyServerRepository } from './key-server.repository';
-import { KeyServerUseCases } from './key-server.usecase';
+import {
+  InvalidKeyServerException,
+  KeyServerUseCases,
+} from './key-server.usecase';
 
 describe('Key Server Use Cases', () => {
   let service: KeyServerUseCases;
@@ -34,14 +37,14 @@ describe('Key Server Use Cases', () => {
         id: 430,
         userId,
         ...keys,
-        encryptVersion: '',
+        encryptVersion: UserKeysEncryptVersions.Ecc,
       });
 
       jest
         .spyOn(keyServerRepository, 'findUserKeysOrCreate')
         .mockResolvedValue([keyServer, true]);
 
-      await service.addKeysToUser(userId, keys);
+      await service.addKeysToUser(userId, { ecc: keys });
 
       expect(keyServerRepository.findUserKeysOrCreate).toHaveBeenCalledTimes(1);
       expect(keyServerRepository.findUserKeysOrCreate).toHaveBeenCalledWith(
@@ -58,8 +61,6 @@ describe('Key Server Use Cases', () => {
       {
         privateKey:
           'gMWcRQZTAnrLMlFgAfGyukRICiLBKFqndsuEzMKuJuPlHlhbyVxPDxuWeZpI',
-        publicKey:
-          'lSWpfeTYwKqrMmfmTgqjQmInalzEDSrMRCNOOVOsrTuGWlbfMTThJHEBPmcV',
       },
       {
         privateKey:
@@ -84,7 +85,7 @@ describe('Key Server Use Cases', () => {
 
         const keys = incompleteKeySet as Keys;
 
-        await service.addKeysToUser(userId, keys);
+        await service.addKeysToUser(userId, { ecc: keys });
 
         expect(keyServerRepository.findUserKeysOrCreate).toHaveBeenCalledTimes(
           0,
@@ -93,29 +94,153 @@ describe('Key Server Use Cases', () => {
     );
   });
 
-  describe('getPublicKey', () => {
-    it('When a public key is found, then it should return the public key', async () => {
-      const userId = 123;
-      const mockPublicKey = 'mockPublicKey';
+  describe('findOrCreateKeysForUser', () => {
+    const userId = 234059;
 
-      jest
-        .spyOn(keyServerRepository, 'findPublicKey')
-        .mockResolvedValue(mockPublicKey);
+    it('When invalid ecc keys are provided, it should throw', async () => {
+      const invalidEccKeys = {
+        privateKey:
+          'gMWcRQZTAnrLMlFgAfGyukRICiLBKFqndsuEzMKuJuPlHlhbyVxPDxuWeZpI',
+        encryptVersion: UserKeysEncryptVersions.Ecc,
+      };
 
-      const result = await service.getPublicKey(userId);
-
-      expect(result).toEqual(mockPublicKey);
-      expect(keyServerRepository.findPublicKey).toHaveBeenCalledWith(userId);
+      await expect(
+        service.findOrCreateKeysForUser(userId, invalidEccKeys),
+      ).rejects.toThrow(InvalidKeyServerException);
     });
 
-    it('When no public key is found, then it should return undefined', async () => {
-      const userId = 123;
-      jest
-        .spyOn(keyServerRepository, 'findPublicKey')
-        .mockResolvedValue(undefined);
+    it('When invalid kyber keys are provided, it should throw', async () => {
+      const invalidKyberKeys = {
+        privateKey:
+          'gMWcRQZTAnrLMlFgAfGyukRICiLBKFqndsuEzMKuJuPlHlhbyVxPDxuWeZpI',
+        encryptVersion: UserKeysEncryptVersions.Kyber,
+      };
 
-      await service.getPublicKey(userId);
-      expect(keyServerRepository.findPublicKey).toHaveBeenCalledWith(userId);
+      await expect(
+        service.findOrCreateKeysForUser(userId, invalidKyberKeys),
+      ).rejects.toThrow(InvalidKeyServerException);
+    });
+
+    it('When valid keys are provided, then it should create them', async () => {
+      const validEccKey = {
+        privateKey:
+          'gMWcRQZTAnrLMlFgAfGyukRICiLBKFqndsuEzMKuJuPlHlhbyVxPDxuWeZpI',
+        publicKey:
+          'lSWpfeTYwKqrMmfmTgqjQmInalzEDSrMRCNOOVOsrTuGWlbfMTThJHEBPmcV',
+        revocationKey:
+          'WtPCEiOBbBTKIcOsePFyUCwCbfFmuoJsZKHnuKnjMbvWSPJxOdDFtaNRvwCB',
+        encryptVersion: UserKeysEncryptVersions.Ecc,
+      };
+
+      const keyServer = new KeyServer({
+        id: 430,
+        userId,
+        ...validEccKey,
+      });
+
+      jest
+        .spyOn(keyServerRepository, 'findUserKeysOrCreate')
+        .mockResolvedValue([keyServer, true]);
+
+      await service.findOrCreateKeysForUser(userId, validEccKey);
+
+      expect(keyServerRepository.findUserKeysOrCreate).toHaveBeenCalledTimes(1);
+      expect(keyServerRepository.findUserKeysOrCreate).toHaveBeenCalledWith(
+        userId,
+        {
+          userId,
+          ...validEccKey,
+        },
+      );
+    });
+  });
+
+  describe('updateByUserAndEncryptVersion', () => {
+    const userId = 234059;
+
+    it('When keys need to be update, then it should update them accordingly', async () => {
+      const validEccKey = {
+        privateKey:
+          'gMWcRQZTAnrLMlFgAfGyukRICiLBKFqndsuEzMKuJuPlHlhbyVxPDxuWeZpI',
+        publicKey:
+          'lSWpfeTYwKqrMmfmTgqjQmInalzEDSrMRCNOOVOsrTuGWlbfMTThJHEBPmcV',
+        revocationKey:
+          'WtPCEiOBbBTKIcOsePFyUCwCbfFmuoJsZKHnuKnjMbvWSPJxOdDFtaNRvwCB',
+      };
+
+      await expect(
+        service.updateByUserAndEncryptVersion(
+          userId,
+          UserKeysEncryptVersions.Ecc,
+          validEccKey,
+        ),
+      ).resolves.toBeUndefined();
+    });
+  });
+
+  describe('getPublicKeys', () => {
+    const userId = 234059;
+    const KeysData = {
+      privateKey:
+        'gMWcRQZTAnrLMlFgAfGyukRICiLBKFqndsuEzMKuJuPlHlhbyVxPDxuWeZpI',
+      publicKey: 'lSWpfeTYwKqrMmfmTgqjQmInalzEDSrMRCNOOVOsrTuGWlbfMTThJHEBPmcV',
+      revocationKey:
+        'WtPCEiOBbBTKIcOsePFyUCwCbfFmuoJsZKHnuKnjMbvWSPJxOdDFtaNRvwCB',
+    };
+
+    it('When user public keys are retrieved, it should return them successfully', async () => {
+      const eccKey = new KeyServer({
+        id: 430,
+        userId,
+        ...KeysData,
+        encryptVersion: UserKeysEncryptVersions.Ecc,
+      });
+
+      const kyberKey = new KeyServer({
+        id: 431,
+        userId,
+        ...KeysData,
+        encryptVersion: UserKeysEncryptVersions.Kyber,
+      });
+
+      jest
+        .spyOn(keyServerRepository, 'findUserKeys')
+        .mockResolvedValue([eccKey, kyberKey]);
+
+      const userKeys = await service.getPublicKeys(userId);
+
+      expect(userKeys).toEqual({
+        kyber: kyberKey.publicKey,
+        ecc: eccKey.publicKey,
+      });
+    });
+
+    it('When user public keys are retrieved there are keys missing, it should them as empty', async () => {
+      const eccKey = new KeyServer({
+        id: 430,
+        userId,
+        ...KeysData,
+        encryptVersion: UserKeysEncryptVersions.Ecc,
+      });
+
+      jest
+        .spyOn(keyServerRepository, 'findUserKeys')
+        .mockResolvedValueOnce([eccKey]);
+
+      jest.spyOn(keyServerRepository, 'findUserKeys').mockResolvedValueOnce([]);
+
+      const userKeys = await service.getPublicKeys(userId);
+      const noKeys = await service.getPublicKeys(userId);
+
+      expect(userKeys).toEqual({
+        kyber: null,
+        ecc: eccKey.publicKey,
+      });
+
+      expect(noKeys).toEqual({
+        kyber: null,
+        ecc: null,
+      });
     });
   });
 
@@ -132,20 +257,27 @@ describe('Key Server Use Cases', () => {
           'WtPCEiOBbBTKIcOsePFyUCwCbfFmuoJsZKHnuKnjMbvWSPJxOdDFtaNRvwCB',
       };
 
-      const keyServer = new KeyServer({
+      const ecc = new KeyServer({
         id: 430,
         userId,
         ...keys,
-        encryptVersion: '',
+        encryptVersion: UserKeysEncryptVersions.Ecc,
+      });
+
+      const kyber = new KeyServer({
+        id: 431,
+        userId,
+        ...keys,
+        encryptVersion: UserKeysEncryptVersions.Kyber,
       });
 
       jest
         .spyOn(keyServerRepository, 'findUserKeys')
-        .mockResolvedValue(keyServer);
+        .mockResolvedValue([ecc, kyber]);
 
       const result = await service.findUserKeys(userId);
 
-      expect(result).toEqual(keys);
+      expect(result).toEqual({ kyber, ecc });
       expect(keyServerRepository.findUserKeys).toHaveBeenCalledWith(userId);
     });
   });

--- a/src/modules/keyserver/key-server.usecase.spec.ts
+++ b/src/modules/keyserver/key-server.usecase.spec.ts
@@ -5,6 +5,7 @@ import {
   InvalidKeyServerException,
   KeyServerUseCases,
 } from './key-server.usecase';
+import { BadRequestException } from '@nestjs/common';
 
 describe('Key Server Use Cases', () => {
   let service: KeyServerUseCases;
@@ -97,7 +98,7 @@ describe('Key Server Use Cases', () => {
   describe('findOrCreateKeysForUser', () => {
     const userId = 234059;
 
-    it('When invalid ecc keys are provided, it should throw', async () => {
+    it('When there are missing ecc keys, it should throw', async () => {
       const invalidEccKeys = {
         privateKey:
           'gMWcRQZTAnrLMlFgAfGyukRICiLBKFqndsuEzMKuJuPlHlhbyVxPDxuWeZpI',
@@ -109,7 +110,7 @@ describe('Key Server Use Cases', () => {
       ).rejects.toThrow(InvalidKeyServerException);
     });
 
-    it('When invalid kyber keys are provided, it should throw', async () => {
+    it('When there are missing kyber keys, it should throw', async () => {
       const invalidKyberKeys = {
         privateKey:
           'gMWcRQZTAnrLMlFgAfGyukRICiLBKFqndsuEzMKuJuPlHlhbyVxPDxuWeZpI',
@@ -188,7 +189,7 @@ describe('Key Server Use Cases', () => {
         'WtPCEiOBbBTKIcOsePFyUCwCbfFmuoJsZKHnuKnjMbvWSPJxOdDFtaNRvwCB',
     };
 
-    it('When user public keys are retrieved, it should return them successfully', async () => {
+    it('When the user public keys are retrieved, it should return them successfully', async () => {
       const eccKey = new KeyServer({
         id: 430,
         userId,
@@ -215,7 +216,7 @@ describe('Key Server Use Cases', () => {
       });
     });
 
-    it('When user public keys are retrieved there are keys missing, it should them as empty', async () => {
+    it('When the user public keys are retrieved but they are missing, then it returns null values', async () => {
       const eccKey = new KeyServer({
         id: 430,
         userId,

--- a/src/modules/keyserver/key-server.usecase.ts
+++ b/src/modules/keyserver/key-server.usecase.ts
@@ -1,46 +1,137 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 import { UserAttributes } from '../user/user.attributes';
-import { Keys } from './key-server.domain';
+import {
+  KeyServer,
+  KeyServerAttributes,
+  UserKeysEncryptVersions,
+} from './key-server.domain';
 import { SequelizeKeyServerRepository } from './key-server.repository';
+
+export class InvalidKeyServerException extends Error {
+  constructor(public validationMessage: string) {
+    super(validationMessage);
+    Object.setPrototypeOf(this, InvalidKeyServerException.prototype);
+  }
+}
+
+type PartialKeys = Partial<Omit<KeyServerAttributes, 'id' | 'userId'>>;
 
 @Injectable()
 export class KeyServerUseCases {
   constructor(private repository: SequelizeKeyServerRepository) {}
 
-  async addKeysToUser(userId: UserAttributes['id'], keys: Keys): Promise<Keys> {
-    if (!keys.privateKey || !keys.publicKey || !keys.revocationKey) {
-      return;
-    }
+  async addKeysToUser(
+    userId: UserAttributes['id'],
+    keys: {
+      kyber?: Omit<PartialKeys, 'encryptVersion'>;
+      ecc?: Omit<PartialKeys, 'encryptVersion'>;
+    },
+  ): Promise<{ kyber: KeyServer | null; ecc: KeyServer | null }> {
+    const processKey = async (
+      encryptVersion: UserKeysEncryptVersions,
+      keyData?: Omit<PartialKeys, 'encryptVersion'>,
+    ): Promise<KeyServer | null> => {
+      if (!keyData) return null;
 
-    const [{ publicKey, privateKey, revocationKey }] =
-      await this.repository.findUserKeysOrCreate(userId, {
-        userId,
-        publicKey: keys.publicKey,
-        privateKey: keys.privateKey,
-        revocationKey: keys.revocationKey,
-        encryptVersion: 'ecc',
-      });
+      try {
+        return await this.findOrCreateKeysForUser(userId, {
+          publicKey: keyData.publicKey,
+          privateKey: keyData.privateKey,
+          revocationKey: keyData.revocationKey,
+          encryptVersion,
+        });
+      } catch (error) {
+        Logger.error(
+          `[KEYS/ADD_KEYS_TO_USER]: Error adding ${encryptVersion} key to user ${userId}, error: ${JSON.stringify(
+            error,
+          )}`,
+        );
+        return null;
+      }
+    };
 
-    return { publicKey, privateKey, revocationKey };
+    const [kyberKey, eccKey] = await Promise.all([
+      processKey(UserKeysEncryptVersions.Kyber, keys.kyber),
+      processKey(UserKeysEncryptVersions.Ecc, keys.ecc),
+    ]);
+
+    return { kyber: kyberKey, ecc: eccKey };
   }
 
-  async getPublicKey(userId: UserAttributes['id']): Promise<string> {
-    const publicKey = await this.repository.findPublicKey(userId);
-
-    return publicKey;
-  }
-
-  async findUserKeys(userId: UserAttributes['id']): Promise<Keys | null> {
-    const keys = await this.repository.findUserKeys(userId);
-
-    if (!keys) {
-      return null;
+  async findOrCreateKeysForUser(
+    userId: UserAttributes['id'],
+    keys: PartialKeys,
+  ): Promise<KeyServer> {
+    try {
+      KeyServer.validate(keys.encryptVersion, keys);
+    } catch (error) {
+      throw new InvalidKeyServerException(error.message);
     }
 
-    return {
+    const [createdKeys] = await this.repository.findUserKeysOrCreate(userId, {
+      userId,
       publicKey: keys.publicKey,
       privateKey: keys.privateKey,
       revocationKey: keys.revocationKey,
+      encryptVersion: keys.encryptVersion,
+    });
+
+    return createdKeys;
+  }
+
+  async updateByUserAndEncryptVersion(
+    userId: UserAttributes['id'],
+    encryptVersion: KeyServerAttributes['encryptVersion'],
+    data: Partial<Omit<KeyServerAttributes, 'id'>>,
+  ): Promise<void> {
+    await this.repository.updateByUserAndEncryptVersion(
+      userId,
+      encryptVersion,
+      data,
+    );
+  }
+
+  async getPublicKeys(userId: UserAttributes['id']): Promise<{
+    kyber: string | null;
+    ecc: string | null;
+  }> {
+    const userKeys = await this.repository.findUserKeys(userId);
+
+    const eccKeys = this.findKeyByEncryptionMethod(
+      userKeys,
+      UserKeysEncryptVersions.Ecc,
+    );
+
+    const kyberKeys = this.findKeyByEncryptionMethod(
+      userKeys,
+      UserKeysEncryptVersions.Kyber,
+    );
+
+    return {
+      kyber: kyberKeys?.publicKey || null,
+      ecc: eccKeys?.publicKey || null,
     };
+  }
+
+  async findUserKeys(
+    userId: UserAttributes['id'],
+  ): Promise<{ kyber: KeyServer | null; ecc: KeyServer | null }> {
+    const keys = await this.repository.findUserKeys(userId);
+
+    const kyber = keys.find(
+      (key) => key.encryptVersion === UserKeysEncryptVersions.Kyber,
+    );
+    const ecc = keys.find(
+      (key) => key.encryptVersion === UserKeysEncryptVersions.Ecc,
+    );
+
+    return { kyber, ecc };
+  }
+
+  private findKeyByEncryptionMethod(
+    userKeys: KeyServer[],
+    version: UserKeysEncryptVersions,
+  ): KeyServer | null {
+    return userKeys.find((key) => key.encryptVersion === version) || null;
   }
 }

--- a/src/modules/keyserver/key-server.usecase.ts
+++ b/src/modules/keyserver/key-server.usecase.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { BadRequestException, Injectable, Logger } from '@nestjs/common';
 import { UserAttributes } from '../user/user.attributes';
 import {
   KeyServer,
@@ -7,7 +7,7 @@ import {
 } from './key-server.domain';
 import { SequelizeKeyServerRepository } from './key-server.repository';
 
-export class InvalidKeyServerException extends Error {
+export class InvalidKeyServerException extends BadRequestException {
   constructor(public validationMessage: string) {
     super(validationMessage);
     Object.setPrototypeOf(this, InvalidKeyServerException.prototype);

--- a/src/modules/user/dto/update-password.dto.ts
+++ b/src/modules/user/dto/update-password.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsString } from 'class-validator';
+import { IsOptional, IsString, MaxLength } from 'class-validator';
 
 export class UpdatePasswordDto {
   @IsString()
@@ -31,16 +31,28 @@ export class UpdatePasswordDto {
   mnemonic: string;
 
   @IsString()
+  @MaxLength(3200)
   @ApiProperty({
-    example: 'newPrivateKey',
-    description: 'New private key',
+    example: 'encryptedPrivateKey',
+    description: 'Ecc private key encrypted with new password',
   })
   privateKey: string;
 
+  @IsOptional()
+  @IsString()
+  @MaxLength(3200)
+  @ApiProperty({
+    example: 'encryptedPrivateKey',
+    description: 'Kyber private key encrypted with new password',
+  })
+  privateKyberKey?: string;
+
+  @IsOptional()
   @IsString()
   @ApiProperty({
     example: 'encryptVersion',
     description: 'Encrypt version',
+    deprecated: true,
   })
-  encryptVersion: string;
+  encryptVersion?: string;
 }

--- a/src/modules/user/pre-created-user.domain.ts
+++ b/src/modules/user/pre-created-user.domain.ts
@@ -1,3 +1,4 @@
+import { UserKeysEncryptVersions } from '../keyserver/key-server.domain';
 import { PreCreatedUserAttributes } from './pre-created-users.attributes';
 
 export class PreCreatedUser implements PreCreatedUserAttributes {
@@ -11,7 +12,7 @@ export class PreCreatedUser implements PreCreatedUserAttributes {
   publicKey: string;
   privateKey: string;
   revocationKey: string;
-  encryptVersion: string;
+  encryptVersion: UserKeysEncryptVersions;
   constructor({
     id,
     email,

--- a/src/modules/user/pre-created-users.model.ts
+++ b/src/modules/user/pre-created-users.model.ts
@@ -9,6 +9,7 @@ import {
   Unique,
 } from 'sequelize-typescript';
 import { PreCreatedUserAttributes } from './pre-created-users.attributes';
+import { KeyServerAttributes } from '../keyserver/key-server.domain';
 
 @Table({
   underscored: true,
@@ -45,7 +46,7 @@ export class PreCreatedUserModel
   revocationKey: string;
 
   @Column(DataType.STRING)
-  encryptVersion: string;
+  encryptVersion: KeyServerAttributes['encryptVersion'];
 
   @Column
   password: string;

--- a/src/modules/user/user.controller.spec.ts
+++ b/src/modules/user/user.controller.spec.ts
@@ -547,6 +547,9 @@ describe('User Controller', () => {
     });
 
     it('When all conditions are met, it updates the password and returns tokens', async () => {
+      const newPassword = 'newPassword';
+      const newSalt = 'newSalt';
+
       const kyberKey = newKeyServer({
         encryptVersion: UserKeysEncryptVersions.Kyber,
       });
@@ -555,8 +558,8 @@ describe('User Controller', () => {
       const mockTokens = { token: 'mockToken', newToken: 'mockNewToken' };
       cryptoService.decryptText
         .mockReturnValueOnce(mockUser.password) // currentPassword
-        .mockReturnValueOnce('decryptedNewPassword') // newPassword
-        .mockReturnValueOnce('decryptedNewSalt'); // newSalt
+        .mockReturnValueOnce(newPassword)
+        .mockReturnValueOnce(newSalt);
       keyServerUseCases.findUserKeys.mockResolvedValueOnce({
         kyber: kyberKey,
         ecc: eccKey,
@@ -571,8 +574,8 @@ describe('User Controller', () => {
 
       expect(userUseCases.updatePassword).toHaveBeenCalledWith(mockUser, {
         currentPassword: mockUser.password,
-        newPassword: 'decryptedNewPassword',
-        newSalt: 'decryptedNewSalt',
+        newPassword: newPassword,
+        newSalt: newSalt,
         mnemonic: mockUpdatePasswordDto.mnemonic,
         privateKey: mockUpdatePasswordDto.privateKey,
         encryptVersion: mockUpdatePasswordDto.encryptVersion,

--- a/src/modules/user/user.usecase.spec.ts
+++ b/src/modules/user/user.usecase.spec.ts
@@ -43,6 +43,7 @@ import {
   newNotificationToken,
   newFile,
   newFolder,
+  newKeyServer,
 } from '../../../test/fixtures';
 import { MailTypes } from '../security/mail-limit/mailTypes';
 import { SequelizeWorkspaceRepository } from '../workspaces/repositories/workspaces.repository';
@@ -55,11 +56,13 @@ import {
 import { UserNotificationTokens } from './user-notification-tokens.domain';
 import { v4 } from 'uuid';
 import { SequelizeKeyServerRepository } from '../keyserver/key-server.repository';
-import { KeyServerModel } from '../keyserver/key-server.model';
 import * as speakeasy from 'speakeasy';
 import { MailerService } from '../../externals/mailer/mailer.service';
 import { LoginAccessDto } from '../auth/dto/login-access.dto';
 import { UpdateProfileDto } from './dto/update-profile.dto';
+import { UpdatePasswordDto } from './dto/update-password.dto';
+import { UserKeysEncryptVersions } from '../keyserver/key-server.domain';
+import { KeyServerUseCases } from '../keyserver/key-server.usecase';
 
 jest.mock('../../middlewares/passport', () => {
   const originalModule = jest.requireActual('../../middlewares/passport');
@@ -88,6 +91,8 @@ describe('User use cases', () => {
   let workspaceRepository: SequelizeWorkspaceRepository;
   let mailerService: MailerService;
   let avatarService: AvatarService;
+  let keyServerUseCases: KeyServerUseCases;
+
   const loggerErrorSpy = jest.spyOn(Logger, 'error').mockImplementation();
 
   const user = User.build({
@@ -156,6 +161,8 @@ describe('User use cases', () => {
     );
     mailerService = moduleRef.get<MailerService>(MailerService);
     avatarService = moduleRef.get<AvatarService>(AvatarService);
+    keyServerUseCases = moduleRef.get<KeyServerUseCases>(KeyServerUseCases);
+
     jest.clearAllMocks();
   });
 
@@ -833,11 +840,7 @@ describe('User use cases', () => {
   });
 
   describe('loginAccess', () => {
-    const keys = {
-      publicKey: 'publicKey',
-      privateKey: 'privateKey',
-      revocateKey: 'revocateKey',
-    };
+    const keys = newKeyServer();
 
     it('When an email in uppercase is provided, then it should be transformed to lowercase', async () => {
       const loginAccessDto: LoginAccessDto = {
@@ -932,11 +935,11 @@ describe('User use cases', () => {
           secret_2FA: null,
         },
       });
-      const keyServer = {
+      const keyServer = newKeyServer({
         ...keys,
-        revocationKey: keys.revocateKey,
+        revocationKey: keys.revocationKey,
         userId: user.id,
-      } as unknown as KeyServerModel;
+      });
 
       const folder = newFolder({ owner: user, attributes: { bucket: v4() } });
 
@@ -1000,11 +1003,13 @@ describe('User use cases', () => {
           secret_2FA: 'secret',
         },
       });
-      const keyServer = {
+
+      const keyServer = newKeyServer({
         ...keys,
-        revocationKey: keys.revocateKey,
+        revocationKey: keys.revocationKey,
         userId: user.id,
-      } as unknown as KeyServerModel;
+      });
+
       const folder = newFolder({ owner: user, attributes: { bucket: v4() } });
 
       jest.spyOn(userRepository, 'findByUsername').mockResolvedValue(user);
@@ -1027,6 +1032,48 @@ describe('User use cases', () => {
       expect(result.user).toHaveProperty('bucket', folder.bucket);
       expect(result).toHaveProperty('token', 'authToken');
       expect(result).toHaveProperty('newToken', 'newAuthToken');
+    });
+
+    it('When user without keys logs and no key is saved, then it should return empty keys ', async () => {
+      const hashedPassword = 'hashedPassword';
+      const user = newUser({
+        attributes: {
+          password: hashedPassword,
+          errorLoginCount: 0,
+          secret_2FA: null,
+        },
+      });
+      const loginAccessDto: LoginAccessDto = {
+        email: user.email,
+        password: hashedPassword,
+        tfa: '',
+      };
+
+      const folder = newFolder({ owner: user, attributes: { bucket: v4() } });
+
+      jest.spyOn(userRepository, 'findByUsername').mockResolvedValue(user);
+      jest.spyOn(cryptoService, 'decryptText').mockReturnValue(hashedPassword);
+      jest
+        .spyOn(userUseCases, 'getAuthTokens')
+        .mockReturnValue({ token: 'authToken', newToken: 'newAuthToken' });
+      jest.spyOn(userUseCases, 'updateByUuid').mockResolvedValue(undefined);
+      jest.spyOn(folderUseCases, 'getFolderById').mockResolvedValueOnce(folder);
+      jest
+        .spyOn(keyServerUseCases, 'findUserKeys')
+        .mockResolvedValue({ ecc: null, kyber: null });
+
+      const result = await userUseCases.loginAccess(loginAccessDto);
+
+      expect(result.user).toHaveProperty('keys', {
+        ecc: {
+          privateKey: null,
+          publicKey: null,
+        },
+        kyber: {
+          privateKey: null,
+          publicKey: null,
+        },
+      });
     });
   });
 
@@ -1368,6 +1415,92 @@ describe('User use cases', () => {
         user.uuid,
         payload,
       );
+    });
+  });
+
+  describe('updatePassword', () => {
+    const userKeys = {
+      ecc: newKeyServer(),
+      kyber: newKeyServer({ encryptVersion: UserKeysEncryptVersions.Kyber }),
+    };
+
+    const updatePasswordDto: UpdatePasswordDto = {
+      currentPassword: 'currentHashedPassword',
+      newPassword: 'newHashedPassword',
+      newSalt: 'newSalt',
+      mnemonic: 'mnemonic',
+      privateKey: 'encryptedPrivateKey',
+      privateKyberKey: 'encryptedKyberPrivateKey',
+      encryptVersion: UserKeysEncryptVersions.Ecc,
+    };
+
+    const fixedSystemCurrentDate = new Date();
+
+    beforeAll(() => {
+      jest.useFakeTimers();
+      jest.setSystemTime(fixedSystemCurrentDate);
+    });
+
+    afterAll(() => {
+      jest.useRealTimers();
+    });
+
+    it('When user updates their password, then it should update password and privateKeys successfully', async () => {
+      jest
+        .spyOn(keyServerUseCases, 'findUserKeys')
+        .mockResolvedValueOnce(userKeys);
+
+      await userUseCases.updatePassword(user, updatePasswordDto);
+
+      expect(userRepository.updateById).toHaveBeenCalledWith(user.id, {
+        password: updatePasswordDto.newPassword,
+        hKey: Buffer.from(updatePasswordDto.newSalt),
+        mnemonic: updatePasswordDto.mnemonic,
+        lastPasswordChangedAt: fixedSystemCurrentDate,
+      });
+
+      expect(
+        keyServerUseCases.updateByUserAndEncryptVersion,
+      ).toHaveBeenCalledWith(user.id, UserKeysEncryptVersions.Ecc, {
+        privateKey: updatePasswordDto.privateKey,
+      });
+    });
+
+    it('When user with kyber keys tries to update their password but kyber key was not sent, then it should throw', async () => {
+      const updatePasswordDtoNoKyber = {
+        ...updatePasswordDto,
+        privateKyberKey: null,
+      };
+
+      jest
+        .spyOn(keyServerUseCases, 'findUserKeys')
+        .mockResolvedValueOnce(userKeys);
+
+      await expect(
+        userUseCases.updatePassword(user, updatePasswordDtoNoKyber),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('When user updates their password along with new kyber keys, then it should update successfully', async () => {
+      await userUseCases.updatePassword(user, updatePasswordDto);
+
+      expect(userRepository.updateById).toHaveBeenCalledWith(user.id, {
+        password: updatePasswordDto.newPassword,
+        hKey: Buffer.from(updatePasswordDto.newSalt),
+        mnemonic: updatePasswordDto.mnemonic,
+        lastPasswordChangedAt: fixedSystemCurrentDate,
+      });
+
+      expect(
+        keyServerUseCases.updateByUserAndEncryptVersion,
+      ).toHaveBeenCalledWith(user.id, UserKeysEncryptVersions.Ecc, {
+        privateKey: updatePasswordDto.privateKey,
+      });
+      expect(
+        keyServerUseCases.updateByUserAndEncryptVersion,
+      ).toHaveBeenCalledWith(user.id, UserKeysEncryptVersions.Kyber, {
+        privateKey: updatePasswordDto.privateKyberKey,
+      });
     });
   });
 });

--- a/src/modules/user/user.usecase.spec.ts
+++ b/src/modules/user/user.usecase.spec.ts
@@ -1034,7 +1034,7 @@ describe('User use cases', () => {
       expect(result).toHaveProperty('newToken', 'newAuthToken');
     });
 
-    it('When user without keys logs and no key is saved, then it should return empty keys ', async () => {
+    it('When user without keys logs in, then it should return empty keys', async () => {
       const hashedPassword = 'hashedPassword';
       const user = newUser({
         attributes: {

--- a/test/fixtures.spec.ts
+++ b/test/fixtures.spec.ts
@@ -10,6 +10,7 @@ import {
 } from '../src/modules/workspaces/attributes/workspace-items-users.attributes';
 import * as fixtures from './fixtures';
 import { SharingActionName } from '../src/modules/sharing/sharing.domain';
+import { UserKeysEncryptVersions } from '../src/modules/keyserver/key-server.domain';
 
 describe('Testing fixtures tests', () => {
   describe("User's fixture", () => {
@@ -580,6 +581,57 @@ describe('Testing fixtures tests', () => {
       const role = fixtures.newRole(customName);
 
       expect(role.name).toBe(customName);
+    });
+  });
+
+  describe('KeyServer fixture', () => {
+    it('When it generates a KeyServer, then the attributes should be random', () => {
+      const keyServer1 = fixtures.newKeyServer();
+      const keyServer2 = fixtures.newKeyServer();
+
+      expect(keyServer1.publicKey).not.toBe(keyServer2.publicKey);
+      expect(keyServer1.privateKey).not.toBe(keyServer2.privateKey);
+    });
+
+    it('When it generates a KeyServer with ECC encryption, then the revocationKey should be present', () => {
+      const keyServer = fixtures.newKeyServer({
+        encryptVersion: UserKeysEncryptVersions.Ecc,
+      });
+
+      expect(keyServer.revocationKey).toBeTruthy();
+    });
+
+    it('When it generates a KeyServer with Kyber encryption, then the revocationKey should be undefined', () => {
+      const keyServer = fixtures.newKeyServer({
+        encryptVersion: UserKeysEncryptVersions.Kyber,
+      });
+
+      expect(keyServer.revocationKey).toBeUndefined();
+    });
+
+    it('When it generates a KeyServer with custom attributes, then those attributes should be set', () => {
+      const customAttributes = {
+        id: 123,
+        userId: 456,
+        publicKey: 'customPublicKey',
+        privateKey: 'customPrivateKey',
+        revocationKey: 'customRevocationKey',
+        encryptVersion: UserKeysEncryptVersions.Ecc,
+      };
+      const keyServer = fixtures.newKeyServer(customAttributes);
+
+      expect(keyServer.id).toBe(customAttributes.id);
+      expect(keyServer.userId).toBe(customAttributes.userId);
+      expect(keyServer.publicKey).toBe(customAttributes.publicKey);
+      expect(keyServer.privateKey).toBe(customAttributes.privateKey);
+      expect(keyServer.revocationKey).toBe(customAttributes.revocationKey);
+      expect(keyServer.encryptVersion).toBe(customAttributes.encryptVersion);
+    });
+
+    it('When it generates a KeyServer, then the default encryption version should be ECC', () => {
+      const keyServer = fixtures.newKeyServer();
+
+      expect(keyServer.encryptVersion).toBe(UserKeysEncryptVersions.Ecc);
     });
   });
 });

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -34,6 +34,11 @@ import { WorkspaceItemUser } from '../src/modules/workspaces/domains/workspace-i
 import { PreCreatedUser } from '../src/modules/user/pre-created-user.domain';
 import { UserNotificationTokens } from '../src/modules/user/user-notification-tokens.domain';
 import { UserNotificationTokenAttributes } from '../src/modules/user/user-notification-tokens.attribute';
+import {
+  KeyServer,
+  KeyServerAttributes,
+  UserKeysEncryptVersions,
+} from '../src/modules/keyserver/key-server.domain';
 
 export const constants = {
   BUCKET_ID_LENGTH: 24,
@@ -220,7 +225,7 @@ export const newPreCreatedUser = (): PreCreatedUser => {
     publicKey: '',
     privateKey: '',
     revocationKey: '',
-    encryptVersion: '03-aes',
+    encryptVersion: UserKeysEncryptVersions.Ecc,
   });
 };
 
@@ -539,4 +544,25 @@ export const newNotificationToken = (
       token[key] = params.attributes[key];
     });
   return token;
+};
+
+export const newKeyServer = (
+  params?: Partial<KeyServerAttributes>,
+): KeyServer => {
+  const defaultAttributes: KeyServerAttributes = {
+    id: randomDataGenerator.natural({ min: 1 }),
+    userId: randomDataGenerator.natural({ min: 1 }),
+    publicKey: randomDataGenerator.string({ length: 64 }),
+    privateKey: randomDataGenerator.string({ length: 64 }),
+    revocationKey: randomDataGenerator.string({ length: 64 }),
+    encryptVersion: UserKeysEncryptVersions.Ecc,
+  };
+
+  const attributes: KeyServerAttributes = { ...defaultAttributes, ...params };
+
+  if (attributes.encryptVersion !== UserKeysEncryptVersions.Ecc) {
+    attributes.revocationKey = undefined;
+  }
+
+  return KeyServer.build(attributes);
 };


### PR DESCRIPTION
### Changes
- Added missing tests to affected endpoints to ensure backwards compatibility (we just want to check privateKey, publicKey and revocationKey are being returned as expected)

- **GET /public-key/:email**:
  - Continues sending `publicKey` field for backward compatibility.
  - new keys object containing kyber and ecc keys is returned.

- **Put /password/**:
  - Added privateKyberKey as optional body input.
  - If users have Kyber keys but a new encrypted Kyber key is not provided, the password update is prevented.
  - Removed the private key creation function from the logic. This function was a potential source of issues; in rare cases (e.g., when users without any keys tried to update their password), it could result in empty rows with only privateKeys being created.

- **Post /users/**:
  - Keys are currently created as ECC keys. Kyber support will be added to this endpoint in another PR.

- **POST /pre-created-users/register**:
  - Keys are currently created as ECC keys. Kyber support will be added to this endpoint in another PR.
