### PR TITLE
[PB-3868] fix: trashed folders metadata can now be updated

### DIFF
--- a/src/modules/folder/folder.usecase.spec.ts
+++ b/src/modules/folder/folder.usecase.spec.ts
@@ -1104,6 +1104,27 @@ describe('FolderUseCases', () => {
       ).rejects.toThrow(ForbiddenException);
     });
 
+    it('When the folder is removed, then it should throw', async () => {
+      const mockFolder = newFolder({ attributes: { removed: true } });
+      jest.spyOn(folderRepository, 'findOne').mockResolvedValueOnce(mockFolder);
+
+      await expect(
+        service.updateFolderMetaData(
+          userMocked,
+          mockFolder.uuid,
+          newFolderMetadata,
+        ),
+      ).rejects.toThrow(UnprocessableEntityException);
+    });
+
+    it('When the folder is not found, then it should throw', async () => {
+      jest.spyOn(folderRepository, 'findOne').mockResolvedValueOnce(null);
+
+      await expect(
+        service.updateFolderMetaData(userMocked, v4(), newFolderMetadata),
+      ).rejects.toThrow(NotFoundException);
+    });
+
     it('When a folder with the same name already exists in the same location, then it should throw', async () => {
       const mockFolder = newFolder({ owner: userMocked });
       const folderWithSameName = newFolder({

--- a/src/modules/folder/folder.usecase.ts
+++ b/src/modules/folder/folder.usecase.ts
@@ -337,9 +337,17 @@ export class FolderUseCases {
   ) {
     const folder = await this.folderRepository.findOne({
       uuid: folderUuid,
-      deleted: false,
-      removed: false,
     });
+
+    if (!folder) {
+      throw new NotFoundException('Folder not found');
+    }
+
+    if (folder.isRemoved()) {
+      throw new UnprocessableEntityException(
+        'Cannot update this folder metadata',
+      );
+    }
 
     if (!folder.isOwnedBy(user)) {
       throw new ForbiddenException('This folder is not yours');


### PR DESCRIPTION
When we want to move a folder into another folder that already contains a folder with the same name the folder were trying to move, we rename the current folder and move it. 

When the folder we are moving is trashed and we try to restore it, we do the same thing, we first change the folder's name to move it. However, this was throwing internal server error.