### PR TITLE
[PB-4129] feat(logger): added global exception filter

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -25,6 +25,8 @@ import { AppSumoModule } from './modules/app-sumo/app-sumo.module';
 import { PlanModule } from './modules/plan/plan.module';
 import { WorkspacesModule } from './modules/workspaces/workspaces.module';
 import { GatewayModule } from './modules/gateway/gateway.module';
+import { APP_FILTER } from '@nestjs/core';
+import { HttpGlobalExceptionFilter } from './common/http-global-exception-filter.exception';
 
 @Module({
   imports: [
@@ -120,6 +122,11 @@ import { GatewayModule } from './modules/gateway/gateway.module';
     GatewayModule,
   ],
   controllers: [],
-  providers: [],
+  providers: [
+    {
+      provide: APP_FILTER,
+      useClass: HttpGlobalExceptionFilter,
+    },
+  ],
 })
 export class AppModule {}

--- a/src/common/http-global-exception-filter.exception.spec.ts
+++ b/src/common/http-global-exception-filter.exception.spec.ts
@@ -1,0 +1,192 @@
+import {
+  ArgumentsHost,
+  HttpException,
+  HttpStatus,
+  Logger,
+} from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { HttpAdapterHost } from '@nestjs/core';
+import { ValidationError } from 'sequelize';
+import { AxiosError } from 'axios';
+import { HttpGlobalExceptionFilter } from './http-global-exception-filter.exception';
+import { createMock, DeepMocked } from '@golevelup/ts-jest';
+import { newUser } from '../../test/fixtures';
+
+jest.mock('../modules/auth/decorators/client.decorator', () => ({
+  getClientIdFromHeaders: jest.fn().mockReturnValue('drive-web'),
+}));
+
+describe('HttpGlobalExceptionFilter', () => {
+  let filter: HttpGlobalExceptionFilter;
+  let mockHttpAdapter: DeepMocked<HttpAdapterHost['httpAdapter']>;
+  let mockHttpAdapterHost: DeepMocked<HttpAdapterHost>;
+  let loggerMock: DeepMocked<Logger>;
+
+  beforeEach(async () => {
+    mockHttpAdapter = createMock<HttpAdapterHost['httpAdapter']>();
+    mockHttpAdapterHost = createMock<HttpAdapterHost>({
+      httpAdapter: mockHttpAdapter,
+    });
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        HttpGlobalExceptionFilter,
+        {
+          provide: HttpAdapterHost,
+          useValue: mockHttpAdapterHost,
+        },
+      ],
+    }).compile();
+    loggerMock = createMock<Logger>();
+    module.useLogger(loggerMock);
+    filter = module.get<HttpGlobalExceptionFilter>(HttpGlobalExceptionFilter);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('When HttpException is sent, it should format response and not log errors', () => {
+    const mockUser = newUser();
+    const exceptionMessage = 'Test exception';
+    const mockException = new HttpException(
+      exceptionMessage,
+      HttpStatus.BAD_REQUEST,
+    );
+    const mockHost = createMockArgumentsHost('/test-url', 'GET', mockUser);
+
+    filter.catch(mockException, mockHost);
+
+    expect(mockHttpAdapter.reply).toHaveBeenCalledWith(
+      expect.anything(),
+      {
+        statusCode: HttpStatus.BAD_REQUEST,
+        message: exceptionMessage,
+      },
+      HttpStatus.BAD_REQUEST,
+    );
+    expect(loggerMock.error).not.toHaveBeenCalled();
+  });
+
+  describe('Not HTTP errors logs', () => {
+    it('When unexpected error is sent, it should log details and return 500 error', () => {
+      const mockUser = newUser();
+      const mockException = new Error('Unexpected error');
+      const mockHost = createMockArgumentsHost('/test-url', 'GET', mockUser);
+
+      filter.catch(mockException, mockHost);
+
+      expect(loggerMock.error).toHaveBeenCalled();
+      expect(mockHttpAdapter.reply).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          statusCode: HttpStatus.INTERNAL_SERVER_ERROR,
+          message: 'Internal Server Error',
+          errorId: expect.any(String),
+        }),
+        HttpStatus.INTERNAL_SERVER_ERROR,
+      );
+    });
+
+    it('When SequelizeError is sent, it should log with DATABASE tag', () => {
+      const mockUser = newUser();
+      const mockException = new ValidationError(
+        'Database validation error',
+        [],
+      );
+      const mockHost = createMockArgumentsHost('/test-url', 'GET', mockUser);
+
+      filter.catch(mockException, mockHost);
+
+      expect(loggerMock.error).toHaveBeenCalled();
+      expect(loggerMock.error.mock.calls[0][0]).toContain('[DATABASE]');
+      expect(mockHttpAdapter.reply).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          statusCode: HttpStatus.INTERNAL_SERVER_ERROR,
+          message: 'Internal Server Error',
+        }),
+        HttpStatus.INTERNAL_SERVER_ERROR,
+      );
+    });
+
+    it('When AxiosError is sent, it should log with EXTERNAL_SERVICE tag', () => {
+      const mockException = new AxiosError(
+        'External service error',
+        'ETIMEDOUT',
+        {} as any,
+        {},
+        {
+          status: 500,
+          data: 'Error',
+          statusText: 'Error',
+          headers: {},
+          config: {} as any,
+        },
+      );
+      const mockUser = newUser();
+      const mockHost = createMockArgumentsHost('/test-url', 'GET', mockUser);
+
+      filter.catch(mockException, mockHost);
+
+      expect(loggerMock.error).toHaveBeenCalled();
+      expect(loggerMock.error.mock.calls[0][0]).toContain('[EXTERNAL_SERVICE]');
+      expect(mockHttpAdapter.reply).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          statusCode: HttpStatus.INTERNAL_SERVER_ERROR,
+          message: 'Internal Server Error',
+        }),
+        HttpStatus.INTERNAL_SERVER_ERROR,
+      );
+    });
+
+    it('When request does not contain user, it should be able to handle it gracefully', () => {
+      const mockException = new Error('Unexpected error');
+      const mockHost = createMockArgumentsHost('/test-url', 'GET', null);
+
+      filter.catch(mockException, mockHost);
+
+      expect(loggerMock.error).toHaveBeenCalled();
+      expect(mockHttpAdapter.reply).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          statusCode: HttpStatus.INTERNAL_SERVER_ERROR,
+          message: 'Internal Server Error',
+        }),
+        HttpStatus.INTERNAL_SERVER_ERROR,
+      );
+    });
+  });
+
+  describe('isExceptionObject', () => {
+    it('When an object is an exception object, it should return true', () => {
+      expect(filter.isExceptionObject(new Error('test'))).toBe(true);
+      expect(filter.isExceptionObject({ message: 'test message' })).toBe(true);
+    });
+
+    it('When an object is not an exception object, it should return false', () => {
+      expect(filter.isExceptionObject({ something: 'else' })).toBe(false);
+      expect(filter.isExceptionObject(null)).toBe(false);
+      expect(filter.isExceptionObject(undefined)).toBe(false);
+    });
+  });
+});
+
+const createMockArgumentsHost = (
+  url: string,
+  method: string,
+  user: any,
+  body: any = {},
+) =>
+  createMock<ArgumentsHost>({
+    switchToHttp: () => ({
+      getRequest: () => ({
+        url,
+        method,
+        user,
+        body,
+      }),
+      getResponse: () => ({}),
+    }),
+  });

