### PR TITLE
[_] chore(logs): disable logs colors if not on dev

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -3,7 +3,7 @@ import dotenv from 'dotenv';
 dotenv.config({ path: `.env.${process.env.NODE_ENV}` });
 
 import './newrelic';
-import { ValidationPipe, Logger } from '@nestjs/common';
+import { ValidationPipe, Logger, ConsoleLogger } from '@nestjs/common';
 import { NestFactory, Reflector } from '@nestjs/core';
 import { AppModule } from './app.module';
 import apiMetrics from 'prometheus-api-metrics';
@@ -44,6 +44,10 @@ async function bootstrap() {
       methods: 'GET,HEAD,PUT,PATCH,POST,DELETE',
       preflightContinue: false,
     },
+    logger: new ConsoleLogger({
+      colors: config.isDevelopment,
+      prefix: 'Drive-server',
+    }),
   });
 
   const enableTrustProxy = config.isProduction;


### PR DESCRIPTION
Colored logs add noise to our logs platform. This PR just removes logs colors so we can have cleaner logs.

### Changes

1. Remove logs colors if environment is not development.