### PR TITLE
[_] refactor: userController error handling and unit tests logger

### DIFF
--- a/src/common/http-global-exception-filter.exception.spec.ts
+++ b/src/common/http-global-exception-filter.exception.spec.ts
@@ -27,6 +27,7 @@ describe('HttpGlobalExceptionFilter', () => {
     mockHttpAdapterHost = createMock<HttpAdapterHost>({
       httpAdapter: mockHttpAdapter,
     });
+    loggerMock = createMock<Logger>();
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -36,9 +37,9 @@ describe('HttpGlobalExceptionFilter', () => {
           useValue: mockHttpAdapterHost,
         },
       ],
-    }).compile();
-    loggerMock = createMock<Logger>();
-    module.useLogger(loggerMock);
+    })
+      .setLogger(loggerMock)
+      .compile();
     filter = module.get<HttpGlobalExceptionFilter>(HttpGlobalExceptionFilter);
   });
 

--- a/src/externals/notifications/storage.notifications.service.spec.ts
+++ b/src/externals/notifications/storage.notifications.service.spec.ts
@@ -1,5 +1,5 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { createMock } from '@golevelup/ts-jest';
+import { createMock, DeepMocked } from '@golevelup/ts-jest';
 import { Logger } from '@nestjs/common';
 import { StorageNotificationService } from './storage.notifications.service';
 import { NotificationService } from './notification.service';
