### PR TITLE
[PB-3686] fix: folders with trashed parent can now be moved

### DIFF
--- a/src/modules/folder/folder.usecase.spec.ts
+++ b/src/modules/folder/folder.usecase.spec.ts
@@ -592,7 +592,7 @@ describe('FolderUseCases', () => {
 
       jest.spyOn(folderRepository, 'findOne').mockResolvedValueOnce(folder);
       jest
-        .spyOn(folderRepository, 'findById')
+        .spyOn(folderRepository, 'findOne')
         .mockResolvedValueOnce(mockParentFolder);
       jest
         .spyOn(folderRepository, 'findByUuid')
@@ -666,7 +666,7 @@ describe('FolderUseCases', () => {
 
       jest.spyOn(folderRepository, 'findOne').mockResolvedValueOnce(folder);
       jest
-        .spyOn(folderRepository, 'findById')
+        .spyOn(folderRepository, 'findOne')
         .mockResolvedValueOnce(mockParentFolder);
 
       await expect(
@@ -684,7 +684,7 @@ describe('FolderUseCases', () => {
 
       jest.spyOn(folderRepository, 'findOne').mockResolvedValueOnce(folder);
       jest
-        .spyOn(folderRepository, 'findById')
+        .spyOn(folderRepository, 'findOne')
         .mockResolvedValueOnce(mockParentFolder);
       jest
         .spyOn(folderRepository, 'findByUuid')
@@ -718,6 +718,7 @@ describe('FolderUseCases', () => {
       ).rejects.toThrow(NotFoundException);
 
       jest.spyOn(folderRepository, 'findOne').mockResolvedValueOnce(folder);
+      jest.spyOn(folderRepository, 'findOne').mockResolvedValueOnce(null);
       jest.spyOn(folderRepository, 'findByUuid').mockResolvedValueOnce(null);
       await expect(
         service.moveFolder(userMocked, folder.uuid, destinationFolder.uuid),
@@ -725,7 +726,14 @@ describe('FolderUseCases', () => {
     });
 
     it('When folder is moved to a folder that has been already moved to, then it should throw a conflict error', async () => {
+      const mockParentFolder = newFolder({
+        attributes: { userId: userMocked.id },
+      });
+
       jest.spyOn(folderRepository, 'findOne').mockResolvedValueOnce(folder);
+      jest
+        .spyOn(folderRepository, 'findOne')
+        .mockResolvedValueOnce(mockParentFolder);
       jest
         .spyOn(folderRepository, 'findByUuid')
         .mockResolvedValueOnce(destinationFolder);
@@ -745,6 +753,10 @@ describe('FolderUseCases', () => {
     });
 
     it('When folder is moved to a folder that has already a folder with the same name, then it should throw a conflict error', async () => {
+      const mockParentFolder = newFolder({
+        attributes: { userId: userMocked.id },
+      });
+
       const conflictFolder = newFolder({
         attributes: {
           ...folder,
@@ -752,6 +764,10 @@ describe('FolderUseCases', () => {
         },
       });
       jest.spyOn(folderRepository, 'findOne').mockResolvedValueOnce(folder);
+      jest
+        .spyOn(folderRepository, 'findOne')
+        .mockResolvedValueOnce(mockParentFolder);
+
       jest
         .spyOn(folderRepository, 'findByUuid')
         .mockResolvedValueOnce(destinationFolder);

--- a/src/modules/folder/folder.usecase.ts
+++ b/src/modules/folder/folder.usecase.ts
@@ -799,14 +799,18 @@ export class FolderUseCases {
       );
     }
 
-    const parentFolder = await this.folderRepository.findById(folder.parentId);
-    if (parentFolder.removed === true) {
+    const parentFolder = await this.folderRepository.findOne({
+      id: folder.parentId,
+    });
+
+    if (parentFolder?.isRemoved()) {
       throw new UnprocessableEntityException(
         `Folder ${folderUuid} can not be moved`,
       );
     }
 
     const destinationFolder = await this.getFolderByUuid(destinationUuid, user);
+
     if (destinationFolder.removed === true) {
       throw new UnprocessableEntityException(
         `Folder can not be moved to ${destinationUuid}`,


### PR DESCRIPTION
Endpoint fails when you try to move a trashed children folder from a trashed folder to another folder. The parent folder was being searched using `findById`, but this function searches implicitly for folders with `deleted = true`, so parent folder was not found, causing this unexpected error. 

We need to prevent movements from deleted folders, not from trashed ones.

**Changes**
1. Parent folder is searched using `findOne` without any implicit logic behind.

**How to reproduce it:**

1. Create a parent folder
2. Create a children folder
3. Trash the children folder
4. Trash the parent folder
5. Try to restore the children folder -> internal server error
