### PR TITLE
[_]: chore/implement deleteFileByFileId functionality

### DIFF
--- a/src/modules/file/file.controller.ts
+++ b/src/modules/file/file.controller.ts
@@ -485,4 +485,27 @@ export class FileController {
 
     return { deleted: true };
   }
+
+  @Delete('/:bucketId/:fileId')
+  @ApiBearerAuth()
+  @ApiOperation({
+    summary: 'Delete file from storage by fileId',
+  })
+  async deleteFileByFileId(
+    @UserDecorator() user: User,
+    @Param('bucketId') bucketId: string,
+    @Param('fileId') fileId: string,
+    @Client() clientId: string,
+  ) {
+    const { fileExistedInDb, id, uuid } =
+      await this.fileUseCases.deleteFileByFileId(user, bucketId, fileId);
+
+    if (fileExistedInDb) {
+      this.storageNotificationService.fileDeleted({
+        payload: { id, uuid },
+        user,
+        clientId,
+      });
+    }
+  }
 }


### PR DESCRIPTION
Attempt to delete files by `fileId`. If file is found in the db a normal delete flow would be attempted, if it is not found we attempt to directly delete if from network.
Would be the equivalent of `DELETE: <drive-server>/storage/bucket/:bucket/file/:fileId`




