### PR TITLE
[PB-4104] feat: Migrate limit and backup device endpoints

### DIFF
--- a/src/externals/crypto/crypto.service.ts
+++ b/src/externals/crypto/crypto.service.ts
@@ -29,7 +29,7 @@ export class CryptoService {
     return this.aesService.encrypt(text, buffer);
   }
 
-  encryptName(name: string, salt?: number) {
+  encryptName(name: string, salt?: number | string) {
     if (salt) {
       return this.aesService.encrypt(name, salt, salt === undefined);
     }
@@ -65,11 +65,11 @@ export class CryptoService {
     }
   }
 
-  decryptText(encryptedText: string, salt?: number) {
+  decryptText(encryptedText: string, salt?: number | string) {
     return this.decryptName(encryptedText, salt);
   }
 
-  encryptText(textToEncrypt: string, salt?: number) {
+  encryptText(textToEncrypt: string, salt?: number | string) {
     return this.encryptName(textToEncrypt, salt);
   }
 

--- a/src/modules/backups/backup.controller.spec.ts
+++ b/src/modules/backups/backup.controller.spec.ts
@@ -1,0 +1,128 @@
+import { newUser } from './../../../test/fixtures';
+import { Test, TestingModule } from '@nestjs/testing';
+import { createMock } from '@golevelup/ts-jest';
+import { BackupController } from './backup.controller';
+import { BackupUseCase } from './backup.usecase';
+import { NotFoundException, BadRequestException } from '@nestjs/common';
+
+describe('BackupController', () => {
+  let backupController: BackupController;
+  let backupUseCase: BackupUseCase;
+
+  const userMocked = newUser({
+    attributes: {
+      id: 1,
+      uuid: 'user-uuid',
+      email: 'test@example.com',
+      backupsBucket: 'bucket-id',
+    },
+  });
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [BackupController],
+      providers: [BackupUseCase],
+    })
+      .useMocker(() => createMock())
+      .compile();
+
+    backupController = module.get<BackupController>(BackupController);
+    backupUseCase = module.get<BackupUseCase>(BackupUseCase);
+  });
+
+  describe('activateBackup', () => {
+    it('When activateBackup is called, then it should return the backups bucket', async () => {
+      const mockResponse = { backupsBucket: 'bucket-id' };
+      jest.spyOn(backupUseCase, 'activate').mockResolvedValue(mockResponse);
+
+      const result = await backupController.activateBackup(userMocked);
+      expect(result).toEqual(mockResponse);
+    });
+  });
+
+  describe('createDeviceAsFolder', () => {
+    it('When createDeviceAsFolder is called, then it should return the created folder', async () => {
+      const mockResponse = { id: 1, name: 'Device Folder' };
+      jest
+        .spyOn(backupUseCase, 'createDeviceAsFolder')
+        .mockResolvedValue(mockResponse as any);
+
+      const result = await backupController.createDeviceAsFolder(userMocked, {
+        deviceName: 'Device Folder',
+      });
+      expect(result).toEqual(mockResponse);
+    });
+  });
+
+  describe('getDevicesAsFolder', () => {
+    it('When getDevicesAsFolder is called, then it should return all devices as folders', async () => {
+      const mockResponse = [{ id: 1, name: 'Device Folder' }];
+      jest
+        .spyOn(backupUseCase, 'getDevicesAsFolder')
+        .mockResolvedValue(mockResponse as any);
+
+      const result = await backupController.getDevicesAsFolder(userMocked);
+      expect(result).toEqual(mockResponse);
+    });
+
+    it('When backups are not activated, then it should throw a BadRequestException', async () => {
+      jest
+        .spyOn(backupUseCase, 'getDevicesAsFolder')
+        .mockRejectedValue(new BadRequestException());
+
+      await expect(
+        backupController.getDevicesAsFolder(userMocked),
+      ).rejects.toThrow(BadRequestException);
+    });
+  });
+
+  describe('getDeviceAsFolder', () => {
+    it('When getDeviceAsFolder is called with a valid folderId, then it should return the folder', async () => {
+      const mockResponse = { id: 1, name: 'Device Folder' };
+      jest
+        .spyOn(backupUseCase, 'getDeviceAsFolder')
+        .mockResolvedValue(mockResponse as any);
+
+      const result = await backupController.getDeviceAsFolder(userMocked, 1);
+      expect(result).toEqual(mockResponse);
+    });
+
+    it('When folder is not found, then it should throw a NotFoundException', async () => {
+      jest
+        .spyOn(backupUseCase, 'getDeviceAsFolder')
+        .mockRejectedValue(new NotFoundException());
+
+      await expect(
+        backupController.getDeviceAsFolder(userMocked, 1),
+      ).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('updateDeviceAsFolder', () => {
+    it('When updateDeviceAsFolder is called, then it should return the updated folder', async () => {
+      const mockResponse = { id: 1, name: 'Updated Folder' };
+      jest
+        .spyOn(backupUseCase, 'updateDeviceAsFolder')
+        .mockResolvedValue(mockResponse as any);
+
+      const result = await backupController.updateDeviceAsFolder(
+        userMocked,
+        1,
+        { deviceName: 'Updated Folder' },
+      );
+      expect(result).toEqual(mockResponse);
+    });
+
+    it('When folder is not found, then it should throw a NotFoundException', async () => {
+      jest
+        .spyOn(backupUseCase, 'updateDeviceAsFolder')
+        .mockRejectedValue(new NotFoundException());
+
+      await expect(
+        backupController.updateDeviceAsFolder(userMocked, 1, {
+          deviceName: 'Updated Folder',
+        }),
+      ).rejects.toThrow(NotFoundException);
+    });
+  });
+});

--- a/src/modules/backups/backup.controller.spec.ts
+++ b/src/modules/backups/backup.controller.spec.ts
@@ -77,13 +77,16 @@ describe('BackupController', () => {
   });
 
   describe('getDeviceAsFolder', () => {
-    it('When getDeviceAsFolder is called with a valid folderId, then it should return the folder', async () => {
-      const mockResponse = { id: 1, name: 'Device Folder' };
+    it('When getDeviceAsFolder is called with a valid uuid, then it should return the folder', async () => {
+      const mockResponse = { uuid: 'folder-uuid', name: 'Device Folder' };
       jest
         .spyOn(backupUseCase, 'getDeviceAsFolder')
         .mockResolvedValue(mockResponse as any);
 
-      const result = await backupController.getDeviceAsFolder(userMocked, 1);
+      const result = await backupController.getDeviceAsFolder(
+        userMocked,
+        'folder-uuid',
+      );
       expect(result).toEqual(mockResponse);
     });
 
@@ -93,21 +96,21 @@ describe('BackupController', () => {
         .mockRejectedValue(new NotFoundException());
 
       await expect(
-        backupController.getDeviceAsFolder(userMocked, 1),
+        backupController.getDeviceAsFolder(userMocked, 'folder-uuid'),
       ).rejects.toThrow(NotFoundException);
     });
   });
 
   describe('updateDeviceAsFolder', () => {
     it('When updateDeviceAsFolder is called, then it should return the updated folder', async () => {
-      const mockResponse = { id: 1, name: 'Updated Folder' };
+      const mockResponse = { uuid: 'folder-uuid', name: 'Updated Folder' };
       jest
         .spyOn(backupUseCase, 'updateDeviceAsFolder')
         .mockResolvedValue(mockResponse as any);
 
       const result = await backupController.updateDeviceAsFolder(
         userMocked,
-        1,
+        'folder-uuid',
         { deviceName: 'Updated Folder' },
       );
       expect(result).toEqual(mockResponse);
@@ -119,7 +122,7 @@ describe('BackupController', () => {
         .mockRejectedValue(new NotFoundException());
 
       await expect(
-        backupController.updateDeviceAsFolder(userMocked, 1, {
+        backupController.updateDeviceAsFolder(userMocked, 'folder-uuid', {
           deviceName: 'Updated Folder',
         }),
       ).rejects.toThrow(NotFoundException);

--- a/src/modules/backups/backup.controller.ts
+++ b/src/modules/backups/backup.controller.ts
@@ -1,0 +1,163 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  Param,
+  Patch,
+  Post,
+} from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiTags } from '@nestjs/swagger';
+import { User as UserDecorator } from '../auth/decorators/user.decorator';
+import { User } from '../user/user.domain';
+import { BackupUseCase } from './backup.usecase';
+import { CreateDeviceDto } from './dto/create-device.dto';
+import { CreateDeviceAsFolderDto } from './dto/create-device-as-folder.dto';
+import { CreateBackupDto } from './dto/create-backup.dto';
+
+@ApiTags('Backup')
+@Controller('backup')
+export class BackupController {
+  constructor(private readonly backupUseCases: BackupUseCase) {}
+
+  @Get('/device')
+  @HttpCode(200)
+  @ApiOperation({
+    summary: 'Get all user devices',
+  })
+  @ApiBearerAuth()
+  async getAllDevices(@UserDecorator() user: User) {
+    return this.backupUseCases.getAllDevices(user);
+  }
+
+  @Delete('/device/:deviceId')
+  @HttpCode(200)
+  @ApiOperation({
+    summary: 'Delete user device',
+  })
+  @ApiBearerAuth()
+  async deleteDevice(
+    @UserDecorator() user: User,
+    @Param('deviceId') deviceId: number,
+  ) {
+    return this.backupUseCases.deleteDevice(user, deviceId);
+  }
+
+  @Post('/device/:mac')
+  @HttpCode(200)
+  @ApiOperation({
+    summary: 'Create user device',
+  })
+  @ApiBearerAuth()
+  async createDevice(
+    @UserDecorator() user: User,
+    @Param('mac') mac: string,
+    @Body() body: CreateDeviceDto,
+  ) {
+    return this.backupUseCases.createDevice(user, mac, body);
+  }
+
+  @Post('/activate')
+  @HttpCode(200)
+  @ApiOperation({
+    summary: 'Activate user backup',
+  })
+  @ApiBearerAuth()
+  async activateBackup(@UserDecorator() user: User) {
+    return this.backupUseCases.activate(user);
+  }
+
+  @Post('/deviceAsFolder')
+  @HttpCode(200)
+  @ApiOperation({
+    summary: 'Create a folder using device name',
+  })
+  @ApiBearerAuth()
+  async createDeviceAsFolder(
+    @UserDecorator() user: User,
+    @Body() body: CreateDeviceAsFolderDto,
+  ) {
+    return this.backupUseCases.createDeviceAsFolder(user, body.deviceName);
+  }
+
+  @Get('/deviceAsFolder/:folderId')
+  @HttpCode(200)
+  @ApiOperation({
+    summary: 'Get folder by id',
+  })
+  @ApiBearerAuth()
+  async getDeviceAsFolder(
+    @UserDecorator() user: User,
+    @Param('folderId') folderId: number,
+  ) {
+    return this.backupUseCases.getDeviceAsFolder(user, folderId);
+  }
+
+  @Patch('/deviceAsFolder/:folderId')
+  @HttpCode(200)
+  @ApiOperation({
+    summary: 'Update device as folder',
+  })
+  @ApiBearerAuth()
+  async updateDeviceAsFolder(
+    @UserDecorator() user: User,
+    @Param('folderId') folderId: number,
+    @Body() body: CreateDeviceAsFolderDto,
+  ) {
+    return this.backupUseCases.updateDeviceAsFolder(
+      user,
+      folderId,
+      body.deviceName,
+    );
+  }
+
+  @Get('/deviceAsFolder')
+  @HttpCode(200)
+  @ApiOperation({
+    summary: 'Get all devices as folder',
+  })
+  @ApiBearerAuth()
+  async getDevicesAsFolder(@UserDecorator() user: User) {
+    return this.backupUseCases.getDevicesAsFolder(user);
+  }
+
+  @Post('/')
+  @HttpCode(200)
+  @ApiOperation({
+    summary: 'Create backup',
+  })
+  @ApiBearerAuth()
+  async createBackup(
+    @UserDecorator() user: User,
+    @Body() body: CreateBackupDto,
+  ) {
+    return this.backupUseCases.createBackup(user, body);
+  }
+
+  @Get('/:mac')
+  @HttpCode(200)
+  @ApiOperation({
+    summary: 'Get backups by mac',
+  })
+  @ApiBearerAuth()
+  async getBackupsByMac(
+    @UserDecorator() user: User,
+    @Param('mac') mac: string,
+  ) {
+    return this.backupUseCases.getBackupsByMac(user, mac);
+  }
+
+  @Delete('/:backupId')
+  @HttpCode(200)
+  @ApiOperation({
+    summary: 'Delete backup',
+  })
+  @ApiBearerAuth()
+  async deleteBackup(
+    @UserDecorator() user: User,
+    @Param('backupId') backupId: number,
+  ) {
+    return this.backupUseCases.deleteBackup(user, backupId);
+  }
+}

--- a/src/modules/backups/backup.controller.ts
+++ b/src/modules/backups/backup.controller.ts
@@ -12,6 +12,7 @@ import { User as UserDecorator } from '../auth/decorators/user.decorator';
 import { User } from '../user/user.domain';
 import { BackupUseCase } from './backup.usecase';
 import { CreateDeviceAsFolderDto } from './dto/create-device-as-folder.dto';
+import { ValidateUUIDPipe } from '../workspaces/pipes/validate-uuid.pipe';
 
 @ApiTags('Backup')
 @Controller('backup')
@@ -41,33 +42,33 @@ export class BackupController {
     return this.backupUseCases.createDeviceAsFolder(user, body.deviceName);
   }
 
-  @Get('/deviceAsFolder/:folderId')
+  @Get('/deviceAsFolder/:uuid')
   @HttpCode(200)
   @ApiOperation({
-    summary: 'Get folder by id',
+    summary: 'Get device as folder by uuid',
   })
   @ApiBearerAuth()
   async getDeviceAsFolder(
     @UserDecorator() user: User,
-    @Param('folderId') folderId: number,
+    @Param('uuid', ValidateUUIDPipe) uuid: string,
   ) {
-    return this.backupUseCases.getDeviceAsFolder(user, folderId);
+    return this.backupUseCases.getDeviceAsFolder(user, uuid);
   }
 
-  @Patch('/deviceAsFolder/:folderId')
+  @Patch('/deviceAsFolder/:uuid')
   @HttpCode(200)
   @ApiOperation({
-    summary: 'Update device as folder',
+    summary: 'Update device as folder by uuid',
   })
   @ApiBearerAuth()
   async updateDeviceAsFolder(
     @UserDecorator() user: User,
-    @Param('folderId') folderId: number,
+    @Param('uuid', ValidateUUIDPipe) uuid: string,
     @Body() body: CreateDeviceAsFolderDto,
   ) {
     return this.backupUseCases.updateDeviceAsFolder(
       user,
-      folderId,
+      uuid,
       body.deviceName,
     );
   }

--- a/src/modules/backups/backup.controller.ts
+++ b/src/modules/backups/backup.controller.ts
@@ -1,7 +1,6 @@
 import {
   Body,
   Controller,
-  Delete,
   Get,
   HttpCode,
   Param,
@@ -18,29 +17,6 @@ import { CreateDeviceAsFolderDto } from './dto/create-device-as-folder.dto';
 @Controller('backup')
 export class BackupController {
   constructor(private readonly backupUseCases: BackupUseCase) {}
-
-  @Get('/device')
-  @HttpCode(200)
-  @ApiOperation({
-    summary: 'Get all user devices',
-  })
-  @ApiBearerAuth()
-  async getAllDevices(@UserDecorator() user: User) {
-    return this.backupUseCases.getAllDevices(user);
-  }
-
-  @Delete('/device/:deviceId')
-  @HttpCode(200)
-  @ApiOperation({
-    summary: 'Delete user device',
-  })
-  @ApiBearerAuth()
-  async deleteDevice(
-    @UserDecorator() user: User,
-    @Param('deviceId') deviceId: number,
-  ) {
-    return this.backupUseCases.deleteDevice(user, deviceId);
-  }
 
   @Post('/activate')
   @HttpCode(200)
@@ -104,31 +80,5 @@ export class BackupController {
   @ApiBearerAuth()
   async getDevicesAsFolder(@UserDecorator() user: User) {
     return this.backupUseCases.getDevicesAsFolder(user);
-  }
-
-  @Get('/:mac')
-  @HttpCode(200)
-  @ApiOperation({
-    summary: 'Get backups by mac',
-  })
-  @ApiBearerAuth()
-  async getBackupsByMac(
-    @UserDecorator() user: User,
-    @Param('mac') mac: string,
-  ) {
-    return this.backupUseCases.getBackupsByMac(user, mac);
-  }
-
-  @Delete('/:backupId')
-  @HttpCode(200)
-  @ApiOperation({
-    summary: 'Delete backup',
-  })
-  @ApiBearerAuth()
-  async deleteBackup(
-    @UserDecorator() user: User,
-    @Param('backupId') backupId: number,
-  ) {
-    return this.backupUseCases.deleteBackup(user, backupId);
   }
 }

--- a/src/modules/backups/backup.controller.ts
+++ b/src/modules/backups/backup.controller.ts
@@ -12,9 +12,7 @@ import { ApiBearerAuth, ApiOperation, ApiTags } from '@nestjs/swagger';
 import { User as UserDecorator } from '../auth/decorators/user.decorator';
 import { User } from '../user/user.domain';
 import { BackupUseCase } from './backup.usecase';
-import { CreateDeviceDto } from './dto/create-device.dto';
 import { CreateDeviceAsFolderDto } from './dto/create-device-as-folder.dto';
-import { CreateBackupDto } from './dto/create-backup.dto';
 
 @ApiTags('Backup')
 @Controller('backup')
@@ -42,20 +40,6 @@ export class BackupController {
     @Param('deviceId') deviceId: number,
   ) {
     return this.backupUseCases.deleteDevice(user, deviceId);
-  }
-
-  @Post('/device/:mac')
-  @HttpCode(200)
-  @ApiOperation({
-    summary: 'Create user device',
-  })
-  @ApiBearerAuth()
-  async createDevice(
-    @UserDecorator() user: User,
-    @Param('mac') mac: string,
-    @Body() body: CreateDeviceDto,
-  ) {
-    return this.backupUseCases.createDevice(user, mac, body);
   }
 
   @Post('/activate')
@@ -120,19 +104,6 @@ export class BackupController {
   @ApiBearerAuth()
   async getDevicesAsFolder(@UserDecorator() user: User) {
     return this.backupUseCases.getDevicesAsFolder(user);
-  }
-
-  @Post('/')
-  @HttpCode(200)
-  @ApiOperation({
-    summary: 'Create backup',
-  })
-  @ApiBearerAuth()
-  async createBackup(
-    @UserDecorator() user: User,
-    @Body() body: CreateBackupDto,
-  ) {
-    return this.backupUseCases.createBackup(user, body);
   }
 
   @Get('/:mac')

--- a/src/modules/backups/backup.domain.ts
+++ b/src/modules/backups/backup.domain.ts
@@ -1,0 +1,58 @@
+import { BackupAttributes } from './models/backup.attributes';
+
+export class Backup implements BackupAttributes {
+  id?: number;
+  userId: number;
+  planId?: string;
+  uuid?: string;
+  path?: string;
+  fileId?: string;
+  deviceId: number;
+  hash?: string;
+  interval?: number;
+  size?: number;
+  bucket?: string;
+  lastBackupAt?: Date;
+  enabled?: boolean;
+  encrypt_version?: string;
+  createdAt?: Date;
+  updatedAt?: Date;
+
+  constructor(attributes: BackupAttributes) {
+    this.id = attributes.id;
+    this.userId = attributes.userId;
+    this.path = attributes.path;
+    this.fileId = attributes.fileId;
+    this.deviceId = attributes.deviceId;
+    this.hash = attributes.hash;
+    this.interval = attributes.interval;
+    this.size = attributes.size;
+    this.bucket = attributes.bucket;
+    this.lastBackupAt = attributes.lastBackupAt;
+    this.enabled = attributes.enabled;
+    this.encrypt_version = attributes.encrypt_version;
+    this.createdAt = attributes.createdAt;
+    this.updatedAt = attributes.updatedAt;
+  }
+
+  static build(attributes: Partial<BackupAttributes>): Backup {
+    return new Backup(attributes as BackupAttributes);
+  }
+
+  toJson(): BackupAttributes {
+    return {
+      id: this.id,
+      userId: this.userId,
+      path: this.path,
+      fileId: this.fileId,
+      deviceId: this.deviceId,
+      hash: this.hash,
+      interval: this.interval,
+      size: this.size,
+      bucket: this.bucket,
+      lastBackupAt: this.lastBackupAt,
+      enabled: this.enabled,
+      encrypt_version: this.encrypt_version,
+    };
+  }
+}

--- a/src/modules/backups/backup.module.ts
+++ b/src/modules/backups/backup.module.ts
@@ -1,13 +1,53 @@
-import { Module } from '@nestjs/common';
+import { NotificationModule } from './../../externals/notifications/notifications.module';
+import { forwardRef, Module } from '@nestjs/common';
 import { SequelizeModule } from '@nestjs/sequelize';
+import { BackupController } from './backup.controller';
+import { BackupUseCase } from './backup.usecase';
+import { SequelizeBackupRepository } from './backup.repository';
 import { BackupModel } from './models/backup.model';
 import { DeviceModel } from './models/device.model';
-import { SequelizeBackupRepository } from './backup.repository';
-import { BackupUseCase } from './backup.usecase';
+import { UserModel } from '../user/user.model';
+import { BridgeModule } from './../../externals/bridge/bridge.module';
+import { CryptoModule } from './../../externals/crypto/crypto.module';
+import { FileModule } from '../file/file.module';
+import { FolderModule } from '../folder/folder.module';
+import { SequelizeUserRepository } from '../user/user.repository';
+import { FolderModel } from '../folder/folder.model';
+import { SharingModule } from '../sharing/sharing.module';
+import { WorkspacesModule } from '../workspaces/workspaces.module';
+import { UserNotificationTokensModel } from '../user/user-notification-tokens.model';
+import { ShareModel } from '../share/share.repository';
+import { ShareModule } from '../share/share.module';
+import { ThumbnailModule } from '../thumbnail/thumbnail.module';
+import { ThumbnailModel } from '../thumbnail/thumbnail.model';
 
 @Module({
-  imports: [SequelizeModule.forFeature([BackupModel, DeviceModel])],
-  providers: [SequelizeBackupRepository, BackupUseCase],
-  exports: [SequelizeModule, BackupUseCase],
+  imports: [
+    SequelizeModule.forFeature([
+      BackupModel,
+      DeviceModel,
+      FolderModel,
+      UserModel,
+      UserNotificationTokensModel,
+      ShareModel,
+      ThumbnailModel,
+    ]),
+    forwardRef(() => FileModule),
+    forwardRef(() => FolderModule),
+    forwardRef(() => ShareModule),
+    forwardRef(() => ThumbnailModule),
+    forwardRef(() => SharingModule),
+    forwardRef(() => WorkspacesModule),
+    CryptoModule,
+    BridgeModule,
+    NotificationModule,
+  ],
+  controllers: [BackupController],
+  providers: [
+    SequelizeBackupRepository,
+    BackupUseCase,
+    SequelizeUserRepository,
+  ],
+  exports: [BackupUseCase, SequelizeBackupRepository],
 })
 export class BackupModule {}

--- a/src/modules/backups/backup.repository.spec.ts
+++ b/src/modules/backups/backup.repository.spec.ts
@@ -1,0 +1,148 @@
+import { newUser } from './../../../test/fixtures';
+import { Test, TestingModule } from '@nestjs/testing';
+import { SequelizeBackupRepository } from './backup.repository';
+import { DeviceModel } from './models/device.model';
+import { BackupModel } from './models/backup.model';
+import { createMock } from '@golevelup/ts-jest';
+import { getModelToken } from '@nestjs/sequelize';
+
+describe('SequelizeBackupRepository', () => {
+  let repository: SequelizeBackupRepository;
+  let deviceModel: typeof DeviceModel;
+  let backupModel: typeof BackupModel;
+
+  const userMocked = newUser({
+    attributes: {
+      id: 1,
+      uuid: 'user-uuid',
+      email: 'test@example.com',
+      backupsBucket: 'bucket-id',
+    },
+  });
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [SequelizeBackupRepository],
+    })
+      .useMocker(() => createMock())
+      .compile();
+
+    repository = module.get<SequelizeBackupRepository>(
+      SequelizeBackupRepository,
+    );
+    deviceModel = module.get<typeof DeviceModel>(getModelToken(DeviceModel));
+    backupModel = module.get<typeof BackupModel>(getModelToken(BackupModel));
+  });
+
+  describe('deleteDevicesBy', () => {
+    it('When deleteDevicesBy is called, then it should delete', async () => {
+      jest.spyOn(deviceModel, 'destroy').mockResolvedValue(1);
+
+      const result = await repository.deleteDevicesBy({
+        userId: userMocked.id,
+      });
+      expect(result).toBe(1);
+      expect(deviceModel.destroy).toHaveBeenCalledWith({
+        where: { userId: userMocked.id },
+      });
+    });
+
+    it('When no devices match the criteria, then it should return 0', async () => {
+      jest.spyOn(deviceModel, 'destroy').mockResolvedValue(0);
+
+      const result = await repository.deleteDevicesBy({ userId: 999 });
+      expect(result).toBe(0);
+      expect(deviceModel.destroy).toHaveBeenCalledWith({
+        where: { userId: 999 },
+      });
+    });
+  });
+
+  describe('deleteBackupsBy', () => {
+    it('When deleteBackupsBy is called, then it should delete', async () => {
+      jest.spyOn(backupModel, 'destroy').mockResolvedValue(1);
+
+      const result = await repository.deleteBackupsBy({
+        userId: userMocked.id,
+      });
+      expect(result).toBe(1);
+      expect(backupModel.destroy).toHaveBeenCalledWith({
+        where: { userId: userMocked.id },
+      });
+    });
+
+    it('When no backups match the criteria, then it should return 0', async () => {
+      jest.spyOn(backupModel, 'destroy').mockResolvedValue(0);
+
+      const result = await repository.deleteBackupsBy({ userId: 999 });
+      expect(result).toBe(0);
+      expect(backupModel.destroy).toHaveBeenCalledWith({
+        where: { userId: 999 },
+      });
+    });
+  });
+
+  describe('toDomainDevice', () => {
+    const deviceModelMock = {
+      toJSON: jest.fn().mockReturnValue({
+        id: 1,
+        name: 'Device 1',
+        backups: [{ id: 1, path: 'add_path_here' }],
+      }),
+      backups: [
+        {
+          toJSON: jest.fn().mockReturnValue({ id: 1, path: 'add_path_here' }),
+        },
+      ],
+    } as unknown as DeviceModel;
+    it('When toDomainDevice is called with a device model, then it should return', () => {
+      const result = (repository as any).toDomainDevice(deviceModelMock);
+
+      expect(result).toEqual(
+        expect.objectContaining({
+          id: 1,
+          name: 'Device 1',
+          backups: [
+            expect.objectContaining({
+              id: 1,
+              path: 'add_path_here',
+            }),
+          ],
+        }),
+      );
+    });
+
+    it('When toDomainDevice is called with a device model without backups, then it should return with an empty backups array', () => {
+      deviceModelMock.backups = [];
+      const result = (repository as any).toDomainDevice(deviceModelMock);
+
+      expect(result).toEqual(
+        expect.objectContaining({
+          id: 1,
+          name: 'Device 1',
+          backups: [],
+        }),
+      );
+    });
+  });
+
+  describe('toDomainBackup', () => {
+    it('When toDomainBackup is called with a backup model, then it should return', () => {
+      const backupModelMock = {
+        toJSON: jest.fn().mockReturnValue({
+          id: 1,
+          path: 'add_path_here',
+        }),
+      } as unknown as BackupModel;
+
+      const result = (repository as any).toDomainBackup(backupModelMock);
+
+      expect(result).toEqual(
+        expect.objectContaining({
+          id: 1,
+          path: 'add_path_here',
+        }),
+      );
+    });
+  });
+});

--- a/src/modules/backups/backup.repository.ts
+++ b/src/modules/backups/backup.repository.ts
@@ -25,10 +25,10 @@ export class SequelizeBackupRepository {
   }
 
   async createDevice(user: User, payload: Partial<DeviceModel>) {
-    const device = await new this.deviceModel({
+    const device = await this.deviceModel.create({
       ...payload,
       userId: user.id,
-    }).save();
+    });
     return this.toDomainDevice(device);
   }
 
@@ -71,10 +71,10 @@ export class SequelizeBackupRepository {
   }
 
   async createBackup(user: User, payload: Partial<BackupModel>) {
-    const backup = await new this.backupModel({
+    const backup = await this.backupModel.create({
       ...payload,
       userId: user.id,
-    }).save();
+    });
     return this.toDomainBackup(backup);
   }
 

--- a/src/modules/backups/backup.repository.ts
+++ b/src/modules/backups/backup.repository.ts
@@ -2,8 +2,6 @@ import { Injectable } from '@nestjs/common';
 import { InjectModel } from '@nestjs/sequelize';
 import { DeviceModel } from './models/device.model';
 import { BackupModel } from './models/backup.model';
-import { Sequelize } from 'sequelize';
-import { User } from '../user/user.domain';
 import { Device } from './device.domain';
 import { Backup } from './backup.domain';
 
@@ -22,64 +20,6 @@ export class SequelizeBackupRepository {
 
   public async deleteBackupsBy(where: Partial<BackupModel>): Promise<number> {
     return this.backupModel.destroy({ where });
-  }
-
-  async findDeviceByUserAndMac(user: User, mac: string) {
-    const device = await this.deviceModel.findOne({
-      where: { userId: user.id, mac },
-    });
-    return device ? this.toDomainDevice(device) : null;
-  }
-
-  async findAllDevices(user: User) {
-    const devices = await this.deviceModel.findAll({
-      where: { userId: user.id },
-      attributes: {
-        include: [[Sequelize.fn('SUM', Sequelize.col('backups.size')), 'size']],
-      },
-      group: [Sequelize.col('DeviceModel.id'), Sequelize.col('backups.id')],
-      include: [
-        {
-          model: BackupModel,
-          as: 'backups',
-        },
-      ],
-    });
-    return devices.map(this.toDomainDevice);
-  }
-
-  async findDeviceByUserAndId(user: User, deviceId: number) {
-    const device = await this.deviceModel.findOne({
-      where: { userId: user.id, id: deviceId },
-      include: [
-        {
-          model: BackupModel,
-          as: 'backups',
-          required: false,
-        },
-      ],
-    });
-    return device ? this.toDomainDevice(device) : null;
-  }
-
-  async findAllBackupsByUserAndDevice(user: User, deviceId: number) {
-    const backups = await this.backupModel.findAll({
-      where: { userId: user.id, deviceId },
-    });
-    return backups.map(this.toDomainBackup);
-  }
-
-  async findBackupByUserAndId(user: User, backupId: number) {
-    const backup = await this.backupModel.findOne({
-      where: { userId: user.id, id: backupId },
-    });
-    return backup ? this.toDomainBackup(backup) : null;
-  }
-
-  async deleteBackupByUserAndId(user: User, backupId: number) {
-    return this.backupModel.destroy({
-      where: { userId: user.id, id: backupId },
-    });
   }
 
   private toDomainDevice(deviceModel: DeviceModel): Device {

--- a/src/modules/backups/backup.repository.ts
+++ b/src/modules/backups/backup.repository.ts
@@ -24,14 +24,6 @@ export class SequelizeBackupRepository {
     return this.backupModel.destroy({ where });
   }
 
-  async createDevice(user: User, payload: Partial<DeviceModel>) {
-    const device = await this.deviceModel.create({
-      ...payload,
-      userId: user.id,
-    });
-    return this.toDomainDevice(device);
-  }
-
   async findDeviceByUserAndMac(user: User, mac: string) {
     const device = await this.deviceModel.findOne({
       where: { userId: user.id, mac },
@@ -68,14 +60,6 @@ export class SequelizeBackupRepository {
       ],
     });
     return device ? this.toDomainDevice(device) : null;
-  }
-
-  async createBackup(user: User, payload: Partial<BackupModel>) {
-    const backup = await this.backupModel.create({
-      ...payload,
-      userId: user.id,
-    });
-    return this.toDomainBackup(backup);
   }
 
   async findAllBackupsByUserAndDevice(user: User, deviceId: number) {

--- a/src/modules/backups/backup.usecase.spec.ts
+++ b/src/modules/backups/backup.usecase.spec.ts
@@ -1,0 +1,215 @@
+import { newUser } from './../../../test/fixtures';
+import { Test, TestingModule } from '@nestjs/testing';
+import { createMock } from '@golevelup/ts-jest';
+import { BackupUseCase } from './backup.usecase';
+import { SequelizeBackupRepository } from './backup.repository';
+import { BridgeService } from '../../externals/bridge/bridge.service';
+import { CryptoService } from '../../externals/crypto/crypto.service';
+import { FolderUseCases } from '../folder/folder.usecase';
+import { FileUseCases } from '../file/file.usecase';
+import {
+  NotFoundException,
+  ConflictException,
+  BadRequestException,
+} from '@nestjs/common';
+
+describe('BackupUseCase', () => {
+  let backupUseCase: BackupUseCase;
+  let backupRepository: SequelizeBackupRepository;
+  let bridgeService: BridgeService;
+  let cryptoService: CryptoService;
+  let folderUseCases: FolderUseCases;
+  let fileUseCases: FileUseCases;
+
+  const userMocked = newUser({
+    attributes: {
+      id: 1,
+      uuid: 'user-uuid',
+      email: 'test@example.com',
+      backupsBucket: 'bucket-id',
+    },
+  });
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [BackupUseCase],
+    })
+      .useMocker(() => createMock())
+      .compile();
+
+    backupUseCase = module.get<BackupUseCase>(BackupUseCase);
+    backupRepository = module.get<SequelizeBackupRepository>(
+      SequelizeBackupRepository,
+    );
+    bridgeService = module.get<BridgeService>(BridgeService);
+    cryptoService = module.get<CryptoService>(CryptoService);
+    folderUseCases = module.get<FolderUseCases>(FolderUseCases);
+    fileUseCases = module.get<FileUseCases>(FileUseCases);
+  });
+
+  describe('activate', () => {
+    it('When backups are already activated, then it should return the backups bucket', async () => {
+      const result = await backupUseCase.activate(userMocked);
+      expect(result).toEqual({ backupsBucket: 'bucket-id' });
+    });
+
+    it('When backups are not activated, then it should create a new bucket', async () => {
+      const mockBucket = { id: 'new-bucket-id' };
+      jest
+        .spyOn(bridgeService, 'createBucket')
+        .mockResolvedValue(mockBucket as any);
+
+      const userWithoutBucket = { ...userMocked, backupsBucket: null };
+      const result = await backupUseCase.activate(userWithoutBucket as any);
+      expect(result).toEqual({ backupsBucket: 'new-bucket-id' });
+    });
+  });
+
+  describe('createDeviceAsFolder', () => {
+    it('When a folder with the same name exists, then it should throw a ConflictException', async () => {
+      jest
+        .spyOn(folderUseCases, 'getFolders')
+        .mockResolvedValue([{ id: 1, name: 'Device Folder' }] as any);
+
+      await expect(
+        backupUseCase.createDeviceAsFolder(userMocked, 'Device Folder'),
+      ).rejects.toThrow(ConflictException);
+    });
+
+    it('When no folder with the same name exists, then it should create the folder', async () => {
+      const mockFolder = { id: 1, name: 'Device Folder' };
+      jest.spyOn(folderUseCases, 'getFolders').mockResolvedValue([]);
+      jest
+        .spyOn(folderUseCases, 'createFolderDevice')
+        .mockResolvedValue(mockFolder as any);
+
+      const result = await backupUseCase.createDeviceAsFolder(
+        userMocked,
+        'Device Folder',
+      );
+      expect(result).toEqual(mockFolder);
+    });
+  });
+
+  describe('getDevicesAsFolder', () => {
+    it('When backups are not activated, then it should throw a BadRequestException', async () => {
+      const userWithoutBucket = { ...userMocked, backupsBucket: null };
+      await expect(
+        backupUseCase.getDevicesAsFolder(userWithoutBucket as any),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('When backups are activated, then it should return all devices as folders', async () => {
+      const mockFolders = [{ id: 1, name: 'Device Folder' }];
+      jest
+        .spyOn(folderUseCases, 'getFoldersByUserId')
+        .mockResolvedValue(mockFolders as any);
+
+      const result = await backupUseCase.getDevicesAsFolder(userMocked);
+      expect(result).toEqual(expect.any(Array));
+    });
+  });
+
+  describe('deleteUserBackups', () => {
+    it('When deleting user backups, then it should delete all backups and devices for the user', async () => {
+      jest.spyOn(backupRepository, 'deleteBackupsBy').mockResolvedValue(5);
+      jest.spyOn(backupRepository, 'deleteDevicesBy').mockResolvedValue(3);
+
+      const result = await backupUseCase.deleteUserBackups(userMocked.id);
+      expect(result).toEqual({ deletedBackups: 5, deletedDevices: 3 });
+    });
+  });
+
+  describe('isFolderEmpty', () => {
+    it('When the folder has no subfolders or files, then it should return true', async () => {
+      jest.spyOn(folderUseCases, 'getFoldersByParentId').mockResolvedValue([]);
+      jest.spyOn(fileUseCases, 'getByFolderAndUser').mockResolvedValue([]);
+
+      const result = await backupUseCase.isFolderEmpty(userMocked, {
+        id: 1,
+      } as any);
+      expect(result).toBe(true);
+    });
+
+    it('When the folder has subfolders or files, then it should return false', async () => {
+      jest
+        .spyOn(folderUseCases, 'getFoldersByParentId')
+        .mockResolvedValue([{ id: 2 }] as any);
+      jest.spyOn(fileUseCases, 'getByFolderAndUser').mockResolvedValue([]);
+
+      const result = await backupUseCase.isFolderEmpty(userMocked, {
+        id: 1,
+      } as any);
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('getDeviceAsFolder', () => {
+    it('When the folder does not exist, then it should throw a NotFoundException', async () => {
+      jest.spyOn(folderUseCases, 'getFolderByUserId').mockResolvedValue(null);
+
+      await expect(
+        backupUseCase.getDeviceAsFolder(userMocked, 1),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('When the folder exists, then it should return the folder', async () => {
+      const mockFolder = {
+        id: 1,
+        name: 'Encrypted Folder',
+        bucket: 'bucket-id',
+        updatedAt: new Date(),
+      };
+      jest
+        .spyOn(folderUseCases, 'getFolderByUserId')
+        .mockResolvedValue(mockFolder as any);
+      jest.spyOn(backupUseCase, 'isFolderEmpty').mockResolvedValue(false);
+
+      const result = await backupUseCase.getDeviceAsFolder(userMocked, 1);
+      expect(result).toEqual({
+        ...mockFolder,
+        hasBackups: true,
+        lastBackupAt: mockFolder.updatedAt,
+      });
+    });
+  });
+
+  describe('updateDeviceAsFolder', () => {
+    it('When the folder does not exist, then it should throw a NotFoundException', async () => {
+      jest.spyOn(folderUseCases, 'getFolderByUserId').mockResolvedValue(null);
+
+      await expect(
+        backupUseCase.updateDeviceAsFolder(userMocked, 1, 'New Device Name'),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('When the folder exists, then it should update the folder with the new name', async () => {
+      const mockFolder = {
+        id: 1,
+        name: 'Old Encrypted Name',
+        bucket: 'bucket-id',
+      };
+      const updatedFolder = {
+        ...mockFolder,
+        name: 'New Encrypted Name',
+        plainName: 'New Device Name',
+      };
+      jest
+        .spyOn(folderUseCases, 'getFolderByUserId')
+        .mockResolvedValue(mockFolder as any);
+      jest
+        .spyOn(cryptoService, 'encryptName')
+        .mockReturnValue('New Encrypted Name');
+      jest
+        .spyOn(folderUseCases, 'updateByFolderId')
+        .mockResolvedValue(updatedFolder as any);
+
+      const result = await backupUseCase.updateDeviceAsFolder(
+        userMocked,
+        1,
+        'New Device Name',
+      );
+      expect(result).toEqual(updatedFolder);
+    });
+  });
+});

--- a/src/modules/backups/backup.usecase.spec.ts
+++ b/src/modules/backups/backup.usecase.spec.ts
@@ -146,26 +146,31 @@ describe('BackupUseCase', () => {
 
   describe('getDeviceAsFolder', () => {
     it('When the folder does not exist, then it should throw a NotFoundException', async () => {
-      jest.spyOn(folderUseCases, 'getFolderByUserId').mockResolvedValue(null);
+      jest
+        .spyOn(folderUseCases, 'getFolderByUuid')
+        .mockRejectedValue(new NotFoundException());
 
       await expect(
-        backupUseCase.getDeviceAsFolder(userMocked, 1),
+        backupUseCase.getDeviceAsFolder(userMocked, 'folder-uuid'),
       ).rejects.toThrow(NotFoundException);
     });
 
     it('When the folder exists, then it should return the folder', async () => {
       const mockFolder = {
-        id: 1,
+        uuid: 'folder-uuid',
         name: 'Encrypted Folder',
         bucket: 'bucket-id',
         updatedAt: new Date(),
       };
       jest
-        .spyOn(folderUseCases, 'getFolderByUserId')
+        .spyOn(folderUseCases, 'getFolderByUuid')
         .mockResolvedValue(mockFolder as any);
       jest.spyOn(backupUseCase, 'isFolderEmpty').mockResolvedValue(false);
 
-      const result = await backupUseCase.getDeviceAsFolder(userMocked, 1);
+      const result = await backupUseCase.getDeviceAsFolder(
+        userMocked,
+        'folder-uuid',
+      );
       expect(result).toEqual({
         ...mockFolder,
         hasBackups: true,
@@ -176,16 +181,22 @@ describe('BackupUseCase', () => {
 
   describe('updateDeviceAsFolder', () => {
     it('When the folder does not exist, then it should throw a NotFoundException', async () => {
-      jest.spyOn(folderUseCases, 'getFolderByUserId').mockResolvedValue(null);
+      jest
+        .spyOn(folderUseCases, 'getFolderByUuid')
+        .mockRejectedValue(new NotFoundException());
 
       await expect(
-        backupUseCase.updateDeviceAsFolder(userMocked, 1, 'New Device Name'),
+        backupUseCase.updateDeviceAsFolder(
+          userMocked,
+          'folder-uuid',
+          'New Device Name',
+        ),
       ).rejects.toThrow(NotFoundException);
     });
 
     it('When the folder exists, then it should update the folder with the new name', async () => {
       const mockFolder = {
-        id: 1,
+        uuid: 'folder-uuid',
         name: 'Old Encrypted Name',
         bucket: 'bucket-id',
       };
@@ -195,7 +206,7 @@ describe('BackupUseCase', () => {
         plainName: 'New Device Name',
       };
       jest
-        .spyOn(folderUseCases, 'getFolderByUserId')
+        .spyOn(folderUseCases, 'getFolderByUuid')
         .mockResolvedValue(mockFolder as any);
       jest
         .spyOn(cryptoService, 'encryptName')
@@ -206,7 +217,7 @@ describe('BackupUseCase', () => {
 
       const result = await backupUseCase.updateDeviceAsFolder(
         userMocked,
-        1,
+        'folder-uuid',
         'New Device Name',
       );
       expect(result).toEqual(updatedFolder);

--- a/src/modules/backups/backup.usecase.ts
+++ b/src/modules/backups/backup.usecase.ts
@@ -13,7 +13,6 @@ import { CryptoService } from './../../externals/crypto/crypto.service';
 import { FolderUseCases } from '../folder/folder.usecase';
 import { FileUseCases } from '../file/file.usecase';
 import { Folder, FolderAttributes } from '../folder/folder.domain';
-import { BackupModel } from './models/backup.model';
 import { SequelizeUserRepository } from '../user/user.repository';
 
 @Injectable()
@@ -36,39 +35,6 @@ export class BackupUseCase {
     ]);
 
     return { deletedBackups, deletedDevices };
-  }
-
-  async getAllDevices(user: User) {
-    return this.backupRepository.findAllDevices(user);
-  }
-
-  async deleteDevice(user: User, deviceId: number) {
-    const device = await this.backupRepository.findDeviceByUserAndId(
-      user,
-      deviceId,
-    );
-    if (!device) {
-      throw new NotFoundException('Device not found');
-    }
-
-    await Promise.all(
-      device.backups.map((backup: BackupModel) => {
-        if (backup.fileId) {
-          return this.networkService.deleteFile(
-            user,
-            backup.bucket,
-            backup.fileId,
-          );
-        }
-      }),
-    );
-
-    await this.backupRepository.deleteBackupsBy({ deviceId });
-
-    return this.backupRepository.deleteDevicesBy({
-      userId: user.id,
-      id: deviceId,
-    });
   }
 
   async activate(user: User) {
@@ -167,30 +133,6 @@ export class BackupUseCase {
       name: encryptedName,
       plainName: deviceName,
     });
-  }
-
-  async getBackupsByMac(user: User, mac: string) {
-    const device = await this.backupRepository.findDeviceByUserAndMac(
-      user,
-      mac,
-    );
-    if (!device) {
-      throw new NotFoundException('Device not found');
-    }
-
-    return this.backupRepository.findAllBackupsByUserAndDevice(user, device.id);
-  }
-
-  async deleteBackup(user: User, backupId: number) {
-    const backup = await this.backupRepository.findBackupByUserAndId(
-      user,
-      backupId,
-    );
-    if (!backup) {
-      throw new NotFoundException('Backup not found');
-    }
-
-    return this.backupRepository.deleteBackupByUserAndId(user, backupId);
   }
 
   async isFolderEmpty(user: User, folder: Folder) {

--- a/src/modules/backups/backup.usecase.ts
+++ b/src/modules/backups/backup.usecase.ts
@@ -95,11 +95,8 @@ export class BackupUseCase {
     );
   }
 
-  async getDeviceAsFolder(user: User, folderId: FolderAttributes['id']) {
-    const folder = await this.folderUsecases.getFolderByUserId(
-      folderId,
-      user.id,
-    );
+  async getDeviceAsFolder(user: User, uuid: FolderAttributes['uuid']) {
+    const folder = await this.folderUsecases.getFolderByUuid(uuid, user);
     if (!folder) {
       throw new NotFoundException('Folder not found');
     }
@@ -113,13 +110,10 @@ export class BackupUseCase {
 
   async updateDeviceAsFolder(
     user: User,
-    folderId: FolderAttributes['id'],
+    uuid: FolderAttributes['uuid'],
     deviceName: string,
   ) {
-    const folder = await this.folderUsecases.getFolderByUserId(
-      folderId,
-      user.id,
-    );
+    const folder = await this.folderUsecases.getFolderByUuid(uuid, user);
     if (!folder) {
       throw new NotFoundException('Folder not found');
     }

--- a/src/modules/backups/backup.usecase.ts
+++ b/src/modules/backups/backup.usecase.ts
@@ -14,7 +14,6 @@ import { FolderUseCases } from '../folder/folder.usecase';
 import { FileUseCases } from '../file/file.usecase';
 import { Folder, FolderAttributes } from '../folder/folder.domain';
 import { BackupModel } from './models/backup.model';
-import { CreateDeviceDto } from './dto/create-device.dto';
 import { SequelizeUserRepository } from '../user/user.repository';
 
 @Injectable()
@@ -41,23 +40,6 @@ export class BackupUseCase {
 
   async getAllDevices(user: User) {
     return this.backupRepository.findAllDevices(user);
-  }
-
-  async createDevice(user: User, mac: string, payload: CreateDeviceDto) {
-    const { platform, deviceName } = payload;
-    const exists = await this.backupRepository.findDeviceByUserAndMac(
-      user,
-      mac,
-    );
-    if (exists) {
-      return exists;
-    }
-
-    return this.backupRepository.createDevice(user, {
-      mac,
-      name: deviceName,
-      platform,
-    });
   }
 
   async deleteDevice(user: User, deviceId: number) {
@@ -185,19 +167,6 @@ export class BackupUseCase {
       name: encryptedName,
       plainName: deviceName,
     });
-  }
-
-  async createBackup(user: User, payload: Partial<BackupModel>) {
-    const { deviceId } = payload;
-    const device = await this.backupRepository.findDeviceByUserAndId(
-      user,
-      deviceId,
-    );
-    if (!device) {
-      throw new NotFoundException('Device not found');
-    }
-
-    return this.backupRepository.createBackup(user, payload);
   }
 
   async getBackupsByMac(user: User, mac: string) {

--- a/src/modules/backups/backup.usecase.ts
+++ b/src/modules/backups/backup.usecase.ts
@@ -1,9 +1,34 @@
-import { Injectable } from '@nestjs/common';
+import {
+  BadRequestException,
+  ConflictException,
+  forwardRef,
+  Inject,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
 import { SequelizeBackupRepository } from './backup.repository';
+import { User } from '../user/user.domain';
+import { BridgeService } from './../../externals/bridge/bridge.service';
+import { CryptoService } from './../../externals/crypto/crypto.service';
+import { FolderUseCases } from '../folder/folder.usecase';
+import { FileUseCases } from '../file/file.usecase';
+import { Folder, FolderAttributes } from '../folder/folder.domain';
+import { BackupModel } from './models/backup.model';
+import { CreateDeviceDto } from './dto/create-device.dto';
+import { SequelizeUserRepository } from '../user/user.repository';
 
 @Injectable()
 export class BackupUseCase {
-  constructor(private readonly backupRepository: SequelizeBackupRepository) {}
+  constructor(
+    private readonly backupRepository: SequelizeBackupRepository,
+    private readonly networkService: BridgeService,
+    private readonly userRepository: SequelizeUserRepository,
+    private readonly cryptoService: CryptoService,
+    @Inject(forwardRef(() => FolderUseCases))
+    private readonly folderUsecases: FolderUseCases,
+    @Inject(forwardRef(() => FileUseCases))
+    private readonly fileUsecases: FileUseCases,
+  ) {}
 
   async deleteUserBackups(userId: number) {
     const [deletedBackups, deletedDevices] = await Promise.all([
@@ -12,5 +37,203 @@ export class BackupUseCase {
     ]);
 
     return { deletedBackups, deletedDevices };
+  }
+
+  async getAllDevices(user: User) {
+    return this.backupRepository.findAllDevices(user);
+  }
+
+  async createDevice(user: User, mac: string, payload: CreateDeviceDto) {
+    const { platform, deviceName } = payload;
+    const exists = await this.backupRepository.findDeviceByUserAndMac(
+      user,
+      mac,
+    );
+    if (exists) {
+      return exists;
+    }
+
+    return this.backupRepository.createDevice(user, {
+      mac,
+      name: deviceName,
+      platform,
+    });
+  }
+
+  async deleteDevice(user: User, deviceId: number) {
+    const device = await this.backupRepository.findDeviceByUserAndId(
+      user,
+      deviceId,
+    );
+    if (!device) {
+      throw new NotFoundException('Device not found');
+    }
+
+    await Promise.all(
+      device.backups.map((backup: BackupModel) => {
+        if (backup.fileId) {
+          return this.networkService.deleteFile(
+            user,
+            backup.bucket,
+            backup.fileId,
+          );
+        }
+      }),
+    );
+
+    await this.backupRepository.deleteBackupsBy({ deviceId });
+
+    return this.backupRepository.deleteDevicesBy({
+      userId: user.id,
+      id: deviceId,
+    });
+  }
+
+  async activate(user: User) {
+    const { email, userId, backupsBucket } = user;
+    if (backupsBucket) {
+      return { backupsBucket };
+    }
+    const bucket = await this.networkService.createBucket(email, userId);
+    await this.userRepository.updateByUuid(user.uuid, {
+      backupsBucket: bucket.id,
+    });
+    return { backupsBucket: bucket.id };
+  }
+
+  async createDeviceAsFolder(user: User, deviceName: string) {
+    let bucket = user.backupsBucket;
+    if (!bucket) {
+      const { backupsBucket } = await this.activate(user);
+      bucket = backupsBucket;
+    }
+
+    const encryptedName = this.cryptoService.encryptName(deviceName, bucket);
+    const folders = await this.folderUsecases.getFolders(user.id, {
+      bucket,
+      name: encryptedName,
+      deleted: false,
+      removed: false,
+    });
+
+    if (folders.length > 0) {
+      throw new ConflictException('Folder with the same name already exists');
+    }
+
+    return this.folderUsecases.createFolderDevice(user, {
+      name: encryptedName,
+      plainName: deviceName,
+      bucket,
+    });
+  }
+
+  async getDevicesAsFolder(user: User) {
+    const { backupsBucket } = user;
+    if (!backupsBucket) {
+      throw new BadRequestException('Backups is not activated for this user');
+    }
+
+    const folders = await this.folderUsecases.getFoldersByUserId(user.id, {
+      bucket: backupsBucket,
+    });
+
+    return Promise.all(
+      folders.map(async (folder) => ({
+        ...folder,
+        plainName: this.cryptoService.decryptName(folder.name, folder.bucket),
+        hasBackups: !(await this.isFolderEmpty(user, folder)),
+        lastBackupAt: folder.updatedAt,
+      })),
+    );
+  }
+
+  async getDeviceAsFolder(user: User, folderId: FolderAttributes['id']) {
+    const folder = await this.folderUsecases.getFolderByUserId(
+      folderId,
+      user.id,
+    );
+    if (!folder) {
+      throw new NotFoundException('Folder not found');
+    }
+
+    return {
+      ...folder,
+      hasBackups: !(await this.isFolderEmpty(user, folder)),
+      lastBackupAt: folder.updatedAt,
+    };
+  }
+
+  async updateDeviceAsFolder(
+    user: User,
+    folderId: FolderAttributes['id'],
+    deviceName: string,
+  ) {
+    const folder = await this.folderUsecases.getFolderByUserId(
+      folderId,
+      user.id,
+    );
+    if (!folder) {
+      throw new NotFoundException('Folder not found');
+    }
+
+    const encryptedName = this.cryptoService.encryptName(
+      deviceName,
+      folder.bucket,
+    );
+
+    return this.folderUsecases.updateByFolderId(folder, {
+      name: encryptedName,
+      plainName: deviceName,
+    });
+  }
+
+  async createBackup(user: User, payload: Partial<BackupModel>) {
+    const { deviceId } = payload;
+    const device = await this.backupRepository.findDeviceByUserAndId(
+      user,
+      deviceId,
+    );
+    if (!device) {
+      throw new NotFoundException('Device not found');
+    }
+
+    return this.backupRepository.createBackup(user, payload);
+  }
+
+  async getBackupsByMac(user: User, mac: string) {
+    const device = await this.backupRepository.findDeviceByUserAndMac(
+      user,
+      mac,
+    );
+    if (!device) {
+      throw new NotFoundException('Device not found');
+    }
+
+    return this.backupRepository.findAllBackupsByUserAndDevice(user, device.id);
+  }
+
+  async deleteBackup(user: User, backupId: number) {
+    const backup = await this.backupRepository.findBackupByUserAndId(
+      user,
+      backupId,
+    );
+    if (!backup) {
+      throw new NotFoundException('Backup not found');
+    }
+
+    return this.backupRepository.deleteBackupByUserAndId(user, backupId);
+  }
+
+  async isFolderEmpty(user: User, folder: Folder) {
+    const folders = await this.folderUsecases.getFoldersByParentId(
+      folder.id,
+      user.id,
+    );
+    const files = await this.fileUsecases.getByFolderAndUser(
+      folder.id,
+      user.id,
+      { deleted: false },
+    );
+    return folders.length === 0 && files.length === 0;
   }
 }

--- a/src/modules/backups/device.domain.ts
+++ b/src/modules/backups/device.domain.ts
@@ -1,0 +1,39 @@
+import { DeviceAttributes } from './models/device.attributes';
+
+export class Device implements DeviceAttributes {
+  id?: number;
+  mac: string;
+  userId: number;
+  name?: string;
+  platform?: string;
+  createdAt?: Date;
+  updatedAt?: Date;
+  backups?: any[];
+
+  constructor(attributes: DeviceAttributes) {
+    this.id = attributes.id;
+    this.mac = attributes.mac;
+    this.userId = attributes.userId;
+    this.name = attributes.name;
+    this.platform = attributes.platform;
+    this.createdAt = attributes.createdAt;
+    this.updatedAt = attributes.updatedAt;
+    this.backups = attributes.backups;
+  }
+
+  static build(attributes: Partial<DeviceAttributes>): Device {
+    return new Device(attributes as DeviceAttributes);
+  }
+
+  toJson(): DeviceAttributes {
+    return {
+      id: this.id,
+      mac: this.mac,
+      userId: this.userId,
+      name: this.name,
+      platform: this.platform,
+      createdAt: this.createdAt,
+      updatedAt: this.updatedAt,
+    };
+  }
+}

--- a/src/modules/backups/dto/create-backup.dto.ts
+++ b/src/modules/backups/dto/create-backup.dto.ts
@@ -1,0 +1,25 @@
+import {
+  IsString,
+  IsNumber,
+  IsOptional,
+  IsUUID,
+  IsBoolean,
+  IsDate,
+} from 'class-validator';
+
+export class CreateBackupDto {
+  @IsNumber()
+  deviceId: number;
+
+  @IsString()
+  path: string;
+
+  @IsNumber()
+  interval: number;
+
+  @IsBoolean()
+  enabled: boolean;
+
+  @IsString()
+  encrypt_version: string;
+}

--- a/src/modules/backups/dto/create-device-as-folder.dto.ts
+++ b/src/modules/backups/dto/create-device-as-folder.dto.ts
@@ -1,0 +1,6 @@
+import { IsString } from 'class-validator';
+
+export class CreateDeviceAsFolderDto {
+  @IsString()
+  deviceName: string;
+}

--- a/src/modules/backups/dto/create-device.dto.ts
+++ b/src/modules/backups/dto/create-device.dto.ts
@@ -1,0 +1,9 @@
+import { IsString } from 'class-validator';
+
+export class CreateDeviceDto {
+  @IsString()
+  deviceName: string;
+
+  @IsString()
+  platform: string;
+}

--- a/src/modules/backups/models/backup.attributes.ts
+++ b/src/modules/backups/models/backup.attributes.ts
@@ -1,0 +1,16 @@
+export interface BackupAttributes {
+  id?: number;
+  userId: number;
+  path?: string;
+  fileId?: string;
+  deviceId: number;
+  hash?: string;
+  interval?: number;
+  size?: number;
+  bucket?: string;
+  lastBackupAt?: Date;
+  enabled?: boolean;
+  encrypt_version?: string;
+  createdAt?: Date;
+  updatedAt?: Date;
+}

--- a/src/modules/backups/models/backup.model.ts
+++ b/src/modules/backups/models/backup.model.ts
@@ -11,12 +11,14 @@ import {
   BelongsTo,
 } from 'sequelize-typescript';
 import { UserModel } from '../../user/user.model';
+import { DeviceModel } from './device.model';
+import { BackupAttributes } from './backup.attributes';
 
 @Table({
   timestamps: true,
   tableName: 'backups',
 })
-export class BackupModel extends Model {
+export class BackupModel extends Model implements BackupAttributes {
   @PrimaryKey
   @AutoIncrement
   @Column
@@ -25,13 +27,6 @@ export class BackupModel extends Model {
   @ForeignKey(() => UserModel)
   @Column
   userId: number;
-
-  @Column(DataType.STRING)
-  planId: string;
-
-  @Column(DataType.UUID)
-  uuid: string;
-
   @AllowNull
   @Column(DataType.TEXT)
   path: string;
@@ -40,8 +35,8 @@ export class BackupModel extends Model {
   @Column(DataType.STRING(24))
   fileId: string;
 
-  @AllowNull
-  @Column
+  @ForeignKey(() => DeviceModel)
+  @Column(DataType.INTEGER)
   deviceId: number;
 
   @AllowNull
@@ -70,7 +65,7 @@ export class BackupModel extends Model {
 
   @AllowNull
   @Column(DataType.STRING)
-  encryptVersion: string;
+  encrypt_version: string;
 
   @AllowNull
   @Column(DataType.DATE)

--- a/src/modules/backups/models/device.attributes.ts
+++ b/src/modules/backups/models/device.attributes.ts
@@ -1,0 +1,10 @@
+export interface DeviceAttributes {
+  id?: number;
+  mac: string;
+  userId: number;
+  name?: string;
+  platform?: string;
+  createdAt?: Date;
+  updatedAt?: Date;
+  backups?: any[];
+}

--- a/src/modules/backups/models/device.model.ts
+++ b/src/modules/backups/models/device.model.ts
@@ -9,14 +9,17 @@ import {
   ForeignKey,
   BelongsTo,
   Index,
+  HasMany,
 } from 'sequelize-typescript';
 import { UserModel } from '../../user/user.model';
+import { BackupModel } from './backup.model';
+import { DeviceAttributes } from './device.attributes';
 
 @Table({
   timestamps: true,
   tableName: 'devices',
 })
-export class DeviceModel extends Model {
+export class DeviceModel extends Model implements DeviceAttributes {
   @PrimaryKey
   @AutoIncrement
   @Column
@@ -49,4 +52,10 @@ export class DeviceModel extends Model {
 
   @BelongsTo(() => UserModel)
   user: UserModel;
+
+  @HasMany(() => BackupModel, {
+    foreignKey: 'deviceId',
+    as: 'backups',
+  })
+  backups: BackupModel[];
 }

--- a/src/modules/folder/folder.repository.ts
+++ b/src/modules/folder/folder.repository.ts
@@ -519,6 +519,17 @@ export class SequelizeFolderRepository implements FolderRepository {
     return this.toDomain(folder);
   }
 
+  async createFolder(
+    userId: UserAttributes['id'],
+    folderData: Partial<FolderAttributes>,
+  ) {
+    const folder = await this.folderModel.create({
+      ...folderData,
+      userId,
+    });
+    return this.toDomain(folder);
+  }
+
   async bulkCreate(
     folders: {
       userId: UserAttributes['id'];

--- a/src/modules/folder/folder.usecase.spec.ts
+++ b/src/modules/folder/folder.usecase.spec.ts
@@ -374,6 +374,8 @@ describe('FolderUseCases', () => {
         },
       });
 
+      jest.spyOn(cryptoService, 'decryptName').mockReturnValue('');
+
       expect(() => service.decryptFolderName(folder)).toThrow(
         'Unable to decrypt folder name',
       );

--- a/src/modules/folder/folder.usecase.ts
+++ b/src/modules/folder/folder.usecase.ts
@@ -242,16 +242,11 @@ export class FolderUseCases {
     return folders;
   }
 
-  async getFoldersToUser(
+  async getFoldersByUserId(
     userId: FolderAttributes['userId'],
-    { deleted }: FolderOptions = { deleted: false },
-  ) {
-    const folders = await this.folderRepository.findAll({
-      userId,
-      deleted,
-    });
-
-    return folders;
+    where: Partial<FolderAttributes>,
+  ): Promise<Folder[]> {
+    return this.folderRepository.findAll({ userId, ...where });
   }
 
   async createRootFolder(
@@ -330,6 +325,13 @@ export class FolderUseCases {
         };
       }),
     );
+  }
+
+  async createFolderDevice(user: User, folderData: Partial<FolderAttributes>) {
+    if (!folderData.name || !folderData.bucket) {
+      throw new BadRequestException('Folder name and bucket are required');
+    }
+    return this.folderRepository.createFolder(user.id, folderData);
   }
 
   async updateFolderMetaData(
@@ -936,5 +938,12 @@ export class FolderUseCases {
       path,
       rootFolder.uuid,
     );
+  }
+
+  async updateByFolderId(
+    folder: Folder,
+    folderData: Partial<FolderAttributes>,
+  ): Promise<Folder> {
+    return this.folderRepository.updateByFolderId(folder.id, folderData);
   }
 }

--- a/src/modules/user/user.controller.spec.ts
+++ b/src/modules/user/user.controller.spec.ts
@@ -902,4 +902,38 @@ describe('User Controller', () => {
       expect(userUseCases.getUserUsage).toHaveBeenCalledWith(user);
     });
   });
+
+  describe('limit', () => {
+    const userMocked = newUser();
+    it('When a valid user is provided, then it should return the space limit', async () => {
+      const maxSpaceBytes = 1000000000;
+      jest
+        .spyOn(userUseCases, 'getSpaceLimit')
+        .mockResolvedValue(maxSpaceBytes);
+
+      const result = await userController.limit(userMocked);
+
+      expect(userUseCases.getSpaceLimit).toHaveBeenCalledWith(userMocked);
+      expect(result).toEqual({ maxSpaceBytes });
+    });
+
+    it('When an error occurs while getting the space limit, then it should log the error and throw it', async () => {
+      const errorMessage = 'Error getting space limit';
+      jest
+        .spyOn(userUseCases, 'getSpaceLimit')
+        .mockRejectedValue(new Error(errorMessage));
+      const consoleErrorSpy = jest
+        .spyOn(Logger, 'error')
+        .mockImplementation(() => {});
+
+      await expect(userController.limit(userMocked)).rejects.toThrow(
+        errorMessage,
+      );
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining(
+          `[USER/SPACE_LIMIT] Error getting space limit for user: ${userMocked.id}. Error: ${errorMessage}`,
+        ),
+      );
+    });
+  });
 });

--- a/src/modules/user/user.controller.ts
+++ b/src/modules/user/user.controller.ts
@@ -982,4 +982,24 @@ export class UserController {
 
     return usage;
   }
+
+  @Get('/limit')
+  @HttpCode(200)
+  @ApiBearerAuth()
+  @ApiOkResponse({
+    description: 'Get user space limit',
+  })
+  async limit(@UserDecorator() user: User) {
+    try {
+      const maxSpaceBytes = await this.userUseCases.getSpaceLimit(user);
+      return { maxSpaceBytes };
+    } catch (err) {
+      Logger.error(
+        `[USER/SPACE_LIMIT] Error getting space limit for user: ${
+          user.id
+        }. Error: ${(err as Error).message}`,
+      );
+      throw err;
+    }
+  }
 }

--- a/src/modules/user/user.module.ts
+++ b/src/modules/user/user.module.ts
@@ -76,7 +76,7 @@ import { CacheManagerModule } from '../cache-manager/cache-manager.module';
     SecurityModule,
     forwardRef(() => FeatureLimitModule),
     forwardRef(() => WorkspacesModule),
-    BackupModule,
+    forwardRef(() => BackupModule),
     CacheManagerModule,
   ],
   controllers: [UserController],

--- a/src/modules/user/user.usecase.spec.ts
+++ b/src/modules/user/user.usecase.spec.ts
@@ -2137,6 +2137,32 @@ describe('User use cases', () => {
       );
     });
   });
+
+  describe('getSpaceLimit', () => {
+    it('When a valid user is provided, then it should return the space limit', async () => {
+      const expectedLimit = 1000000000;
+      jest.spyOn(bridgeService, 'getLimit').mockResolvedValue(expectedLimit);
+
+      const result = await userUseCases.getSpaceLimit(user);
+
+      expect(bridgeService.getLimit).toHaveBeenCalledWith(
+        user.bridgeUser,
+        user.userId,
+      );
+      expect(result).toEqual(expectedLimit);
+    });
+
+    it('When an error occurs while getting the space limit, then it should throw an error', async () => {
+      const errorMessage = 'Error getting space limit';
+      jest
+        .spyOn(bridgeService, 'getLimit')
+        .mockRejectedValue(new Error(errorMessage));
+
+      await expect(userUseCases.getSpaceLimit(user)).rejects.toThrow(
+        errorMessage,
+      );
+    });
+  });
 });
 
 const createTestingModule = (): Promise<TestingModule> => {

--- a/src/modules/user/user.usecase.ts
+++ b/src/modules/user/user.usecase.ts
@@ -1620,4 +1620,8 @@ export class UserUseCases {
       }
     }
   }
+
+  getSpaceLimit(user: User): Promise<number> {
+    return this.networkService.getLimit(user.bridgeUser, user.userId);
+  }
 }


### PR DESCRIPTION
### Unit Test Information
- There are over 500 lines of code in tests(*.spec.ts)
- There are new files that don't require testing
---
### Updates
- Migrate `limit` and `backup deviceAsFolder` endpoints

---

### Endpoints 
- `GET` _/api/limit_ `server -> wip` _/api/users/limit_

- `POST` _/api/backup/activate `server_ -> wip` _/api/backup/activate_
- `POST` _/api/backup/deviceAsFolder_ `server -> wip` _/api/backup/deviceAsFolder_
```
Body { "deviceName": string }
```
- `GET` _/api/backup/deviceAsFolder_ `server -> wip` _/api/backup/deviceAsFolder_

- `GET` _/api/backup/deviceAsFolder/:id_ `server -> wip` _/api/backup/deviceAsFolder/:uuid_
Param: `:uuid` == Folder.uuid`

- `PATCH` _/api/backup/deviceAsFolder/:id_ `server -> wip` _/api/backup/deviceAsFolder/:uuid_
Param: `:uuid` == Folder.uuid`
```
Body { "deviceName": string }
```
