### PR TITLE
[PB-3705] Feat: update triggers for lookup table

### DIFF
--- a/migrations/20250311054626-update-triggers-for-lookup-table.js
+++ b/migrations/20250311054626-update-triggers-for-lookup-table.js
@@ -1,0 +1,72 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.sequelize.query(`
+      DROP TRIGGER IF EXISTS delete_file_from_look_up_table_after_file_deleted ON files;
+      DROP FUNCTION IF EXISTS delete_file_from_look_up_table();
+
+      DROP TRIGGER IF EXISTS delete_folder_from_look_up_table_after_folder_deleted ON folders;
+      DROP FUNCTION IF EXISTS delete_folder_from_look_up_table();
+    `);
+
+    await queryInterface.sequelize.query(`
+      CREATE OR REPLACE FUNCTION delete_file_from_look_up_table()
+      RETURNS TRIGGER AS $$
+      DECLARE
+        user_uuid VARCHAR;
+      BEGIN
+        SELECT uuid INTO user_uuid FROM users WHERE id = OLD.user_id;
+
+        -- Delete the lookup entry
+        DELETE FROM look_up
+        WHERE
+          item_type = 'file' 
+          AND item_id = OLD.uuid 
+          AND user_id = user_uuid;
+
+        RETURN OLD;
+      END;
+      $$ LANGUAGE 'plpgsql';
+
+      CREATE TRIGGER delete_file_from_look_up_table_after_file_deleted
+      AFTER DELETE ON files
+      FOR EACH ROW
+      EXECUTE FUNCTION delete_file_from_look_up_table();
+
+      CREATE OR REPLACE FUNCTION delete_folder_from_look_up_table()
+      RETURNS TRIGGER AS $$
+      DECLARE
+        user_uuid VARCHAR;
+      BEGIN
+        SELECT uuid INTO user_uuid FROM users WHERE id = OLD.user_id;
+
+        -- Delete the lookup entry
+        DELETE FROM look_up
+        WHERE
+          item_type = 'folder' 
+          AND item_id = OLD.uuid 
+          AND user_id = user_uuid;
+
+        RETURN OLD;
+      END;
+      $$ LANGUAGE 'plpgsql';
+
+      CREATE TRIGGER delete_folder_from_look_up_table_after_folder_deleted
+      AFTER DELETE ON folders
+      FOR EACH ROW
+      EXECUTE FUNCTION delete_folder_from_look_up_table();
+    `);
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.sequelize.query(`
+      DROP TRIGGER IF EXISTS delete_file_from_look_up_table_after_file_deleted ON files;
+      DROP FUNCTION IF EXISTS delete_file_from_look_up_table();
+
+      DROP TRIGGER IF EXISTS delete_folder_from_look_up_table_after_folder_deleted ON folders;
+      DROP FUNCTION IF EXISTS delete_folder_from_look_up_table();
+    `);
+  },
+};


### PR DESCRIPTION
### Run script
- The trigger that allow to delete files and folders in the lookup table has been updated.
---
### Updates
- Update trigger to allow deleting files and folders in the lookUp table. The user is searched for by taking the information of the file and folder to be deleted. If the user is not searched for, a File/Folder cannot be deleted because `look_up.user_id` is a `UUID`, while `file.user_id` and `folder.user_id` are `INTEGER`.