--- a/src/common/http-global-exception-filter.exception.ts
+++ b/src/common/http-global-exception-filter.exception.ts
@@ -4,19 +4,16 @@ import {
   HttpException,
   ArgumentsHost,
   HttpStatus,
-  ExceptionFilter,
 } from '@nestjs/common';
 import { BaseError as SequelizeError } from 'sequelize';
 import { AxiosError } from 'axios';
-import { HttpAdapterHost } from '@nestjs/core';
+import { BaseExceptionFilter } from '@nestjs/core';
 import { getClientIdFromHeaders } from '../modules/auth/decorators/client.decorator';
 import { v4 } from 'uuid';
 
 @Catch()
-export class HttpGlobalExceptionFilter implements ExceptionFilter {
+export class HttpGlobalExceptionFilter extends BaseExceptionFilter {
   private readonly logger = new Logger(HttpGlobalExceptionFilter.name);
-
-  constructor(private readonly httpAdapterHost: HttpAdapterHost) {}
 
   catch(exception: any, host: ArgumentsHost) {
     const { httpAdapter } = this.httpAdapterHost;
@@ -24,57 +21,72 @@ export class HttpGlobalExceptionFilter implements ExceptionFilter {
     const request = ctx.getRequest();
     const response = ctx.getResponse();
 
-    //  Errors thrown intentionally by the application
-    if (exception instanceof HttpException) {
-      const status = exception.getStatus
-        ? exception.getStatus()
-        : HttpStatus.INTERNAL_SERVER_ERROR;
+    try {
+      //  Errors thrown intentionally by the application
+      if (exception instanceof HttpException) {
+        const status = exception.getStatus
+          ? exception.getStatus()
+          : HttpStatus.INTERNAL_SERVER_ERROR;
 
-      const res = exception.getResponse();
-      const message = this.isExceptionObject(res)
-        ? res
-        : {
-            statusCode: exception.getStatus(),
-            message: res,
-          };
+        const res = exception.getResponse();
+        const message = this.isExceptionObject(res)
+          ? res
+          : {
+              statusCode: exception.getStatus(),
+              message: res,
+            };
 
-      return httpAdapter.reply(response, message, status);
-    }
+        return httpAdapter.reply(response, message, status);
+      }
 
-    const errorId = v4();
-    const errorResponse = {
-      timestamp: new Date().toISOString(),
-      errorId,
-      name: exception.name,
-      path: request.url,
-      method: request.method,
-      body: request.body || {},
-      user: { email: request?.user?.email, uuid: request?.user?.uuid },
-      client: getClientIdFromHeaders(request),
-      message: (exception as Error)?.message,
-      stack: (exception as Error)?.stack,
-    };
-
-    let errorType = '[UNEXPECTED_ERROR]';
-    if (exception instanceof SequelizeError) {
-      errorType = '[DATABASE]';
-    } else if (exception instanceof AxiosError) {
-      errorType = '[EXTERNAL_SERVICE]';
-    }
-
-    this.logger.error(
-      `${errorType} - Details: ${JSON.stringify(errorResponse)}`,
-    );
-
-    return httpAdapter.reply(
-      response,
-      {
-        statusCode: HttpStatus.INTERNAL_SERVER_ERROR,
-        message: 'Internal Server Error',
+      const errorId = v4();
+      const errorResponse = {
+        timestamp: new Date().toISOString(),
         errorId,
-      },
-      HttpStatus.INTERNAL_SERVER_ERROR,
-    );
+        name: exception.name,
+        path: request.url,
+        method: request.method,
+        body: request.body || {},
+        user: { email: request?.user?.email, uuid: request?.user?.uuid },
+        client: getClientIdFromHeaders(request),
+        message: (exception as Error)?.message,
+        stack: (exception as Error)?.stack,
+      };
+
+      let errorType = '[UNEXPECTED_ERROR]';
+      if (exception instanceof SequelizeError) {
+        errorType = '[DATABASE]';
+      } else if (exception instanceof AxiosError) {
+        errorType = '[EXTERNAL_SERVICE]';
+      }
+
+      this.logger.error(
+        `${errorType} - Details: ${JSON.stringify(errorResponse)}`,
+      );
+
+      return httpAdapter.reply(
+        response,
+        {
+          statusCode: HttpStatus.INTERNAL_SERVER_ERROR,
+          message: 'Internal Server Error',
+          errorId,
+        },
+        HttpStatus.INTERNAL_SERVER_ERROR,
+      );
+    } catch (error) {
+      const errorDetails = {
+        user: { email: request?.user?.email, uuid: request?.user?.uuid },
+        method: request.method,
+        path: request.url,
+        message: error.message,
+        stack: error.stack,
+      };
+      this.logger.error(
+        `Error in HttpGlobalExceptionFilter: ${JSON.stringify(errorDetails)}`,
+      );
+      // If something goes wrong, let the default exception handler take over
+      return super.catch(error, host);
+    }
   }
 
   isExceptionObject(err: any): err is Error {

--- a/src/common/http-global-exception-filter.exception.ts
+++ b/src/common/http-global-exception-filter.exception.ts
@@ -1,0 +1,88 @@
+import {
+  Catch,
+  Logger,
+  HttpException,
+  ArgumentsHost,
+  HttpStatus,
+  ExceptionFilter,
+} from '@nestjs/common';
+import { BaseError as SequelizeError } from 'sequelize';
+import { AxiosError } from 'axios';
+import { HttpAdapterHost } from '@nestjs/core';
+import { getClientIdFromHeaders } from '../modules/auth/decorators/client.decorator';
+import { v4 } from 'uuid';
+
+@Catch()
+export class HttpGlobalExceptionFilter implements ExceptionFilter {
+  private readonly logger = new Logger(HttpGlobalExceptionFilter.name);
+
+  constructor(private readonly httpAdapterHost: HttpAdapterHost) {}
+
+  catch(exception: any, host: ArgumentsHost) {
+    const { httpAdapter } = this.httpAdapterHost;
+    const ctx = host.switchToHttp();
+    const request = ctx.getRequest();
+    const response = ctx.getResponse();
+
+    //  Errors thrown intentionally by the application
+    if (exception instanceof HttpException) {
+      const status = exception.getStatus
+        ? exception.getStatus()
+        : HttpStatus.INTERNAL_SERVER_ERROR;
+
+      const res = exception.getResponse();
+      const message = this.isExceptionObject(res)
+        ? res
+        : {
+            statusCode: exception.getStatus(),
+            message: res,
+          };
+
+      return httpAdapter.reply(response, message, status);
+    }
+
+    const errorId = v4();
+    const errorResponse = {
+      timestamp: new Date().toISOString(),
+      errorId,
+      name: exception.name,
+      path: request.url,
+      method: request.method,
+      body: request.body || {},
+      user: { email: request?.user?.email, uuid: request?.user?.uuid },
+      client: getClientIdFromHeaders(request),
+      message: (exception as Error)?.message,
+      stack: (exception as Error)?.stack,
+    };
+
+    let errorType = '[UNEXPECTED_ERROR]';
+    if (exception instanceof SequelizeError) {
+      errorType = '[DATABASE]';
+    } else if (exception instanceof AxiosError) {
+      errorType = '[EXTERNAL_SERVICE]';
+    }
+
+    this.logger.error(
+      `${errorType} - Details: ${JSON.stringify(errorResponse)}`,
+    );
+
+    return httpAdapter.reply(
+      response,
+      {
+        statusCode: HttpStatus.INTERNAL_SERVER_ERROR,
+        message: 'Internal Server Error',
+        errorId,
+      },
+      HttpStatus.INTERNAL_SERVER_ERROR,
+    );
+  }
+
+  isExceptionObject(err: any): err is Error {
+    return (
+      err !== null &&
+      err !== undefined &&
+      typeof err === 'object' &&
+      'message' in err
+    );
+  }
+}

--- a/src/modules/auth/auth.controller.ts
+++ b/src/modules/auth/auth.controller.ts
@@ -44,7 +44,6 @@ import { LoginResponseDto } from './dto/responses/login-response.dto';
 
 @ApiTags('Auth')
 @Controller('auth')
-@UseFilters(ExtendedHttpExceptionFilter)
 export class AuthController {
   constructor(
     private userUseCases: UserUseCases,

--- a/src/modules/auth/auth.controller.ts
+++ b/src/modules/auth/auth.controller.ts
@@ -14,7 +14,6 @@ import {
   Put,
   UnauthorizedException,
   HttpException,
-  UseFilters,
   Query,
 } from '@nestjs/common';
 import {
@@ -37,7 +36,6 @@ import { DeleteTfaDto } from './dto/delete-tfa.dto';
 import { UpdateTfaDto } from './dto/update-tfa.dto';
 import { WorkspaceLogAction } from '../workspaces/decorators/workspace-log-action.decorator';
 import { WorkspaceLogType } from '../workspaces/attributes/workspace-logs.attributes';
-import { ExtendedHttpExceptionFilter } from '../../common/http-exception-filter-extended.exception';
 import { AreCredentialsCorrectDto } from './dto/are-credentials-correct.dto';
 import { LoginAccessResponseDto } from './dto/responses/login-access-response.dto';
 import { LoginResponseDto } from './dto/responses/login-response.dto';

--- a/src/modules/auth/decorators/client.decorator.ts
+++ b/src/modules/auth/decorators/client.decorator.ts
@@ -1,8 +1,19 @@
 import { createParamDecorator, ExecutionContext } from '@nestjs/common';
 
+export enum ClientHeaders {
+  CLIENT_ID = 'internxt-client-id',
+  CLIENT = 'internxt-client',
+}
+
+export const getClientIdFromHeaders = (request: Request) => {
+  return String(
+    request.headers[ClientHeaders.CLIENT_ID] ||
+      request.headers[ClientHeaders.CLIENT] ||
+      '',
+  );
+};
+
 export const Client = createParamDecorator((_, ctx: ExecutionContext) => {
   const req = ctx.switchToHttp().getRequest();
-  return String(
-    req.headers['internxt-client-id'] || req.headers['internxt-client'],
-  );
+  return getClientIdFromHeaders(req);
 });

--- a/src/modules/file/file.controller.ts
+++ b/src/modules/file/file.controller.ts
@@ -11,7 +11,6 @@ import {
   Post,
   Put,
   Query,
-  UseFilters,
   UseGuards,
   UsePipes,
   ValidationPipe,
@@ -46,7 +45,6 @@ import { StorageNotificationService } from '../../externals/notifications/storag
 import { Client } from '../auth/decorators/client.decorator';
 import { getPathDepth } from '../../lib/path';
 import { Requester } from '../auth/decorators/requester.decorator';
-import { ExtendedHttpExceptionFilter } from '../../common/http-exception-filter-extended.exception';
 import { FileDto } from './dto/responses/file.dto';
 import { UploadGuard } from './guards/upload.guard';
 import { ThumbnailDto } from '../thumbnail/dto/thumbnail.dto';
@@ -351,7 +349,6 @@ export class FileController {
     },
   ])
   @WorkspacesInBehalfValidationFile()
-  @UseFilters(ExtendedHttpExceptionFilter)
   async moveFile(
     @UserDecorator() user: User,
     @Param('uuid') fileUuid: string,

--- a/src/modules/folder/folder.controller.ts
+++ b/src/modules/folder/folder.controller.ts
@@ -54,7 +54,6 @@ import { Workspace } from '../workspaces/domains/workspaces.domain';
 import { getPathDepth } from '../../lib/path';
 import { CheckFoldersExistenceOldDto } from './dto/folder-existence-in-folder-old.dto';
 import { Requester } from '../auth/decorators/requester.decorator';
-import { ExtendedHttpExceptionFilter } from '../../common/http-exception-filter-extended.exception';
 import {
   ExistingFoldersDto,
   FolderDto,
@@ -856,7 +855,6 @@ export class FolderController {
     },
   ])
   @WorkspacesInBehalfValidationFolder()
-  @UseFilters(ExtendedHttpExceptionFilter)
   async moveFolder(
     @UserDecorator() user: User,
     @Param('uuid') folderUuid: string,

--- a/src/modules/gateway/gateway.controller.ts
+++ b/src/modules/gateway/gateway.controller.ts
@@ -11,7 +11,6 @@ import {
   Put,
   Query,
   UseGuards,
-  UseInterceptors,
 } from '@nestjs/common';
 import {
   ApiBearerAuth,
@@ -31,13 +30,11 @@ import { User } from '../user/user.domain';
 import { CheckStorageExpansionDto } from './dto/check-storage-expansion.dto';
 import { ValidateUUIDPipe } from '../workspaces/pipes/validate-uuid.pipe';
 import { UpdateUserDto } from './dto/update-user.dto';
-import { ExtendedHttpExceptionFilter } from '../../common/http-exception-filter-extended.exception';
 import { StorageNotificationService } from '../../externals/notifications/storage.notifications.service';
 
 @ApiTags('Gateway')
 @Controller('gateway')
 @DisableGlobalAuth()
-@UseInterceptors(ExtendedHttpExceptionFilter)
 export class GatewayController {
   private readonly logger = new Logger(GatewayController.name);
 

--- a/src/modules/user/user.controller.ts
+++ b/src/modules/user/user.controller.ts
@@ -80,11 +80,9 @@ import { Client } from '../auth/decorators/client.decorator';
 import { DeactivationRequestEvent } from '../../externals/notifications/events/deactivation-request.event';
 import { ConfirmAccountDeactivationDto } from './dto/confirm-deactivation.dto';
 import { GetUserUsageDto } from './dto/responses/get-user-usage.dto';
-import { ExtendedHttpExceptionFilter } from '../../common/http-exception-filter-extended.exception';
 
 @ApiTags('User')
 @Controller('users')
-@UseFilters(ExtendedHttpExceptionFilter)
 export class UserController {
   constructor(
     private userUseCases: UserUseCases,

--- a/src/modules/workspaces/workspaces.controller.ts
+++ b/src/modules/workspaces/workspaces.controller.ts
@@ -12,7 +12,6 @@ import {
   UseGuards,
   UseInterceptors,
   InternalServerErrorException,
-  UseFilters,
   ForbiddenException,
   NotFoundException,
 } from '@nestjs/common';
@@ -58,7 +57,6 @@ import { CreateWorkspaceFileDto } from './dto/create-workspace-file.dto';
 import { SortableFileAttributes } from '../file/file.domain';
 import { avatarStorageS3Config } from '../../externals/multer';
 import { WorkspaceInvitationsPagination } from './dto/workspace-invitations-pagination.dto';
-import { ExtendedHttpExceptionFilter } from '../../common/http-exception-filter-extended.exception';
 import { ShareItemWithTeamDto } from './dto/share-item-with-team.dto';
 import { OrderBy } from '../../common/order.type';
 import { GetDataFromRequest } from './../../common/extract-data-from-request';
@@ -91,7 +89,6 @@ import { WorkspaceCredentialsDto } from './dto/reponse/workspace-credentials.dto
 
 @ApiTags('Workspaces')
 @Controller('workspaces')
-@UseFilters(ExtendedHttpExceptionFilter)
 export class WorkspacesController {
   constructor(
     private readonly workspaceUseCases: WorkspacesUsecases,


### PR DESCRIPTION
This PR improves our logging format to ensure proper display in our logs ingest tool by replacing the default multiline NestJS Global Exception Filter with a custom implementation that formats logs as single-line JSON objects, categorizes errors by type (external service errors via Axios, database errors from Sequelize, and unexpected application errors).

### Changes
- Add unique error ID generation using UUID for any non intrinsic error
- Categorize errors by type (Database, External Service, or Unexpected)

### Note
To remove colors from the logs, we're using NestJS v10, so we should set the `NO_COLOR` environment variable to some non-empty string.