@@ -16,19 +16,20 @@ describe('StorageNotificationService', () => {
   let notificationService: NotificationService;
   let apnService: ApnService;
   let userRepository: SequelizeUserRepository;
-  let loggerMock: Logger;
+  let loggerMock: DeepMocked<Logger>;
 
   beforeEach(async () => {
+    loggerMock = createMock<Logger>();
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [StorageNotificationService],
     })
+      .setLogger(loggerMock)
       .useMocker(createMock)
       .compile();
 
     jest.useFakeTimers();
     jest.setSystemTime(fixedSystemCurrentDate);
-    loggerMock = createMock<Logger>();
-    module.useLogger(loggerMock);
 
     service = module.get<StorageNotificationService>(
       StorageNotificationService,

--- a/src/modules/app-sumo/app-sumo.usecase.ts
+++ b/src/modules/app-sumo/app-sumo.usecase.ts
@@ -6,7 +6,7 @@ import { PlanNotFoundException } from '../plan/exception/plan-not-found.exceptio
 
 @Injectable()
 export class AppSumoUseCase {
-  private logger = new Logger('AppSumoUseCase');
+  private readonly logger = new Logger('AppSumoUseCase');
 
   constructor(
     private readonly appSumoRepository: SequelizeAppSumoRepository,

--- a/src/modules/auth/auth.controller.spec.ts
+++ b/src/modules/auth/auth.controller.spec.ts
@@ -9,6 +9,7 @@ import { Response } from 'express';
 import {
   BadRequestException,
   ConflictException,
+  Logger,
   NotFoundException,
   UnauthorizedException,
 } from '@nestjs/common';
@@ -19,6 +20,7 @@ import { GeneratedSecret } from 'speakeasy';
 import { UpdateTfaDto } from './dto/update-tfa.dto';
 import { DeleteTfaDto } from './dto/delete-tfa.dto';
 import { UserKeysEncryptVersions } from '../keyserver/key-server.domain';
+import { Test } from '@nestjs/testing';
 
 describe('AuthController', () => {
   let authController: AuthController;
@@ -28,17 +30,17 @@ describe('AuthController', () => {
   let twoFactorAuthService: DeepMocked<TwoFactorAuthService>;
 
   beforeEach(async () => {
-    userUseCases = createMock<UserUseCases>();
-    keyServerUseCases = createMock<KeyServerUseCases>();
-    cryptoService = createMock<CryptoService>();
-    twoFactorAuthService = createMock<TwoFactorAuthService>();
-
-    authController = new AuthController(
-      userUseCases,
-      keyServerUseCases,
-      cryptoService,
-      twoFactorAuthService,
-    );
+    const moduleRef = await Test.createTestingModule({
+      controllers: [AuthController],
+    })
+      .setLogger(createMock<Logger>())
+      .useMocker(() => createMock())
+      .compile();
+    authController = moduleRef.get(AuthController);
+    userUseCases = moduleRef.get(UserUseCases);
+    keyServerUseCases = moduleRef.get(KeyServerUseCases);
+    cryptoService = moduleRef.get(CryptoService);
+    twoFactorAuthService = moduleRef.get(TwoFactorAuthService);
   });
 
   it('should be defined', () => {

--- a/src/modules/gateway/gateway.controller.spec.ts
+++ b/src/modules/gateway/gateway.controller.spec.ts
@@ -17,16 +17,16 @@ describe('Gateway Controller', () => {
   let loggerMock: DeepMocked<Logger>;
 
   beforeEach(async () => {
+    loggerMock = createMock<Logger>();
     const moduleRef = await Test.createTestingModule({
       imports: [],
       controllers: [],
       providers: [GatewayController],
     })
+      .setLogger(loggerMock)
       .useMocker(() => createMock())
       .compile();
 
-    loggerMock = createMock<Logger>();
-    moduleRef.useLogger(loggerMock);
     gatewayController = moduleRef.get(GatewayController);
     gatewayUsecases = moduleRef.get(GatewayUseCases);
     storageNotificationsService = moduleRef.get(StorageNotificationService);

--- a/src/modules/gateway/gateway.usecase.spec.ts
+++ b/src/modules/gateway/gateway.usecase.spec.ts
@@ -25,13 +25,14 @@ describe('GatewayUseCases', () => {
   let loggerMock: DeepMocked<Logger>;
   let storageNotificationService: StorageNotificationService;
   beforeEach(async () => {
+    loggerMock = createMock<Logger>();
     const module: TestingModule = await Test.createTestingModule({
       providers: [GatewayUseCases],
     })
+      .setLogger(loggerMock)
       .useMocker(createMock)
       .compile();
-    loggerMock = createMock<Logger>();
-    module.useLogger(loggerMock);
+
     service = module.get<GatewayUseCases>(GatewayUseCases);
     userRepository = module.get<SequelizeUserRepository>(
       SequelizeUserRepository,

--- a/src/modules/keyserver/key-server.usecase.spec.ts
+++ b/src/modules/keyserver/key-server.usecase.spec.ts
@@ -5,17 +5,22 @@ import {
   InvalidKeyServerException,
   KeyServerUseCases,
 } from './key-server.usecase';
-import { BadRequestException } from '@nestjs/common';
+import { Logger } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
 
 describe('Key Server Use Cases', () => {
   let service: KeyServerUseCases;
   let keyServerRepository: DeepMocked<SequelizeKeyServerRepository>;
 
   beforeEach(async () => {
-    keyServerRepository = createMock<SequelizeKeyServerRepository>();
-    keyServerRepository.findUserKeysOrCreate.mockResolvedValue({} as any);
-
-    service = new KeyServerUseCases(keyServerRepository);
+    const moduleRef = await Test.createTestingModule({
+      providers: [KeyServerUseCases],
+    })
+      .setLogger(createMock<Logger>())
+      .useMocker(() => createMock())
+      .compile();
+    service = moduleRef.get(KeyServerUseCases);
+    keyServerRepository = moduleRef.get(SequelizeKeyServerRepository);
   });
 
   it('when the service is instantiated, then it should be defined', () => {

--- a/src/modules/trash/trash.controller.spec.ts
+++ b/src/modules/trash/trash.controller.spec.ts
@@ -5,13 +5,14 @@ import { FolderUseCases } from '../folder/folder.usecase';
 import { UserUseCases } from '../user/user.usecase';
 import { TrashUseCases } from './trash.usecase';
 import { newUser } from '../../../test/fixtures';
-import { BadRequestException } from '@nestjs/common';
+import { BadRequestException, Logger } from '@nestjs/common';
 import { ItemType } from './dto/controllers/move-items-to-trash.dto';
 import {
   DeleteItemType,
   DeleteItemsDto,
 } from './dto/controllers/delete-item.dto';
 import { StorageNotificationService } from '../../externals/notifications/storage.notifications.service';
+import { Test } from '@nestjs/testing';
 
 const user = newUser();
 const requester = newUser();
@@ -25,18 +26,18 @@ describe('TrashController', () => {
   let storageNotificationService: StorageNotificationService;
 
   beforeEach(async () => {
-    folderUseCases = createMock<FolderUseCases>();
-    fileUseCases = createMock<FileUseCases>();
-    userUseCases = createMock<UserUseCases>();
-    trashUseCases = createMock<TrashUseCases>();
-    storageNotificationService = createMock<StorageNotificationService>();
-    controller = new TrashController(
-      fileUseCases,
-      folderUseCases,
-      userUseCases,
-      storageNotificationService,
-      trashUseCases,
-    );
+    const moduleRef = await Test.createTestingModule({
+      controllers: [TrashController],
+    })
+      .setLogger(createMock<Logger>())
+      .useMocker(() => createMock())
+      .compile();
+    controller = moduleRef.get(TrashController);
+    fileUseCases = moduleRef.get(FileUseCases);
+    userUseCases = moduleRef.get(UserUseCases);
+    storageNotificationService = moduleRef.get(StorageNotificationService);
+    folderUseCases = moduleRef.get(FolderUseCases);
+    trashUseCases = moduleRef.get(TrashUseCases);
   });
 
   it('should be defined', () => {

--- a/src/modules/trash/trash.usecase.spec.ts
+++ b/src/modules/trash/trash.usecase.spec.ts
@@ -1,5 +1,5 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { NotFoundException } from '@nestjs/common';
+import { Logger, NotFoundException } from '@nestjs/common';
 import { createMock } from '@golevelup/ts-jest';
 
 import { TrashUseCases } from './trash.usecase';
@@ -18,6 +18,7 @@ describe('Trash Use Cases', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [TrashUseCases],
     })
+      .setLogger(createMock<Logger>())
       .useMocker(() => createMock())
       .compile();
 

--- a/src/modules/user/user.controller.spec.ts
+++ b/src/modules/user/user.controller.spec.ts
@@ -18,7 +18,6 @@ import { MailLimitReachedException, UserUseCases } from './user.usecase';
 import { NotificationService } from '../../externals/notifications/notification.service';
 import { KeyServerUseCases } from '../keyserver/key-server.usecase';
 import { CryptoService } from '../../externals/crypto/crypto.service';
-import { SharingService } from '../sharing/sharing.service';
 import { SignWithCustomDuration } from '../../middlewares/passport';
 import { AccountTokenAction, User } from './user.domain';
 import { v4 } from 'uuid';
@@ -28,7 +27,7 @@ import { UserKeysEncryptVersions } from '../keyserver/key-server.domain';
 import { UpdatePasswordDto } from './dto/update-password.dto';
 import { CreateUserDto } from './dto/create-user.dto';
 import { RegisterPreCreatedUserDto } from './dto/register-pre-created-user.dto';
-import { Request, Response } from 'express';
+import { Request } from 'express';
 import { DeactivationRequestEvent } from '../../externals/notifications/events/deactivation-request.event';
 import { Test } from '@nestjs/testing';
 

--- a/src/modules/user/user.controller.ts
+++ b/src/modules/user/user.controller.ts
@@ -86,7 +86,7 @@ import { GetUserLimitDto } from './dto/responses/get-user-limit.dto';
 @ApiTags('User')
 @Controller('users')
 export class UserController {
-  private logger = new Logger(UserController.name);
+  private readonly logger = new Logger(UserController.name);
 
   constructor(
     private userUseCases: UserUseCases,

--- a/src/modules/user/user.usecase.spec.ts
+++ b/src/modules/user/user.usecase.spec.ts
@@ -1,4 +1,4 @@
-import { Test, TestingModule } from '@nestjs/testing';
+import { Test } from '@nestjs/testing';
 import { createMock, DeepMocked } from '@golevelup/ts-jest';
 import { AttemptChangeEmailModel } from './attempt-change-email.model';
 import { UserEmailAlreadyInUseException } from './exception/user-email-already-in-use.exception';

--- a/src/modules/user/user.usecase.spec.ts
+++ b/src/modules/user/user.usecase.spec.ts
@@ -1,5 +1,5 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { createMock } from '@golevelup/ts-jest';
+import { createMock, DeepMocked } from '@golevelup/ts-jest';
 import { AttemptChangeEmailModel } from './attempt-change-email.model';
 import { UserEmailAlreadyInUseException } from './exception/user-email-already-in-use.exception';
 
@@ -102,8 +102,7 @@ describe('User use cases', () => {
   let appSumoUseCases: AppSumoUseCase;
   let backupUseCases: BackupUseCase;
   let cacheManagerService: CacheManagerService;
-
-  const loggerErrorSpy = jest.spyOn(Logger, 'error').mockImplementation();
+  let loggerMock: DeepMocked<Logger>;
 
   const user = User.build({
     id: 1,
@@ -136,7 +135,15 @@ describe('User use cases', () => {
   });
 
   beforeEach(async () => {
-    const moduleRef = await createTestingModule();
+    loggerMock = createMock<Logger>();
+
+    const moduleRef = await Test.createTestingModule({
+      controllers: [],
+      providers: [UserUseCases],
+    })
+      .useMocker(() => createMock())
+      .setLogger(loggerMock)
+      .compile();
 
     shareUseCases = moduleRef.get<ShareUseCases>(ShareUseCases);
     folderUseCases = moduleRef.get<FolderUseCases>(FolderUseCases);
@@ -1247,7 +1254,7 @@ describe('User use cases', () => {
 
       userUseCases.logReferralError(userId, new Error());
 
-      expect(loggerErrorSpy).toHaveBeenCalledWith(
+      expect(loggerMock.error).toHaveBeenCalledWith(
         '[STORAGE]: ERROR message undefined applying referral for user %s',
         userId,
       );
@@ -1259,7 +1266,7 @@ describe('User use cases', () => {
 
       userUseCases.logReferralError(userId, error);
 
-      expect(loggerErrorSpy).not.toHaveBeenCalled();
+      expect(loggerMock.error).not.toHaveBeenCalled();
     });
 
     it('When another error is logged, then it should log error message for other errors', () => {
@@ -1268,7 +1275,7 @@ describe('User use cases', () => {
 
       userUseCases.logReferralError(userId, new Error(errorMessage));
 
-      expect(loggerErrorSpy).toHaveBeenCalledWith(
+      expect(loggerMock.error).toHaveBeenCalledWith(
         '[STORAGE]: ERROR applying referral for user %s: %s',
         userId,
         errorMessage,
@@ -1281,7 +1288,7 @@ describe('User use cases', () => {
 
       userUseCases.logReferralError(userId, error);
 
-      expect(loggerErrorSpy).toHaveBeenCalledWith(
+      expect(loggerMock.error).toHaveBeenCalledWith(
         '[STORAGE]: ERROR applying referral for user %s: %s',
         userId,
         'Unknown error',
@@ -2062,9 +2069,6 @@ describe('User use cases', () => {
         .mockResolvedValueOnce({ userId: networkPass, uuid: userMock.uuid });
       jest.spyOn(bridgeService, 'createBucket').mockRejectedValue(bucketError);
 
-      const loggerErrorSpy = jest.spyOn(Logger, 'error').mockImplementation();
-      const loggerWarnSpy = jest.spyOn(Logger, 'warn').mockImplementation();
-
       await expect(
         userUseCases.createUser({
           email: userMock.email,
@@ -2076,8 +2080,8 @@ describe('User use cases', () => {
         }),
       ).rejects.toThrow(bucketError);
 
-      expect(loggerErrorSpy).toHaveBeenCalled();
-      expect(loggerWarnSpy).toHaveBeenCalled();
+      expect(loggerMock.error).toHaveBeenCalled();
+      expect(loggerMock.warn).toHaveBeenCalled();
 
       expect(userRepository.deleteBy).toHaveBeenCalledWith({
         uuid: userMock.uuid,
@@ -2164,12 +2168,3 @@ describe('User use cases', () => {
     });
   });
 });
-
-const createTestingModule = (): Promise<TestingModule> => {
-  return Test.createTestingModule({
-    controllers: [],
-    providers: [UserUseCases],
-  })
-    .useMocker(() => createMock())
-    .compile();
-};

--- a/src/modules/user/user.usecase.ts
+++ b/src/modules/user/user.usecase.ts
@@ -1,5 +1,6 @@
 import {
   BadRequestException,
+  ConflictException,
   ForbiddenException,
   HttpException,
   HttpStatus,
@@ -579,7 +580,7 @@ export class UserUseCases {
     ]);
 
     if (existentUser) {
-      throw new UserAlreadyRegisteredError(newUser.email);
+      throw new ConflictException(newUser.email);
     }
 
     if (preCreatedUser) {

--- a/src/modules/workspaces/workspaces.usecase.spec.ts
+++ b/src/modules/workspaces/workspaces.usecase.spec.ts
@@ -27,6 +27,7 @@ import {
   ConflictException,
   ForbiddenException,
   InternalServerErrorException,
+  Logger,
   NotFoundException,
 } from '@nestjs/common';
 import { PreCreatedUser } from '../user/pre-created-user.domain';
@@ -96,6 +97,7 @@ describe('WorkspacesUsecases', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [WorkspacesUsecases],
     })
+      .setLogger(createMock<Logger>())
       .useMocker(createMock)
       .compile();
 


### PR DESCRIPTION
This just mocks the logger so we do not have a lot of logs when running `yarn test`. Also, I removed the use of Response object to return an error response so we can use the NestJS built-in http errors.