### PR TITLE
[PB-3625] feat: added support for kyber keys on log in and user creation

### DIFF
--- a/src/modules/auth/auth.controller.spec.ts
+++ b/src/modules/auth/auth.controller.spec.ts
@@ -147,6 +147,44 @@ describe('AuthController', () => {
         Error,
       );
     });
+
+    it('When kyber and ecc keys are sent, then it should make the call with the respective keys', async () => {
+      const eccKey = newKeyServer();
+      const kyberKey = newKeyServer({
+        encryptVersion: UserKeysEncryptVersions.Kyber,
+      });
+
+      const inputWithKyberKeys = { ...loginAccessDto };
+      inputWithKyberKeys.keys = {
+        ecc: {
+          ...eccKey.toJSON(),
+        },
+        kyber: {
+          ...kyberKey.toJSON(),
+        },
+      };
+
+      jest.spyOn(keyServerUseCases, 'parseKeysInput').mockReturnValueOnce({
+        ecc: eccKey.toJSON(),
+        kyber: kyberKey.toJSON(),
+      });
+
+      jest.spyOn(userUseCases, 'loginAccess');
+
+      await authController.loginAccess(inputWithKyberKeys);
+
+      expect(userUseCases.loginAccess).toHaveBeenCalledWith({
+        ...inputWithKyberKeys,
+        keys: {
+          ecc: {
+            ...eccKey.toJSON(),
+          },
+          kyber: {
+            ...kyberKey.toJSON(),
+          },
+        },
+      });
+    });
   });
 
   describe('GET /logout', () => {

--- a/src/modules/auth/dto/login-access.dto.ts
+++ b/src/modules/auth/dto/login-access.dto.ts
@@ -1,5 +1,15 @@
-import { ApiProperty } from '@nestjs/swagger';
-import { IsEmail, IsNotEmpty, IsOptional, IsString } from 'class-validator';
+import { ApiProperty, PartialType } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import {
+  IsEmail,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  ValidateNested,
+} from 'class-validator';
+import { KeysDto } from '../../keyserver/dto/keys.dto';
+
+class OptionalKeyGroup extends PartialType(KeysDto) {}
 
 export class LoginAccessDto {
   @ApiProperty({
@@ -29,6 +39,7 @@ export class LoginAccessDto {
   @ApiProperty({
     example: 'public_key',
     description: 'Public Key',
+    deprecated: true,
   })
   @IsOptional()
   @IsString()
@@ -37,6 +48,7 @@ export class LoginAccessDto {
   @ApiProperty({
     example: 'private_key',
     description: 'Private Key',
+    deprecated: true,
   })
   @IsOptional()
   @IsString()
@@ -45,8 +57,18 @@ export class LoginAccessDto {
   @ApiProperty({
     example: 'revocate_key',
     description: 'Revocate Key',
+    deprecated: true,
   })
   @IsOptional()
   @IsString()
   revocateKey?: string;
+
+  @Type(() => OptionalKeyGroup)
+  @IsOptional()
+  @ValidateNested()
+  @ApiProperty({
+    example: 'newKeys',
+    description: 'keys',
+  })
+  keys?: OptionalKeyGroup;
 }

--- a/src/modules/keyserver/dto/keys.dto.ts
+++ b/src/modules/keyserver/dto/keys.dto.ts
@@ -1,0 +1,71 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import {
+  IsString,
+  IsNotEmpty,
+  ValidateNested,
+  IsOptional,
+} from 'class-validator';
+
+export class KyberKeysDto {
+  @IsString()
+  @IsNotEmpty()
+  @ApiProperty({
+    example: 'publicKeyExample',
+    description: 'Public key',
+  })
+  publicKey: string;
+
+  @IsString()
+  @IsNotEmpty()
+  @ApiProperty({
+    example: 'privateKeyExample',
+    description: 'Private key',
+  })
+  privateKey: string;
+}
+
+export class EccKeysDto {
+  @IsString()
+  @IsNotEmpty()
+  @ApiProperty({
+    example: 'publicKeyExample',
+    description: 'Public key',
+  })
+  publicKey: string;
+
+  @IsString()
+  @IsNotEmpty()
+  @ApiProperty({
+    example: 'privateKeyExample',
+    description: 'Private key',
+  })
+  privateKey: string;
+
+  @IsString()
+  @IsOptional()
+  @ApiProperty({
+    example: 'revocationKeyExample',
+    description: 'Revocation key',
+  })
+  revocationKey?: string;
+}
+
+export class KeysDto {
+  @Type(() => EccKeysDto)
+  @ValidateNested()
+  @ApiProperty({
+    type: EccKeysDto,
+    description: 'ECC keys',
+  })
+  ecc: EccKeysDto;
+
+  // TODO: uncomment validations when frontend stops sending kyber object as {privateKey: null, publicKey: null}
+  //@Type(() => KyberKeysDto)
+  //@ValidateNested()
+  @ApiProperty({
+    type: KyberKeysDto,
+    description: 'Kyber keys',
+  })
+  kyber: KyberKeysDto;
+}

--- a/src/modules/keyserver/key-server.usecase.spec.ts
+++ b/src/modules/keyserver/key-server.usecase.spec.ts
@@ -282,4 +282,102 @@ describe('Key Server Use Cases', () => {
       expect(keyServerRepository.findUserKeys).toHaveBeenCalledWith(userId);
     });
   });
+
+  describe('parseKeysInput', () => {
+    it('When both ecc and kyber keys are provided, then it should return the parsed keys', () => {
+      const inputKeys = {
+        ecc: {
+          publicKey: 'eccPublicKey',
+          privateKey: 'eccPrivateKey',
+          revocationKey: 'eccRevocationKey',
+        },
+        kyber: {
+          publicKey: 'kyberPublicKey',
+          privateKey: 'kyberPrivateKey',
+        },
+      };
+
+      const result = service.parseKeysInput(inputKeys);
+
+      expect(result).toEqual({
+        ecc: {
+          publicKey: 'eccPublicKey',
+          privateKey: 'eccPrivateKey',
+          revocationKey: 'eccRevocationKey',
+        },
+        kyber: {
+          publicKey: 'kyberPublicKey',
+          privateKey: 'kyberPrivateKey',
+        },
+      });
+    });
+
+    it('When only ecc keys are provided, then it should return only ecc keys with null kyber keys', () => {
+      const inputKeys = {
+        ecc: {
+          publicKey: 'eccPublicKey',
+          privateKey: 'eccPrivateKey',
+          revocationKey: 'eccRevocationKey',
+        },
+      };
+
+      const result = service.parseKeysInput(inputKeys);
+
+      expect(result).toEqual({
+        ecc: {
+          publicKey: 'eccPublicKey',
+          privateKey: 'eccPrivateKey',
+          revocationKey: 'eccRevocationKey',
+        },
+        kyber: null,
+      });
+    });
+
+    it('When only kyber keys are provided, then it should return only kyber keys with null ecc keys', () => {
+      const inputKeys = {
+        kyber: {
+          publicKey: 'kyberPublicKey',
+          privateKey: 'kyberPrivateKey',
+        },
+      };
+
+      const result = service.parseKeysInput(inputKeys);
+
+      expect(result).toEqual({
+        ecc: null,
+        kyber: {
+          publicKey: 'kyberPublicKey',
+          privateKey: 'kyberPrivateKey',
+        },
+      });
+    });
+
+    it('When no keys are provided, then it should return both ecc and kyber as null', () => {
+      const result = service.parseKeysInput({});
+
+      expect(result).toEqual({
+        ecc: null,
+        kyber: null,
+      });
+    });
+
+    it('When old keys are provided and new keys are missing, it should fall back to old keys', () => {
+      const oldKeys = {
+        publicKey: 'oldPublicKey',
+        privateKey: 'oldPrivateKey',
+        revocationKey: 'oldRevocationKey',
+      };
+
+      const result = service.parseKeysInput({}, oldKeys);
+
+      expect(result).toEqual({
+        ecc: {
+          publicKey: 'oldPublicKey',
+          privateKey: 'oldPrivateKey',
+          revocationKey: 'oldRevocationKey',
+        },
+        kyber: null,
+      });
+    });
+  });
 });

--- a/src/modules/keyserver/key-server.usecase.ts
+++ b/src/modules/keyserver/key-server.usecase.ts
@@ -6,6 +6,7 @@ import {
   UserKeysEncryptVersions,
 } from './key-server.domain';
 import { SequelizeKeyServerRepository } from './key-server.repository';
+import { EccKeysDto, KyberKeysDto } from './dto/keys.dto';
 
 export class InvalidKeyServerException extends BadRequestException {
   constructor(public validationMessage: string) {
@@ -133,5 +134,39 @@ export class KeyServerUseCases {
     version: UserKeysEncryptVersions,
   ): KeyServer | null {
     return userKeys.find((key) => key.encryptVersion === version) || null;
+  }
+
+  parseKeysInput(
+    keys: {
+      kyber?: PartialKeys;
+      ecc?: PartialKeys;
+    },
+    oldKeys?: {
+      privateKey: string;
+      publicKey: string;
+      revocationKey: string;
+    },
+  ): {
+    ecc: EccKeysDto;
+    kyber: KyberKeysDto;
+  } {
+    const eccKeys =
+      keys?.ecc || (oldKeys?.publicKey && oldKeys?.privateKey)
+        ? {
+            publicKey: keys?.ecc?.publicKey || oldKeys?.publicKey,
+            privateKey: keys?.ecc?.privateKey || oldKeys?.privateKey,
+            revocationKey: keys?.ecc?.revocationKey || oldKeys?.revocationKey,
+          }
+        : null;
+
+    const kyberKeys =
+      keys?.kyber?.publicKey && keys?.kyber?.privateKey
+        ? {
+            publicKey: keys.kyber.publicKey,
+            privateKey: keys.kyber.privateKey,
+          }
+        : null;
+
+    return { ecc: eccKeys, kyber: kyberKeys };
   }
 }

--- a/src/modules/user/dto/create-user.dto.ts
+++ b/src/modules/user/dto/create-user.dto.ts
@@ -1,6 +1,28 @@
-import { IsNotEmpty, IsOptional } from 'class-validator';
+import { IsNotEmpty, IsOptional, ValidateNested } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
 import { UserAttributes } from '../user.attributes';
+import { Type } from 'class-transformer';
+import { EccKeysDto, KyberKeysDto } from '../../keyserver/dto/keys.dto';
+
+class KeysDto {
+  @Type(() => EccKeysDto)
+  @IsOptional()
+  @ValidateNested()
+  @ApiProperty({
+    type: EccKeysDto,
+    description: 'ECC keys',
+  })
+  ecc: EccKeysDto;
+
+  @Type(() => KyberKeysDto)
+  @IsOptional()
+  @ValidateNested()
+  @ApiProperty({
+    type: KyberKeysDto,
+    description: 'Kyber keys',
+  })
+  kyber?: KyberKeysDto;
+}
 
 export class CreateUserDto {
   @IsNotEmpty()
@@ -50,34 +72,47 @@ export class CreateUserDto {
   @ApiProperty({
     example: '',
     description: '',
+    deprecated: true,
   })
-  privateKey: string;
+  privateKey?: string;
+
+  @IsOptional()
+  @ApiProperty({
+    example: '',
+    description: '',
+    deprecated: true,
+  })
+  publicKey?: string;
+
+  @IsOptional()
+  @ApiProperty({
+    example: '',
+    description: '',
+    deprecated: true,
+  })
+  revocationKey?: string;
 
   @IsOptional()
   @ApiProperty({
     example: '',
     description: '',
   })
-  publicKey: string;
+  referrer?: UserAttributes['referrer'];
 
   @IsOptional()
   @ApiProperty({
     example: '',
     description: '',
   })
-  revocationKey: string;
+  registerCompleted?: UserAttributes['registerCompleted'];
 
+  @Type(() => KeysDto)
   @IsOptional()
+  @ValidateNested()
   @ApiProperty({
-    example: '',
-    description: '',
+    type: KeysDto,
+    description:
+      'Keys, if provided, will update the user keys. This object replaces the need for privateKey and encryptVersion.',
   })
-  referrer: UserAttributes['referrer'];
-
-  @IsOptional()
-  @ApiProperty({
-    example: '',
-    description: '',
-  })
-  registerCompleted: UserAttributes['registerCompleted'];
+  keys?: KeysDto;
 }


### PR DESCRIPTION
### Updated Endpoints

- **POST /login**:
  - Returns `hasKyberKeys` and `hasEccKeys` flags instead of a single `hasKeys` flag.
  - Allows differentiation between the presence of Kyber and ECC keys.

- **POST /login/access**:
  - Accepts keys via the `keys` object (`KeysDto`) or the legacy fields for ECC encryption (for backwards compatibility)
  - If both are provided, the keys inside the `keys` object take priority.
  - Returns ECC keys in the legacy structure and includes the `keys` object containing both ECC and Kyber keys.

- **POST /users**:
  - Now supports receiving keys via the `keys` object (`KeysDto`).
  - Enables submission of both ECC and Kyber keys during user creation.
  
- **POST /pre-created-users/register**:
  - Now supports receiving keys via the `keys` object (`KeysDto`).
  - Allows submission of both ECC and Kyber keys during the registration of pre-created users.