### PR TITLE
fix(deps): rollback type/jsonwebtoken version to 9.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "@types/crypto-js": "^4.2.1",
     "@types/express": "^4.17.21",
     "@types/jest": "29.5.14",
-    "@types/jsonwebtoken": "9.0.9",
+    "@types/jsonwebtoken": "9.0.2",
     "@types/multer": "^1.4.12",
     "@types/node": "^20.17.28",
     "@types/sequelize": "^4.28.20",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2989,19 +2989,18 @@
   dependencies:
     "@types/node" "*"
 
+"@types/jsonwebtoken@9.0.2":
+  version "9.0.2"
+  resolved "https://registry.yarnpkg.com/@types/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz#9eeb56c76dd555039be2a3972218de5bd3b8d83e"
+  integrity sha512-drE6uz7QBKq1fYqqoFKTDRdFCPHd5TCub75BM+D+cMx7NU9hUz7SESLfC2fSCXVFMO5Yj8sOWHuGqPgjc+fz0Q==
+  dependencies:
+    "@types/node" "*"
+
 "@types/jsonwebtoken@9.0.5":
   version "9.0.5"
   resolved "https://registry.yarnpkg.com/@types/jsonwebtoken/-/jsonwebtoken-9.0.5.tgz#0bd9b841c9e6c5a937c17656e2368f65da025588"
   integrity sha512-VRLSGzik+Unrup6BsouBeHsf4d1hOEgYWTm/7Nmw1sXoN1+tRly/Gy/po3yeahnP4jfnQWWAhQAqcNfH7ngOkA==
   dependencies:
-    "@types/node" "*"
-
-"@types/jsonwebtoken@9.0.9":
-  version "9.0.9"
-  resolved "https://registry.yarnpkg.com/@types/jsonwebtoken/-/jsonwebtoken-9.0.9.tgz#a4c3a446c0ebaaf467a58398382616f416345fb3"
-  integrity sha512-uoe+GxEuHbvy12OUQct2X9JenKM3qAscquYymuQN4fMWG9DBQtykrQEFcAbVACF7qaLw9BePSodUL0kquqBJpQ==
-  dependencies:
-    "@types/ms" "*"
     "@types/node" "*"
 
 "@types/lodash@*":


### PR DESCRIPTION
I noticed on my local that our current jsonWebToken Version is not compatible with 9.0.9 types, this breaks our tests. For some reason tests in the original PR were executed successfully.

This is just a rollback to a compatible version.