### PR TITLE
[PB-3625] chore: increase public and private keys size migration

### DIFF
--- a/migrations/20250128040758-increase-keyserver-public-and-private-keys-length.js
+++ b/migrations/20250128040758-increase-keyserver-public-and-private-keys-length.js
@@ -1,0 +1,22 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface) {
+    await queryInterface.changeColumn('keyserver', 'public_key', {
+      type: Sequelize.STRING(2000),
+    });
+    await queryInterface.changeColumn('keyserver', 'private_key', {
+      type: Sequelize.STRING(4000),
+    });
+  },
+
+  async down(queryInterface) {
+    await queryInterface.changeColumn('keyserver', 'public_key', {
+      type: Sequelize.STRING(1024),
+    });
+    await queryInterface.changeColumn('keyserver', 'private_key', {
+      type: Sequelize.STRING(2000),
+    });
+  },
+};


### PR DESCRIPTION
Kyber keys are significantly larger compared to ECC keys, necessitating an increase in the size of certain fields to accommodate them.

```
Encrypted kyber keys: 3032 characters
Public kyber key: 1068 characters.
```