### PR TITLE
[PB-4129] feat(logger): use subcategories inside UNEXPECTED_ERRROR

### DIFF
--- a/src/common/http-global-exception-filter.exception.spec.ts
+++ b/src/common/http-global-exception-filter.exception.spec.ts
@@ -99,7 +99,9 @@ describe('HttpGlobalExceptionFilter', () => {
       filter.catch(mockException, mockHost);
 
       expect(loggerMock.error).toHaveBeenCalled();
-      expect(loggerMock.error.mock.calls[0][0]).toContain('[DATABASE]');
+      expect(loggerMock.error.mock.calls[0][0]).toContain(
+        'UNEXPECTED_ERROR/DATABASE',
+      );
       expect(mockHttpAdapter.reply).toHaveBeenCalledWith(
         expect.anything(),
         expect.objectContaining({
@@ -130,7 +132,9 @@ describe('HttpGlobalExceptionFilter', () => {
       filter.catch(mockException, mockHost);
 
       expect(loggerMock.error).toHaveBeenCalled();
-      expect(loggerMock.error.mock.calls[0][0]).toContain('[EXTERNAL_SERVICE]');
+      expect(loggerMock.error.mock.calls[0][0]).toContain(
+        'UNEXPECTED_ERROR/EXTERNAL_SERVICE',
+      );
       expect(mockHttpAdapter.reply).toHaveBeenCalledWith(
         expect.anything(),
         expect.objectContaining({

--- a/src/common/http-global-exception-filter.exception.ts
+++ b/src/common/http-global-exception-filter.exception.ts
@@ -53,15 +53,19 @@ export class HttpGlobalExceptionFilter extends BaseExceptionFilter {
         stack: (exception as Error)?.stack,
       };
 
-      let errorType = '[UNEXPECTED_ERROR]';
+      let errorSubtype = '';
       if (exception instanceof SequelizeError) {
-        errorType = '[DATABASE]';
+        errorSubtype = 'DATABASE';
       } else if (exception instanceof AxiosError) {
-        errorType = '[EXTERNAL_SERVICE]';
+        errorSubtype = 'EXTERNAL_SERVICE';
       }
 
+      const errorCategory = errorSubtype
+        ? `UNEXPECTED_ERROR/${errorSubtype}`
+        : 'UNEXPECTED_ERROR';
+
       this.logger.error(
-        `${errorType} - Details: ${JSON.stringify(errorResponse)}`,
+        `[${errorCategory}] - Details: ${JSON.stringify(errorResponse)}`,
       );
 
       return httpAdapter.reply(


### PR DESCRIPTION
### Changes

1. Use subcategories instead of just DATABASE, EXTERNAL_ERROR so we can search all errors by just using EXTERNAL_ERROR.