### PR TITLE
[PB-4106] Feat: migrate backup and device endpoints

### DIFF
--- a/src/modules/backups/backup.controller.spec.ts
+++ b/src/modules/backups/backup.controller.spec.ts
@@ -128,4 +128,101 @@ describe('BackupController', () => {
       ).rejects.toThrow(NotFoundException);
     });
   });
+
+  describe('getBackupsByMac', () => {
+    const mockResponse = {
+      id: 1,
+      deviceId: 1,
+      path: 'add_path',
+      interval: 1,
+      enabled: true,
+      encrypt_version: '03-aes256',
+    };
+    it('When getBackupsByMac is called, then it should return backups for the device', async () => {
+      jest
+        .spyOn(backupUseCase, 'getBackupsByMac')
+        .mockResolvedValue(mockResponse as any);
+
+      const result = await backupController.getBackupsByMac(
+        userMocked,
+        'mac-address',
+      );
+      expect(result).toEqual(mockResponse);
+    });
+
+    it('When device is not found, then it should throw a NotFoundException', async () => {
+      jest
+        .spyOn(backupUseCase, 'getBackupsByMac')
+        .mockRejectedValue(new NotFoundException());
+
+      await expect(
+        backupController.getBackupsByMac(userMocked, 'mac-address'),
+      ).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('getAllDevices', () => {
+    it('When getAllDevices is called, then it should return all user devices', async () => {
+      const mockResponse = [
+        { id: 1, name: 'Device 1' },
+        { id: 2, name: 'Device 2' },
+      ];
+      jest
+        .spyOn(backupUseCase, 'getAllDevices')
+        .mockResolvedValue(mockResponse as any);
+
+      const result = await backupController.getAllDevices(userMocked);
+      expect(result).toEqual(mockResponse);
+    });
+
+    it('When no devices are found, then it should return an empty array', async () => {
+      const mockResponse = [];
+      jest
+        .spyOn(backupUseCase, 'getAllDevices')
+        .mockResolvedValue(mockResponse as any);
+
+      const result = await backupController.getAllDevices(userMocked);
+      expect(result).toEqual(mockResponse);
+    });
+  });
+
+  describe('deleteDevice', () => {
+    it('When deleteDevice is called with a valid deviceId, then it should return the number of deleted devices', async () => {
+      const mockResponse = 1;
+      jest.spyOn(backupUseCase, 'deleteDevice').mockResolvedValue(mockResponse);
+
+      const result = await backupController.deleteDevice(userMocked, 1);
+      expect(result).toEqual(mockResponse);
+    });
+
+    it('When device is not found, then it should throw a NotFoundException', async () => {
+      jest
+        .spyOn(backupUseCase, 'deleteDevice')
+        .mockRejectedValue(new NotFoundException());
+
+      await expect(
+        backupController.deleteDevice(userMocked, 1),
+      ).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('deleteBackup', () => {
+    it('When deleteBackup is called, then it should return the number of deleted backups', async () => {
+      const mockResponse = 1;
+      jest.spyOn(backupUseCase, 'deleteBackup').mockResolvedValue(mockResponse);
+
+      const result = await backupController.deleteBackup(userMocked, 1);
+      expect(result).toEqual(mockResponse);
+    });
+
+    it('When backup is not found, then it should throw a NotFoundException', async () => {
+      jest
+        .spyOn(backupUseCase, 'deleteBackup')
+        .mockRejectedValue(new NotFoundException());
+
+      await expect(
+        backupController.deleteBackup(userMocked, 1),
+      ).rejects.toThrow(NotFoundException);
+    });
+  });
 });

--- a/src/modules/backups/backup.controller.ts
+++ b/src/modules/backups/backup.controller.ts
@@ -1,4 +1,12 @@
-import { Body, Controller, Get, Param, Patch, Post } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  Patch,
+  Post,
+} from '@nestjs/common';
 import { ApiBearerAuth, ApiOperation, ApiTags } from '@nestjs/swagger';
 import { User as UserDecorator } from '../auth/decorators/user.decorator';
 import { User } from '../user/user.domain';
@@ -68,5 +76,50 @@ export class BackupController {
   @ApiBearerAuth()
   async getDevicesAsFolder(@UserDecorator() user: User) {
     return this.backupUseCases.getDevicesAsFolder(user);
+  }
+
+  @Get('/devices')
+  @ApiOperation({
+    summary: 'Get all user devices',
+  })
+  @ApiBearerAuth()
+  async getAllDevices(@UserDecorator() user: User) {
+    return this.backupUseCases.getAllDevices(user);
+  }
+
+  @Delete('/devices/:deviceId')
+  @ApiOperation({
+    summary: 'Delete user device',
+  })
+  @ApiBearerAuth()
+  async deleteDevice(
+    @UserDecorator() user: User,
+    @Param('deviceId') deviceId: number,
+  ) {
+    return this.backupUseCases.deleteDevice(user, deviceId);
+  }
+
+  @Get('/:mac')
+  @ApiOperation({
+    summary: 'Get backups by mac',
+  })
+  @ApiBearerAuth()
+  async getBackupsByMac(
+    @UserDecorator() user: User,
+    @Param('mac') mac: string,
+  ) {
+    return this.backupUseCases.getBackupsByMac(user, mac);
+  }
+
+  @Delete('/:backupId')
+  @ApiOperation({
+    summary: 'Delete backup',
+  })
+  @ApiBearerAuth()
+  async deleteBackup(
+    @UserDecorator() user: User,
+    @Param('backupId') backupId: number,
+  ) {
+    return this.backupUseCases.deleteBackup(user, backupId);
   }
 }

--- a/src/modules/backups/backup.repository.spec.ts
+++ b/src/modules/backups/backup.repository.spec.ts
@@ -82,6 +82,189 @@ describe('SequelizeBackupRepository', () => {
     });
   });
 
+  describe('findDeviceByUserAndMac', () => {
+    it('When a device exists, then it should return the device', async () => {
+      const mockDevice = {
+        id: 1,
+        name: 'Device 1',
+        mac: 'mac-address',
+        platform: 'linux',
+      };
+      jest
+        .spyOn(deviceModel, 'findOne')
+        .mockResolvedValue({ ...mockDevice, toJSON: () => mockDevice } as any);
+
+      const result = await repository.findDeviceByUserAndMac(
+        userMocked,
+        'mac-address',
+      );
+      expect(result).toEqual(expect.objectContaining(mockDevice));
+    });
+
+    it('When a device does not exist, then it should return null', async () => {
+      jest.spyOn(deviceModel, 'findOne').mockResolvedValue(null);
+
+      const result = await repository.findDeviceByUserAndMac(
+        userMocked,
+        'mac-address',
+      );
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('findAllDevices', () => {
+    it('When no devices exist for the user, then it should return an empty array', async () => {
+      jest.spyOn(deviceModel, 'findAll').mockResolvedValue([]);
+
+      const result = await repository.findAllDevices(userMocked);
+      expect(result).toEqual([]);
+    });
+
+    it('When findAllDevices is called, then it should return all devices with aggregated backup size', async () => {
+      const mockDevice = {
+        id: 1,
+        name: 'Device 1',
+        mac: 'mac-address',
+        platform: 'linux',
+        backups: [
+          { size: 100, toJSON: () => ({ size: 100 }) },
+          { size: 200, toJSON: () => ({ size: 200 }) },
+        ],
+        toJSON: () => mockDevice,
+      };
+      jest.spyOn(deviceModel, 'findAll').mockResolvedValue([mockDevice] as any);
+
+      const result = await repository.findAllDevices(userMocked);
+      expect(result).toHaveLength(1);
+      expect(result[0]).toMatchObject({
+        id: 1,
+        name: 'Device 1',
+        backups: [{ size: 100 }, { size: 200 }],
+      });
+    });
+  });
+
+  describe('findDeviceByUserAndId', () => {
+    it('When a device does not exist, then it should return null', async () => {
+      jest.spyOn(deviceModel, 'findOne').mockResolvedValue(null);
+
+      const result = await repository.findDeviceByUserAndId(userMocked, 1);
+      expect(result).toBeNull();
+    });
+
+    it('When findDeviceByUserAndId is called, then it should return the device with its backups', async () => {
+      const mockDevice = {
+        id: 1,
+        name: 'Device 1',
+        mac: 'mac-address',
+        platform: 'linux',
+        backups: [
+          { id: 1, path: 'path1', toJSON: () => ({ id: 1, path: 'path1' }) },
+        ],
+        toJSON: () => mockDevice,
+      };
+      jest.spyOn(deviceModel, 'findOne').mockResolvedValue(mockDevice as any);
+
+      const result = await repository.findDeviceByUserAndId(userMocked, 1);
+      expect(result).toMatchObject({
+        id: 1,
+        name: 'Device 1',
+        backups: [{ id: 1, path: 'path1' }],
+      });
+    });
+  });
+
+  describe('findAllBackupsByUserAndDevice', () => {
+    it('When findAllBackupsByUserAndDevice is called, then it should return all backups for the device', async () => {
+      const backup1 = {
+        id: 1,
+        deviceId: 1,
+        path: 'add_path',
+        interval: 1,
+        enabled: true,
+        encrypt_version: '03-aes256',
+      };
+      const backup2 = {
+        id: 2,
+        deviceId: 1,
+        path: 'add_path_2',
+        interval: 2,
+        enabled: false,
+        encrypt_version: '03-aes256',
+      };
+      const mockBackups = [
+        { ...backup1, toJSON: () => backup1 },
+        { ...backup2, toJSON: () => backup2 },
+      ];
+      jest.spyOn(backupModel, 'findAll').mockResolvedValue(mockBackups as any);
+
+      const result = await repository.findAllBackupsByUserAndDevice(
+        userMocked,
+        1,
+      );
+      expect(result).toEqual(expect.arrayContaining([backup1, backup2]));
+    });
+
+    it('When no backups exist for the device, then it should return an empty array', async () => {
+      jest.spyOn(backupModel, 'findAll').mockResolvedValue([]);
+
+      const result = await repository.findAllBackupsByUserAndDevice(
+        userMocked,
+        999,
+      );
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('findBackupByUserAndId', () => {
+    it('When a backup exists, then it should return the backup', async () => {
+      const mockBackup = {
+        id: 1,
+        deviceId: 1,
+        path: 'add_path',
+        interval: 1,
+        enabled: true,
+        encrypt_version: '03-aes256',
+      };
+      jest.spyOn(backupModel, 'findOne').mockResolvedValue({
+        ...mockBackup,
+        toJSON: () => mockBackup,
+      } as any);
+
+      const result = await repository.findBackupByUserAndId(userMocked, 1);
+      expect(result).toEqual(expect.objectContaining(mockBackup));
+    });
+
+    it('When a backup does not exist, then it should return null', async () => {
+      jest.spyOn(backupModel, 'findOne').mockResolvedValue(null);
+
+      const result = await repository.findBackupByUserAndId(userMocked, 1);
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('deleteBackupByUserAndId', () => {
+    it('When deleteBackupByUserAndId is called, then it should delete the backup', async () => {
+      jest.spyOn(backupModel, 'destroy').mockResolvedValue(1);
+
+      const result = await repository.deleteBackupByUserAndId(userMocked, 1);
+      expect(result).toBe(1);
+      expect(backupModel.destroy).toHaveBeenCalledWith({
+        where: { userId: userMocked.id, id: 1 },
+      });
+    });
+
+    it('When deleteBackupByUserAndId is called with an invalid ID, then it should return 0', async () => {
+      jest.spyOn(backupModel, 'destroy').mockResolvedValue(0);
+
+      const result = await repository.deleteBackupByUserAndId(userMocked, 999);
+      expect(result).toBe(0);
+      expect(backupModel.destroy).toHaveBeenCalledWith({
+        where: { userId: userMocked.id, id: 999 },
+      });
+    });
+  });
+
   describe('toDomainDevice', () => {
     const deviceModelMock = {
       toJSON: jest.fn().mockReturnValue({

--- a/src/modules/backups/backup.repository.ts
+++ b/src/modules/backups/backup.repository.ts
@@ -4,6 +4,8 @@ import { DeviceModel } from './models/device.model';
 import { BackupModel } from './models/backup.model';
 import { Device } from './device.domain';
 import { Backup } from './backup.domain';
+import { User } from '../user/user.domain';
+import { Sequelize } from 'sequelize';
 
 @Injectable()
 export class SequelizeBackupRepository {
@@ -20,6 +22,64 @@ export class SequelizeBackupRepository {
 
   public async deleteBackupsBy(where: Partial<BackupModel>): Promise<number> {
     return this.backupModel.destroy({ where });
+  }
+
+  async findDeviceByUserAndMac(user: User, mac: string) {
+    const device = await this.deviceModel.findOne({
+      where: { userId: user.id, mac },
+    });
+    return device ? this.toDomainDevice(device) : null;
+  }
+
+  async findAllDevices(user: User) {
+    const devices = await this.deviceModel.findAll({
+      where: { userId: user.id },
+      attributes: {
+        include: [[Sequelize.fn('SUM', Sequelize.col('backups.size')), 'size']],
+      },
+      group: [Sequelize.col('DeviceModel.id'), Sequelize.col('backups.id')],
+      include: [
+        {
+          model: BackupModel,
+          as: 'backups',
+        },
+      ],
+    });
+    return devices.map(this.toDomainDevice);
+  }
+
+  async findDeviceByUserAndId(user: User, deviceId: number) {
+    const device = await this.deviceModel.findOne({
+      where: { userId: user.id, id: deviceId },
+      include: [
+        {
+          model: BackupModel,
+          as: 'backups',
+          required: false,
+        },
+      ],
+    });
+    return device ? this.toDomainDevice(device) : null;
+  }
+
+  async findAllBackupsByUserAndDevice(user: User, deviceId: number) {
+    const backups = await this.backupModel.findAll({
+      where: { userId: user.id, deviceId },
+    });
+    return backups.map(this.toDomainBackup);
+  }
+
+  async findBackupByUserAndId(user: User, backupId: number) {
+    const backup = await this.backupModel.findOne({
+      where: { userId: user.id, id: backupId },
+    });
+    return backup ? this.toDomainBackup(backup) : null;
+  }
+
+  async deleteBackupByUserAndId(user: User, backupId: number) {
+    return this.backupModel.destroy({
+      where: { userId: user.id, id: backupId },
+    });
   }
 
   private toDomainDevice(deviceModel: DeviceModel): Device {

--- a/src/modules/backups/backup.usecase.ts
+++ b/src/modules/backups/backup.usecase.ts
@@ -14,6 +14,7 @@ import { FolderUseCases } from '../folder/folder.usecase';
 import { FileUseCases } from '../file/file.usecase';
 import { Folder, FolderAttributes } from '../folder/folder.domain';
 import { SequelizeUserRepository } from '../user/user.repository';
+import { BackupModel } from './models/backup.model';
 
 @Injectable()
 export class BackupUseCase {
@@ -35,6 +36,39 @@ export class BackupUseCase {
     ]);
 
     return { deletedBackups, deletedDevices };
+  }
+
+  async getAllDevices(user: User) {
+    return this.backupRepository.findAllDevices(user);
+  }
+
+  async deleteDevice(user: User, deviceId: number) {
+    const device = await this.backupRepository.findDeviceByUserAndId(
+      user,
+      deviceId,
+    );
+    if (!device) {
+      throw new NotFoundException('Device not found');
+    }
+
+    await Promise.all(
+      device.backups.map((backup: BackupModel) => {
+        if (backup.fileId) {
+          return this.networkService.deleteFile(
+            user,
+            backup.bucket,
+            backup.fileId,
+          );
+        }
+      }),
+    );
+
+    await this.backupRepository.deleteBackupsBy({ deviceId });
+
+    return this.backupRepository.deleteDevicesBy({
+      userId: user.id,
+      id: deviceId,
+    });
   }
 
   async activate(user: User) {
@@ -127,6 +161,30 @@ export class BackupUseCase {
       name: encryptedName,
       plainName: deviceName,
     });
+  }
+
+  async getBackupsByMac(user: User, mac: string) {
+    const device = await this.backupRepository.findDeviceByUserAndMac(
+      user,
+      mac,
+    );
+    if (!device) {
+      throw new NotFoundException('Device not found');
+    }
+
+    return this.backupRepository.findAllBackupsByUserAndDevice(user, device.id);
+  }
+
+  async deleteBackup(user: User, backupId: number) {
+    const backup = await this.backupRepository.findBackupByUserAndId(
+      user,
+      backupId,
+    );
+    if (!backup) {
+      throw new NotFoundException('Backup not found');
+    }
+
+    return this.backupRepository.deleteBackupByUserAndId(user, backupId);
   }
 
   async isFolderEmpty(user: User, folder: Folder) {


### PR DESCRIPTION
### Updates
- Migrate some backup and device endpoints
---
### Endpoints
- `GET` _/api/backup/device_  `server -> wip` _/api/backup/devices_
- `DELETE` _/api/backup/device/:deviceId_  `server -> wip` _/api/backup/devices/:deviceId_
Param: `:deviceId == Device.id`
- `GET` _/api/backup/:mac_ `server -> wip` _/api/backup/:mac_
Param: `:mac == Device.mac`
- `DELETE` _/api/backup/:backupId_ `server -> wip` _/api/backup/:backupId_
Param: `:backupId` == Backup.id`