### PR TITLE
[_] feat: added check user storage stackability endpoint to gateway

### DIFF
--- a/src/lib/convert-size-to-bytes.spec.ts
+++ b/src/lib/convert-size-to-bytes.spec.ts
@@ -26,28 +26,18 @@ describe('convertSizeToBytes function', () => {
     expect(result).toBe(1 * 1024 ** 4);
   });
 
-  it('When the value is negative, then it should throw an error with a message "Value cannot be negative."', () => {
+  it('When the value is negative, then it should throw an error', () => {
     expect(() => convertSizeToBytes(-1, 'MB')).toThrow(
       'Value cannot be negative.',
     );
   });
 
-  it('When the value is NaN, then it should throw an error with a message "Value must be a valid number."', () => {
-    expect(() => convertSizeToBytes(NaN, 'GB')).toThrow(
-      'Value must be a valid number.',
-    );
+  it('When the unit is invalid, then it should throw an error', () => {
+    expect(() => convertSizeToBytes(1, 'XZ' as any)).toThrow();
   });
 
-  it('When the unit is invalid, then it should throw an error with a message "Invalid unit. Use B, KB, MB, GB, TB, or PB."', () => {
-    expect(() => convertSizeToBytes(1, 'XZ' as any)).toThrow(
-      'Invalid unit. Use B, KB, MB, GB, TB, or PB.',
-    );
-  });
-
-  it('When no unit is provided, then it should throw an error with a message "Unit is required."', () => {
-    expect(() => convertSizeToBytes(10, '' as any)).toThrow(
-      'Unit is required.',
-    );
+  it('When no unit is provided, then it should throw an error', () => {
+    expect(() => convertSizeToBytes(10, '' as any)).toThrow();
   });
 
   it('When converting to bytes with a valid unit, then it should return the correct result', () => {

--- a/src/lib/convert-size-to-bytes.spec.ts
+++ b/src/lib/convert-size-to-bytes.spec.ts
@@ -1,0 +1,62 @@
+import { convertSizeToBytes } from './convert-size-to-bytes';
+
+describe('convertSizeToBytes function', () => {
+  it('When converting bytes (B), then it should return the correct byte value', () => {
+    const result = convertSizeToBytes(5, 'B');
+    expect(result).toBe(5);
+  });
+
+  it('When converting kilobytes (KB), then it should return the correct byte value', () => {
+    const result = convertSizeToBytes(2, 'KB');
+    expect(result).toBe(2 * 1024);
+  });
+
+  it('When converting megabytes (MB), then it should return the correct byte value', () => {
+    const result = convertSizeToBytes(1, 'MB');
+    expect(result).toBe(1 * 1024 ** 2);
+  });
+
+  it('When converting gigabytes (GB), then it should return the correct byte value', () => {
+    const result = convertSizeToBytes(3, 'GB');
+    expect(result).toBe(3 * 1024 ** 3);
+  });
+
+  it('When converting terabytes (TB), then it should return the correct byte value', () => {
+    const result = convertSizeToBytes(1, 'TB');
+    expect(result).toBe(1 * 1024 ** 4);
+  });
+
+  it('When the value is negative, then it should throw an error with a message "Value cannot be negative."', () => {
+    expect(() => convertSizeToBytes(-1, 'MB')).toThrow(
+      'Value cannot be negative.',
+    );
+  });
+
+  it('When the value is NaN, then it should throw an error with a message "Value must be a valid number."', () => {
+    expect(() => convertSizeToBytes(NaN, 'GB')).toThrow(
+      'Value must be a valid number.',
+    );
+  });
+
+  it('When the unit is invalid, then it should throw an error with a message "Invalid unit. Use B, KB, MB, GB, TB, or PB."', () => {
+    expect(() => convertSizeToBytes(1, 'XZ' as any)).toThrow(
+      'Invalid unit. Use B, KB, MB, GB, TB, or PB.',
+    );
+  });
+
+  it('When no unit is provided, then it should throw an error with a message "Unit is required."', () => {
+    expect(() => convertSizeToBytes(10, '' as any)).toThrow(
+      'Unit is required.',
+    );
+  });
+
+  it('When converting to bytes with a valid unit, then it should return the correct result', () => {
+    const result = convertSizeToBytes(50, 'TB');
+    expect(result).toBe(50 * 1024 ** 4);
+  });
+
+  it('When converting megabytes (MB) to bytes with a large number, then it should return the correct byte value', () => {
+    const result = convertSizeToBytes(1_000_000, 'MB');
+    expect(result).toBe(1_000_000 * 1024 ** 2);
+  });
+});

--- a/src/lib/convert-size-to-bytes.ts
+++ b/src/lib/convert-size-to-bytes.ts
@@ -1,0 +1,21 @@
+type Unit = 'B' | 'KB' | 'MB' | 'GB' | 'TB';
+
+const units: Record<Unit, number> = {
+  B: 1,
+  KB: 1024,
+  MB: 1024 ** 2,
+  GB: 1024 ** 3,
+  TB: 1024 ** 4,
+};
+
+export function convertSizeToBytes(value: number, unit: Unit): number {
+  if (!units[unit]) {
+    throw new Error('Invalid unit. Use B, KB, MB, GB, TB, or PB.');
+  }
+
+  if (value < 0) {
+    throw new Error('Value cannot be negative.');
+  }
+
+  return value * units[unit];
+}

--- a/src/modules/gateway/dto/check-storage-expansion.dto.ts
+++ b/src/modules/gateway/dto/check-storage-expansion.dto.ts
@@ -1,0 +1,18 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNumber, IsUUID } from 'class-validator';
+
+export class CheckStorageExpansionDto {
+  @ApiProperty({
+    example: 'f9d113e3-8267-4419-a309-9b601f4f6f9b',
+    description: 'UUID of the user',
+  })
+  @IsUUID()
+  userUuid: string;
+
+  @ApiProperty({
+    example: 312321312,
+    description: 'Extra space in bytes to add to the user',
+  })
+  @IsNumber()
+  additionalBytes: number;
+}

--- a/src/modules/gateway/dto/check-storage-expansion.dto.ts
+++ b/src/modules/gateway/dto/check-storage-expansion.dto.ts
@@ -1,4 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
+import { Transform } from 'class-transformer';
 import { IsNumber, IsUUID } from 'class-validator';
 
 export class CheckStorageExpansionDto {
@@ -10,9 +11,13 @@ export class CheckStorageExpansionDto {
   userUuid: string;
 
   @ApiProperty({
-    example: 312321312,
-    description: 'Extra space in bytes to add to the user',
+    example: 3298534883328,
+    description: 'Extra space to add to user in bytes',
+    required: false,
   })
   @IsNumber()
-  additionalBytes: number;
+  @Transform(({ value }) =>
+    typeof value === 'string' ? parseInt(value, 10) : value,
+  )
+  additionalBytes?: number;
 }

--- a/src/modules/gateway/gateway.controller.spec.ts
+++ b/src/modules/gateway/gateway.controller.spec.ts
@@ -176,4 +176,23 @@ describe('Gateway Controller', () => {
       expect(gatewayUsecases.getUserByEmail).toHaveBeenCalledWith(user.email);
     });
   });
+
+  describe('GET /users/storage/stackability', () => {
+    const user = newUser();
+
+    it('When called, it should call service with respective params', async () => {
+      const userUuid = user.uuid;
+      const additionalBytes = 10;
+
+      await gatewayController.checkUserStorageExpansion({
+        userUuid,
+        additionalBytes,
+      });
+
+      expect(gatewayUsecases.checkUserStorageExpansion).toHaveBeenCalledWith(
+        userUuid,
+        additionalBytes,
+      );
+    });
+  });
 });

--- a/src/modules/gateway/gateway.controller.ts
+++ b/src/modules/gateway/gateway.controller.ts
@@ -22,6 +22,7 @@ import { GatewayGuard } from '../auth/gateway.guard';
 import { UpdateWorkspaceStorageDto } from './dto/update-workspace-storage.dto';
 import { DeleteWorkspaceDto } from './dto/delete-workspace.dto';
 import { User } from '../user/user.domain';
+import { CheckStorageExpansionDto } from './dto/check-storage-expansion.dto';
 
 @ApiTags('Gateway')
 @Controller('gateway')
@@ -99,5 +100,21 @@ export class GatewayController {
   @UseGuards(GatewayGuard)
   async getUserByEmail(@Query('email') email: User['email']) {
     return this.gatewayUseCases.getUserByEmail(email);
+  }
+
+  @Get('/users/storage/stackability')
+  @ApiBearerAuth()
+  @ApiOperation({
+    summary: 'Check if user can expand storage space',
+  })
+  @ApiQuery({ name: 'email', type: String, required: true })
+  @UseGuards(GatewayGuard)
+  async checkUserStorageExpansion(@Query() queryDto: CheckStorageExpansionDto) {
+    const { userUuid, additionalBytes } = queryDto;
+
+    return this.gatewayUseCases.checkUserStorageExpansion(
+      userUuid,
+      additionalBytes,
+    );
   }
 }

--- a/src/modules/gateway/gateway.controller.ts
+++ b/src/modules/gateway/gateway.controller.ts
@@ -107,7 +107,8 @@ export class GatewayController {
   @ApiOperation({
     summary: 'Check if user can expand storage space',
   })
-  @ApiQuery({ name: 'email', type: String, required: true })
+  @ApiQuery({ name: 'userUuid', type: String, required: true })
+  @ApiQuery({ name: 'additionalBytes', type: Number, required: true })
   @UseGuards(GatewayGuard)
   async checkUserStorageExpansion(@Query() queryDto: CheckStorageExpansionDto) {
     const { userUuid, additionalBytes } = queryDto;

--- a/src/modules/gateway/gateway.usecase.ts
+++ b/src/modules/gateway/gateway.usecase.ts
@@ -129,7 +129,14 @@ export class GatewayUseCases {
     return user;
   }
 
-  async checkUserStorageExpansion(uuid: string, additionalBytes?: number) {
+  async checkUserStorageExpansion(
+    uuid: string,
+    additionalBytes?: number,
+  ): Promise<{
+    canExpand: boolean;
+    currentMaxSpaceBytes: number;
+    expandableBytes: number;
+  }> {
     const user = await this.userRepository.findByUuid(uuid);
     if (!user) {
       throw new NotFoundException('User not found');

--- a/src/modules/gateway/gateway.usecase.ts
+++ b/src/modules/gateway/gateway.usecase.ts
@@ -8,12 +8,14 @@ import { InitializeWorkspaceDto } from './dto/initialize-workspace.dto';
 import { WorkspacesUsecases } from '../workspaces/workspaces.usecase';
 import { SequelizeUserRepository } from '../user/user.repository';
 import { User } from '../user/user.domain';
+import { UserUseCases } from '../user/user.usecase';
 
 @Injectable()
 export class GatewayUseCases {
   constructor(
     private readonly workspaceUseCases: WorkspacesUsecases,
     private readonly userRepository: SequelizeUserRepository,
+    private readonly userUseCases: UserUseCases,
   ) {}
 
   async initializeWorkspace(initializeWorkspaceDto: InitializeWorkspaceDto) {
@@ -125,5 +127,17 @@ export class GatewayUseCases {
       throw new NotFoundException('User not found');
     }
     return user;
+  }
+
+  async checkUserStorageExpansion(uuid: string, additionalBytes?: number) {
+    const user = await this.userRepository.findByUuid(uuid);
+    if (!user) {
+      throw new NotFoundException('User not found');
+    }
+    const userStorageData = await this.userUseCases.canUserExpandStorage(
+      user,
+      additionalBytes,
+    );
+    return userStorageData;
   }
 }

--- a/src/modules/user/user.usecase.ts
+++ b/src/modules/user/user.usecase.ts
@@ -724,7 +724,7 @@ export class UserUseCases {
     const expandableBytes = MAX_STORAGE_BYTES - currentMaxSpaceBytes;
 
     const canExpand =
-      currentMaxSpaceBytes + additionalBytes < MAX_STORAGE_BYTES;
+      currentMaxSpaceBytes + additionalBytes <= MAX_STORAGE_BYTES;
 
     return { canExpand, currentMaxSpaceBytes, expandableBytes };
   }

--- a/src/modules/user/user.usecase.ts
+++ b/src/modules/user/user.usecase.ts
@@ -713,6 +713,22 @@ export class UserUseCases {
     return hasSubscriptions || isLifetime;
   }
 
+  async canUserExpandStorage(user: User, additionalBytes = 0) {
+    const MAX_STORAGE_BYTES = 1024 ** 4 * 100; // 100 TB
+
+    const currentMaxSpaceBytes = await this.networkService.getLimit(
+      user.bridgeUser,
+      user.userId,
+    );
+
+    const expandableBytes = MAX_STORAGE_BYTES - currentMaxSpaceBytes;
+
+    const canExpand =
+      currentMaxSpaceBytes + additionalBytes < MAX_STORAGE_BYTES;
+
+    return { canExpand, currentMaxSpaceBytes, expandableBytes };
+  }
+
   async hasReferralsProgram(
     userEmail: UserAttributes['email'],
     networkUser: UserAttributes['bridgeUser'],

--- a/src/modules/user/user.usecase.ts
+++ b/src/modules/user/user.usecase.ts
@@ -81,6 +81,7 @@ import { KeyServerUseCases } from '../keyserver/key-server.usecase';
 import { UserKeysEncryptVersions } from '../keyserver/key-server.domain';
 import { AppSumoUseCase } from '../app-sumo/app-sumo.usecase';
 import { BackupUseCase } from '../backups/backup.usecase';
+import { convertSizeToBytes } from '../../lib/convert-size-to-bytes';
 
 export class ReferralsNotAvailableError extends Error {
   constructor() {
@@ -714,7 +715,7 @@ export class UserUseCases {
   }
 
   async canUserExpandStorage(user: User, additionalBytes = 0) {
-    const MAX_STORAGE_BYTES = 1024 ** 4 * 100; // 100 TB
+    const MAX_STORAGE_BYTES = convertSizeToBytes(100, 'TB');
 
     const currentMaxSpaceBytes = await this.networkService.getLimit(
       user.bridgeUser,


### PR DESCRIPTION
This PR implements a new endpoint in the gateway in order to check if the user can stack storage in case the user buys multiple products (e.g. lifetime products). This way, we can be sure that the user does not exceed the set per-user limit - 100TB.