### PR TITLE
[_] fix: invited editor users are now able to share inside shared folders

### DIFF
--- a/src/common/extract-data-from-request.ts
+++ b/src/common/extract-data-from-request.ts
@@ -28,7 +28,7 @@ export const extractDataFromRequest = (
     context.getHandler(),
   );
 
-  const { dataSources } = metadataOptions;
+  const { dataSources = [] } = metadataOptions || {};
 
   const extractedData = {};
 

--- a/src/modules/sharing/guards/sharing-permissions.guard.ts
+++ b/src/modules/sharing/guards/sharing-permissions.guard.ts
@@ -66,14 +66,12 @@ export class SharingPermissionsGuard implements CanActivate {
       throw new ForbiddenException('Invalid token');
     }
 
-    const extractData = this.getSharedDataFromRequest(request, context);
-    const isSharedWithMe = decoded.sharedWithUserUuid === requester.uuid;
-    const isRootToken = decoded.isSharedItem && isSharedWithMe;
+    const isRootToken = decoded.isSharedItem;
 
     let userIsAllowedToPerfomAction = false;
 
     const sharedItemId = isRootToken
-      ? extractData.itemUuid
+      ? this.getSharedDataFromRequest(request, context)?.itemUuid
       : decoded.sharedRootFolderId;
     const workspaceId = decoded.workspace?.workspaceId || decoded.workspaceId;
 


### PR DESCRIPTION
### Update
The destructuring of `dataSources` has been modified so that if `metadataOptions` is `undefined`, it is initialized to an empty array. This prevents the error and ensures that the code works correctly even if no data is provided.

The `SharingPermissionsGuard` will call the function `extractDataFromRequest` so it is important to fix this bug.