### PR TITLE
[_]: fix/include member data when sending user removed notifications

### DIFF
--- a/src/modules/workspaces/workspaces.controller.ts
+++ b/src/modules/workspaces/workspaces.controller.ts
@@ -1186,6 +1186,7 @@ export class WorkspacesController {
     const workspaceUser = await this.workspaceUseCases.findUserInWorkspace(
       memberId,
       workspaceId,
+      true,
     );
 
     if (!workspaceUser) {

--- a/src/modules/workspaces/workspaces.usecase.spec.ts
+++ b/src/modules/workspaces/workspaces.usecase.spec.ts
@@ -6271,4 +6271,95 @@ describe('WorkspacesUsecases', () => {
       expect(result).toEqual(expectedAncestors);
     });
   });
+
+  describe('findUserInWorkspace', () => {
+    const user = newUser();
+    const workspace = newWorkspace();
+    const workspaceUser = newWorkspaceUser({
+      workspaceId: workspace.id,
+      memberId: user.uuid,
+      member: user,
+    });
+
+    it('When user exists in workspace, then it should return the workspace user', async () => {
+      jest
+        .spyOn(workspaceRepository, 'findWorkspaceUser')
+        .mockResolvedValueOnce(workspaceUser);
+
+      const result = await service.findUserInWorkspace(user.uuid, workspace.id);
+
+      expect(result).toEqual(workspaceUser);
+      expect(workspaceRepository.findWorkspaceUser).toHaveBeenCalledWith(
+        {
+          workspaceId: workspace.id,
+          memberId: user.uuid,
+        },
+        false,
+      );
+    });
+
+    it('When user does not exist in workspace, then it should return null', async () => {
+      jest
+        .spyOn(workspaceRepository, 'findWorkspaceUser')
+        .mockResolvedValueOnce(null);
+
+      const result = await service.findUserInWorkspace(user.uuid, workspace.id);
+
+      expect(result).toBeNull();
+      expect(workspaceRepository.findWorkspaceUser).toHaveBeenCalledWith(
+        {
+          workspaceId: workspace.id,
+          memberId: user.uuid,
+        },
+        false,
+      );
+    });
+
+    it('When includeUser is true, then it should return workspace user with user data', async () => {
+      jest
+        .spyOn(workspaceRepository, 'findWorkspaceUser')
+        .mockResolvedValueOnce(workspaceUser);
+
+      const result = await service.findUserInWorkspace(
+        user.uuid,
+        workspace.id,
+        true,
+      );
+
+      expect(result).toEqual(workspaceUser);
+      expect(workspaceRepository.findWorkspaceUser).toHaveBeenCalledWith(
+        {
+          workspaceId: workspace.id,
+          memberId: user.uuid,
+        },
+        true,
+      );
+    });
+
+    it('When includeUser is false, then it should return workspace user without user data', async () => {
+      const workspaceUserWithoutMember = newWorkspaceUser({
+        workspaceId: workspace.id,
+        memberId: user.uuid,
+      });
+
+      jest
+        .spyOn(workspaceRepository, 'findWorkspaceUser')
+        .mockResolvedValueOnce(workspaceUserWithoutMember);
+
+      const result = await service.findUserInWorkspace(
+        user.uuid,
+        workspace.id,
+        false,
+      );
+
+      expect(result).toEqual(workspaceUserWithoutMember);
+      expect(workspaceRepository.findWorkspaceUser).toHaveBeenCalledWith(
+        {
+          workspaceId: workspace.id,
+          memberId: user.uuid,
+        },
+        false,
+      );
+    });
+  });
 });

--- a/src/modules/workspaces/workspaces.usecase.ts
+++ b/src/modules/workspaces/workspaces.usecase.ts
@@ -2601,11 +2601,15 @@ export class WorkspacesUsecases {
   findUserInWorkspace(
     userUuid: User['uuid'],
     workspaceId: Workspace['id'],
+    includeUser = false,
   ): Promise<WorkspaceUser | null> {
-    return this.workspaceRepository.findWorkspaceUser({
-      workspaceId,
-      memberId: userUuid,
-    });
+    return this.workspaceRepository.findWorkspaceUser(
+      {
+        workspaceId,
+        memberId: userUuid,
+      },
+      includeUser,
+    );
   }
 
   async deleteWorkspaceContent(


### PR DESCRIPTION
Fixed an error when sending `WORKSPACE_LEFT` notifications when removing a member from the workspace. As the workspaceMember data retrieved from db was not including the user's data, causing an error when trying to access user.email when sending the notification