### PR TITLE
[PB-4108] Feat: migrate thumbnail endpoint

### DIFF
--- a/src/modules/file/file.controller.ts
+++ b/src/modules/file/file.controller.ts
@@ -48,6 +48,9 @@ import { Requester } from '../auth/decorators/requester.decorator';
 import { ExtendedHttpExceptionFilter } from '../../common/http-exception-filter-extended.exception';
 import { FileDto } from './dto/responses/file.dto';
 import { UploadGuard } from './guards/upload.guard';
+import { ThumbnailDto } from '../thumbnail/dto/thumbnail.dto';
+import { CreateThumbnailDto } from '../thumbnail/dto/create-thumbnail.dto';
+import { ThumbnailUseCases } from '../thumbnail/thumbnail.usecase';
 
 const filesStatuses = ['ALL', 'EXISTS', 'TRASHED', 'DELETED'] as const;
 
@@ -64,6 +67,7 @@ export class FileController {
   constructor(
     private readonly fileUseCases: FileUseCases,
     private readonly storageNotificationService: StorageNotificationService,
+    private readonly thumbnailUseCases: ThumbnailUseCases,
   ) {}
 
   @Post('/')
@@ -444,5 +448,20 @@ export class FileController {
         })} STACK: ${err.stack || 'NO STACK'}`,
       );
     }
+  }
+
+  @Post('/thumbnail')
+  @ApiOperation({
+    summary: 'Create Thumbnail',
+  })
+  @ApiOkResponse({ type: ThumbnailDto })
+  @ApiBearerAuth()
+  @RequiredSharingPermissions(SharingActionName.UploadFile)
+  @UseGuards(SharingPermissionsGuard)
+  async createThumbnail(
+    @UserDecorator() user: User,
+    @Body() createThumbnailDto: CreateThumbnailDto,
+  ): Promise<ThumbnailDto> {
+    return this.thumbnailUseCases.createThumbnail(user, createThumbnailDto);
   }
 }

--- a/src/modules/thumbnail/dto/create-thumbnail.dto.ts
+++ b/src/modules/thumbnail/dto/create-thumbnail.dto.ts
@@ -1,0 +1,70 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsNumber, IsString } from 'class-validator';
+
+export class CreateThumbnailDto {
+  @ApiProperty({
+    description: 'The ID of the file',
+    example: 12345,
+  })
+  @IsNotEmpty()
+  @IsNumber()
+  fileId: number;
+
+  @ApiProperty({
+    description: 'The type of the file',
+    example: 'text',
+  })
+  @IsNotEmpty()
+  @IsString()
+  type: string;
+
+  @ApiProperty({
+    description: 'The size of the file in bytes',
+    example: 123456789,
+  })
+  @IsNotEmpty()
+  @IsNumber()
+  size: number;
+
+  @ApiProperty({
+    description: 'The max width of the file',
+    type: 'number',
+    example: 123456789,
+  })
+  @IsNotEmpty()
+  @IsNumber()
+  maxWidth: number;
+
+  @ApiProperty({
+    description: 'The max height of the file',
+    type: 'number',
+    example: 123456789,
+  })
+  @IsNotEmpty()
+  @IsNumber()
+  maxHeight: number;
+
+  @ApiProperty({
+    description: 'The bucket id where the file is stored',
+    example: 'my-bucket',
+  })
+  @IsNotEmpty()
+  @IsString()
+  bucketId: string;
+
+  @ApiProperty({
+    description: 'The id of file in the bucket',
+    example: 'my-bucket',
+  })
+  @IsNotEmpty()
+  @IsString()
+  bucketFile: string;
+
+  @ApiProperty({
+    description: 'The encryption version used for the file',
+    example: '03-aes',
+  })
+  @IsNotEmpty()
+  @IsString()
+  encryptVersion: string;
+}

--- a/src/modules/thumbnail/dto/thumbnail.dto.ts
+++ b/src/modules/thumbnail/dto/thumbnail.dto.ts
@@ -1,13 +1,26 @@
+import { ApiProperty } from '@nestjs/swagger';
+
 export class ThumbnailDto {
+  @ApiProperty()
   id: number;
+  @ApiProperty()
   fileId: number;
-  type: string;
-  size: number;
-  bucketId: string;
-  bucketFile: string;
-  encryptVersion: string;
-  createdAt: Date;
-  updatedAt: Date;
+  @ApiProperty()
   maxWidth: number;
+  @ApiProperty()
   maxHeight: number;
+  @ApiProperty()
+  type: string;
+  @ApiProperty()
+  size: number;
+  @ApiProperty()
+  bucketId: string;
+  @ApiProperty()
+  bucketFile: string;
+  @ApiProperty()
+  encryptVersion: string;
+  @ApiProperty()
+  createdAt: Date;
+  @ApiProperty()
+  updatedAt: Date;
 }

--- a/src/modules/thumbnail/thumbnail.model.ts
+++ b/src/modules/thumbnail/thumbnail.model.ts
@@ -6,6 +6,7 @@ import {
   ForeignKey,
   DataType,
   BelongsTo,
+  AutoIncrement,
 } from 'sequelize-typescript';
 
 import { ThumbnailAttributes } from './thumbnail.attributes';
@@ -18,6 +19,7 @@ import { FileModel } from '../file/file.model';
 })
 export class ThumbnailModel extends Model implements ThumbnailAttributes {
   @PrimaryKey
+  @AutoIncrement
   @Column
   id: number;
 

--- a/src/modules/thumbnail/thumbnail.module.ts
+++ b/src/modules/thumbnail/thumbnail.module.ts
@@ -2,9 +2,22 @@ import { Module } from '@nestjs/common';
 import { SequelizeModule } from '@nestjs/sequelize';
 import { SequelizeThumbnailRepository } from './thumbnail.repository';
 import { ThumbnailModel } from './thumbnail.model';
+import { ThumbnailUseCases } from './thumbnail.usecase';
+import { BridgeModule } from '../../externals/bridge/bridge.module';
+import { FileModel } from '../file/file.model';
+import { SequelizeFileRepository } from '../file/file.repository';
+import { ShareModel } from '../share/share.repository';
 
 @Module({
-  imports: [SequelizeModule.forFeature([ThumbnailModel])],
-  providers: [SequelizeThumbnailRepository],
+  imports: [
+    SequelizeModule.forFeature([ThumbnailModel, FileModel, ShareModel]),
+    BridgeModule,
+  ],
+  providers: [
+    SequelizeThumbnailRepository,
+    SequelizeFileRepository,
+    ThumbnailUseCases,
+  ],
+  exports: [ThumbnailUseCases, SequelizeThumbnailRepository],
 })
 export class ThumbnailModule {}

--- a/src/modules/thumbnail/thumbnail.repository.spec.ts
+++ b/src/modules/thumbnail/thumbnail.repository.spec.ts
@@ -1,0 +1,121 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getModelToken } from '@nestjs/sequelize';
+import { SequelizeThumbnailRepository } from './thumbnail.repository';
+import { ThumbnailModel } from './thumbnail.model';
+import { createMock } from '@golevelup/ts-jest';
+
+describe('SequelizeThumbnailRepository', () => {
+  let repository: SequelizeThumbnailRepository;
+  let thumbnailModel: typeof ThumbnailModel;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [SequelizeThumbnailRepository],
+    })
+      .useMocker(() => createMock())
+      .compile();
+
+    repository = module.get<SequelizeThumbnailRepository>(
+      SequelizeThumbnailRepository,
+    );
+    thumbnailModel = module.get<typeof ThumbnailModel>(
+      getModelToken(ThumbnailModel),
+    );
+  });
+
+  describe('findById', () => {
+    it('When id exists then return the corresponding thumbnail', async () => {
+      const mockThumbnail = { id: 1, fileId: 2 } as ThumbnailModel;
+      jest.spyOn(thumbnailModel, 'findByPk').mockResolvedValue(mockThumbnail);
+
+      const result = await repository.findById(1);
+
+      expect(result).toEqual(expect.objectContaining({ id: 1, fileId: 2 }));
+      expect(thumbnailModel.findByPk).toHaveBeenCalledWith(1);
+    });
+
+    it('When id does not exist then return null', async () => {
+      jest.spyOn(thumbnailModel, 'findByPk').mockResolvedValue(null);
+
+      const result = await repository.findById(999);
+
+      expect(result).toBeNull();
+      expect(thumbnailModel.findByPk).toHaveBeenCalledWith(999);
+    });
+  });
+
+  describe('findByFileId', () => {
+    it('When fileId exists then return the corresponding thumbnail', async () => {
+      const mockThumbnail = { id: 1, fileId: 2 } as ThumbnailModel;
+      jest.spyOn(thumbnailModel, 'findOne').mockResolvedValue(mockThumbnail);
+
+      const result = await repository.findByFileId(2);
+
+      expect(result).toEqual(expect.objectContaining({ id: 1, fileId: 2 }));
+      expect(thumbnailModel.findOne).toHaveBeenCalledWith({
+        where: { file_id: 2 },
+      });
+    });
+
+    it('When fileId does not exist then return null', async () => {
+      jest.spyOn(thumbnailModel, 'findOne').mockResolvedValue(null);
+
+      const result = await repository.findByFileId(999);
+
+      expect(result).toBeNull();
+      expect(thumbnailModel.findOne).toHaveBeenCalledWith({
+        where: { file_id: 999 },
+      });
+    });
+  });
+
+  describe('create', () => {
+    it('When valid data is provided then create and return the thumbnail', async () => {
+      const newThumbnail = { fileId: 2, type: 'image' } as any;
+      const mockThumbnail = { id: 1, ...newThumbnail } as ThumbnailModel;
+      jest.spyOn(thumbnailModel, 'create').mockResolvedValue(mockThumbnail);
+
+      const result = await repository.create(newThumbnail);
+
+      expect(result).toEqual(expect.objectContaining({ id: 1, fileId: 2 }));
+      expect(thumbnailModel.create).toHaveBeenCalledWith(newThumbnail);
+    });
+  });
+
+  describe('update', () => {
+    it('When valid data is provided then update the thumbnail', async () => {
+      const updateData = { type: 'video' };
+      const where = { id: 1 };
+      jest.spyOn(thumbnailModel, 'update').mockResolvedValue([1]);
+
+      await repository.update(updateData, where);
+
+      expect(thumbnailModel.update).toHaveBeenCalledWith(updateData, {
+        where,
+      });
+    });
+  });
+
+  describe('deleteById', () => {
+    it('When id exists then delete the thumbnail', async () => {
+      jest.spyOn(thumbnailModel, 'destroy').mockResolvedValue(1);
+
+      await repository.deleteById(1);
+
+      expect(thumbnailModel.destroy).toHaveBeenCalledWith({
+        where: { id: 1 },
+      });
+    });
+  });
+
+  describe('deleteBy', () => {
+    it('When condition matches then delete the thumbnails', async () => {
+      const where = { fileId: 2 };
+      jest.spyOn(thumbnailModel, 'destroy').mockResolvedValue(1);
+
+      await repository.deleteBy(where);
+
+      expect(thumbnailModel.destroy).toHaveBeenCalledWith({ where });
+    });
+  });
+});

--- a/src/modules/thumbnail/thumbnail.usecase.spec.ts
+++ b/src/modules/thumbnail/thumbnail.usecase.spec.ts
@@ -1,0 +1,191 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ForbiddenException, Logger, NotFoundException } from '@nestjs/common';
+import { ThumbnailUseCases } from './thumbnail.usecase';
+import { SequelizeThumbnailRepository } from './thumbnail.repository';
+import { BridgeService } from '../../externals/bridge/bridge.service';
+import { newUser } from './../../../test/fixtures';
+import { CreateThumbnailDto } from './dto/create-thumbnail.dto';
+import { createMock } from '@golevelup/ts-jest';
+import { SequelizeFileRepository } from '../file/file.repository';
+
+describe('ThumbnailUseCases', () => {
+  let thumbnailUseCases: ThumbnailUseCases;
+  let thumbnailRepository: SequelizeThumbnailRepository;
+  let fileRepository: SequelizeFileRepository;
+  let networkService: BridgeService;
+
+  const userMocked = newUser();
+
+  const createThumbnailDto: CreateThumbnailDto = {
+    fileId: 123456,
+    bucketId: 'bucketId',
+  } as any;
+
+  const existingThumbnail = {
+    id: 1,
+    fileId: 123456,
+    bucketFile: 'existingBucketFile',
+  } as any;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [ThumbnailUseCases],
+    })
+      .useMocker(() => createMock())
+      .compile();
+
+    thumbnailUseCases = module.get<ThumbnailUseCases>(ThumbnailUseCases);
+    thumbnailRepository = module.get<SequelizeThumbnailRepository>(
+      SequelizeThumbnailRepository,
+    );
+    fileRepository = module.get<SequelizeFileRepository>(
+      SequelizeFileRepository,
+    );
+    networkService = module.get<BridgeService>(BridgeService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('createThumbnail', () => {
+    beforeEach(() => {
+      jest.spyOn(fileRepository, 'findOneBy').mockResolvedValue({
+        id: createThumbnailDto.fileId,
+        userId: userMocked.id,
+      } as any);
+    });
+
+    it('When a new thumbnail is created, then it should return the created thumbnail', async () => {
+      jest.spyOn(thumbnailRepository, 'findByFileId').mockResolvedValue(null);
+      jest
+        .spyOn(thumbnailRepository, 'create')
+        .mockResolvedValue(existingThumbnail);
+
+      const result = await thumbnailUseCases.createThumbnail(
+        userMocked,
+        createThumbnailDto,
+      );
+
+      expect(thumbnailRepository.findByFileId).toHaveBeenCalledWith(
+        createThumbnailDto.fileId,
+      );
+      expect(thumbnailRepository.create).toHaveBeenCalledWith({
+        ...createThumbnailDto,
+        createdAt: expect.any(Date),
+        updatedAt: expect.any(Date),
+      });
+      expect(result).toEqual(existingThumbnail);
+    });
+
+    it('When an existing thumbnail is found, then it should delete the existing thumbnail and update it', async () => {
+      jest
+        .spyOn(thumbnailRepository, 'findByFileId')
+        .mockResolvedValue(existingThumbnail);
+      jest.spyOn(networkService, 'deleteFile').mockResolvedValue(undefined);
+      jest
+        .spyOn(thumbnailRepository, 'update')
+        .mockResolvedValue(existingThumbnail);
+
+      const result = await thumbnailUseCases.createThumbnail(
+        userMocked,
+        createThumbnailDto,
+      );
+
+      expect(networkService.deleteFile).toHaveBeenCalledWith(
+        userMocked,
+        createThumbnailDto.bucketId,
+        existingThumbnail.bucketFile,
+      );
+      expect(thumbnailRepository.update).toHaveBeenCalledWith(
+        createThumbnailDto,
+        {
+          id: existingThumbnail.id,
+          fileId: existingThumbnail.fileId,
+        },
+      );
+      expect(result).toEqual(existingThumbnail);
+    });
+
+    it('When an error occurs while deleting the existing thumbnail, it should log the error but continue', async () => {
+      jest
+        .spyOn(thumbnailRepository, 'findByFileId')
+        .mockResolvedValue(existingThumbnail);
+      jest
+        .spyOn(networkService, 'deleteFile')
+        .mockRejectedValue(new Error('Delete error'));
+      jest
+        .spyOn(thumbnailRepository, 'update')
+        .mockResolvedValue(existingThumbnail);
+      const consoleErrorSpy = jest
+        .spyOn(Logger, 'error')
+        .mockImplementation(() => {});
+
+      const result = await thumbnailUseCases.createThumbnail(
+        userMocked,
+        createThumbnailDto,
+      );
+
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Error deleting existent thumbnail'),
+      );
+      expect(thumbnailRepository.update).toHaveBeenCalledWith(
+        createThumbnailDto,
+        {
+          id: existingThumbnail.id,
+          fileId: existingThumbnail.fileId,
+        },
+      );
+      expect(result).toEqual(existingThumbnail);
+    });
+
+    it('When an error occurs while creating a new thumbnail, it should handle the error', async () => {
+      jest.spyOn(thumbnailRepository, 'findByFileId').mockResolvedValue(null);
+      jest
+        .spyOn(thumbnailRepository, 'create')
+        .mockRejectedValue(new Error('Creation error'));
+
+      await expect(
+        thumbnailUseCases.createThumbnail(userMocked, createThumbnailDto),
+      ).rejects.toThrow('Creation error');
+    });
+
+    it('When the file is not found, it should throw a NotFoundException', async () => {
+      jest.spyOn(fileRepository, 'findOneBy').mockResolvedValue(null);
+
+      await expect(
+        thumbnailUseCases.createThumbnail(userMocked, createThumbnailDto),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('When the user does not own the file, it should throw a ForbiddenException', async () => {
+      jest.spyOn(fileRepository, 'findOneBy').mockResolvedValue({
+        id: createThumbnailDto.fileId,
+        userId: 'differentUserId',
+      } as any);
+
+      await expect(
+        thumbnailUseCases.createThumbnail(userMocked, createThumbnailDto),
+      ).rejects.toThrow(ForbiddenException);
+    });
+
+    it('When the file exists and belongs to the user, it should proceed with thumbnail creation', async () => {
+      jest.spyOn(thumbnailRepository, 'findByFileId').mockResolvedValue(null);
+      jest
+        .spyOn(thumbnailRepository, 'create')
+        .mockResolvedValue(existingThumbnail);
+
+      const result = await thumbnailUseCases.createThumbnail(
+        userMocked,
+        createThumbnailDto,
+      );
+
+      expect(thumbnailRepository.create).toHaveBeenCalledWith({
+        ...createThumbnailDto,
+        createdAt: expect.any(Date),
+        updatedAt: expect.any(Date),
+      });
+      expect(result).toEqual(existingThumbnail);
+    });
+  });
+});

--- a/src/modules/thumbnail/thumbnail.usecase.ts
+++ b/src/modules/thumbnail/thumbnail.usecase.ts
@@ -1,0 +1,66 @@
+import {
+  ForbiddenException,
+  Injectable,
+  Logger,
+  NotFoundException,
+} from '@nestjs/common';
+import { BridgeService } from '../../externals/bridge/bridge.service';
+import { User } from '../user/user.domain';
+import { SequelizeThumbnailRepository } from './thumbnail.repository';
+import { CreateThumbnailDto } from './dto/create-thumbnail.dto';
+import { ThumbnailAttributes } from './thumbnail.attributes';
+import { Thumbnail } from './thumbnail.domain';
+import { SequelizeFileRepository } from '../file/file.repository';
+
+@Injectable()
+export class ThumbnailUseCases {
+  constructor(
+    private thumbnailRepository: SequelizeThumbnailRepository,
+    private network: BridgeService,
+    private fileRepository: SequelizeFileRepository,
+  ) {}
+  async createThumbnail(user: User, thumbnail: CreateThumbnailDto) {
+    const file = await this.fileRepository.findOneBy({ id: thumbnail.fileId });
+    if (!file) {
+      throw new NotFoundException('File not found');
+    }
+    if (file.userId !== user.id) {
+      throw new ForbiddenException(
+        'You do not have permission to modify this file',
+      );
+    }
+    const existingThumbnail = await this.thumbnailRepository.findByFileId(
+      thumbnail.fileId,
+    );
+    if (existingThumbnail) {
+      try {
+        await this.network.deleteFile(
+          user,
+          thumbnail.bucketId,
+          existingThumbnail.bucketFile,
+        );
+      } catch (error) {
+        Logger.error(
+          `[THUMBNAIL/CREATE] Error deleting existent thumbnail. Error: ${error.message}`,
+        );
+      }
+      await this.thumbnailRepository.update(thumbnail, {
+        id: existingThumbnail.id,
+        fileId: existingThumbnail.fileId,
+      });
+      return this.thumbnailRepository.findByFileId(thumbnail.fileId);
+    }
+
+    return this.thumbnailRepository.create({
+      ...thumbnail,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+  }
+  async findAll(where: Partial<ThumbnailAttributes>): Promise<Thumbnail[]> {
+    return this.thumbnailRepository.findAll(where);
+  }
+  async deleteBy(where: Partial<ThumbnailAttributes>): Promise<void> {
+    return this.thumbnailRepository.deleteBy(where);
+  }
+}


### PR DESCRIPTION
### Updates
- Migrating storage thumbnail endpoint
---

### Endpoint
- `drive-server` `POST` _/storage/thumbnail_ `->` `wip` _/files/thumbnail_
```
Body
{
    "fileId": 9999,
    "maxWidth": 300,
    "maxHeight": 300,
    "type": "png",
    "size": 19658,
    "bucketId": "BUCKET9a85f433f5079cd72e",
    "bucketFile": "BUCKET2c52b2da002bf29f8a",
    "encryptVersion": VERSION
}
```