### PR TITLE
[_] chore: fixed view details migration for local environments

### DIFF
--- a/migrations/20250128142106-add-view-details-to-permissions.js
+++ b/migrations/20250128142106-add-view-details-to-permissions.js
@@ -28,8 +28,10 @@ module.exports = {
 
       return permission;
     });
-
-    await queryInterface.bulkInsert('permissions', permissions);
+    // Sequelize / DB fails if we pass empty array to inserts. Local environments do not have type column
+    if (permissions.length > 0) {
+      await queryInterface.bulkInsert('permissions', permissions);
+    }
   },
 
   async down(queryInterface, Sequelize) {


### PR DESCRIPTION
This migration was adapted due to an extra column in our prod environment. This just fixes an error we were getting when this migration runs on local environment.