### PR TITLE
feat(PQ): added PQ encryption to replace pre created user function

### DIFF
--- a/src/modules/sharing/sharing.domain.ts
+++ b/src/modules/sharing/sharing.domain.ts
@@ -136,6 +136,10 @@ export class Sharing implements SharingAttributes {
     return this.type === SharingType.Public;
   }
 
+  isHybrid(): boolean {
+    return this.encryptionAlgorithm === 'hybrid';
+  }
+
   isProtected(): boolean {
     return this.encryptedPassword !== null;
   }
@@ -264,6 +268,10 @@ export class SharingInvite implements SharingInviteAttributes {
 
   isSharedWith(user: User): boolean {
     return user.uuid === this.sharedWith;
+  }
+
+  isHybrid(): boolean {
+    return this.encryptionAlgorithm === 'hybrid';
   }
 
   toJSON(): SharingInviteAttributes {

--- a/src/modules/sharing/sharing.repository.ts
+++ b/src/modules/sharing/sharing.repository.ts
@@ -721,7 +721,7 @@ export class SequelizeSharingRepository implements SharingRepository {
       },
     });
 
-    return invites.map((i) => i.toJSON<SharingInvite>());
+    return invites.map((i) => SharingInvite.build(i.toJSON<SharingInvite>()));
   }
 
   async bulkUpdate(invites: Partial<SharingInvite>[]): Promise<void> {

--- a/src/modules/user/pre-created-user.domain.ts
+++ b/src/modules/user/pre-created-user.domain.ts
@@ -13,6 +13,8 @@ export class PreCreatedUser implements PreCreatedUserAttributes {
   privateKey: string;
   revocationKey: string;
   encryptVersion: UserKeysEncryptVersions;
+  publicKyberKey?: string;
+  privateKyberKey?: string;
   constructor({
     id,
     email,
@@ -25,6 +27,8 @@ export class PreCreatedUser implements PreCreatedUserAttributes {
     privateKey,
     revocationKey,
     encryptVersion,
+    publicKyberKey,
+    privateKyberKey,
   }: PreCreatedUserAttributes) {
     this.id = id;
     this.uuid = uuid;
@@ -33,6 +37,8 @@ export class PreCreatedUser implements PreCreatedUserAttributes {
     this.privateKey = privateKey;
     this.revocationKey = revocationKey;
     this.encryptVersion = encryptVersion;
+    this.publicKyberKey = publicKyberKey;
+    this.privateKyberKey = privateKyberKey;
     this.username = username;
     this.password = password;
     this.mnemonic = mnemonic;

--- a/src/modules/user/pre-created-users.attributes.ts
+++ b/src/modules/user/pre-created-users.attributes.ts
@@ -13,4 +13,6 @@ export interface PreCreatedUserAttributes {
   privateKey: KeyServerAttributes['privateKey'];
   revocationKey: KeyServerAttributes['revocationKey'];
   encryptVersion: KeyServerAttributes['encryptVersion'];
+  publicKyberKey?: KeyServerAttributes['publicKey'];
+  privateKyberKey?: KeyServerAttributes['privateKey'];
 }

--- a/src/modules/user/pre-created-users.model.ts
+++ b/src/modules/user/pre-created-users.model.ts
@@ -48,6 +48,14 @@ export class PreCreatedUserModel
   @Column(DataType.STRING)
   encryptVersion: KeyServerAttributes['encryptVersion'];
 
+  @AllowNull(true)
+  @Column(DataType.STRING(4000))
+  privateKyberKey?: string;
+
+  @AllowNull(true)
+  @Column(DataType.STRING(2000))
+  publicKyberKey?: string;
+
   @Column
   password: string;
 

--- a/src/modules/user/user.module.ts
+++ b/src/modules/user/user.module.ts
@@ -49,6 +49,7 @@ import { SequelizeWorkspaceRepository } from '../workspaces/repositories/workspa
 import { UserNotificationTokensModel } from './user-notification-tokens.model';
 import { BackupModule } from '../backups/backup.module';
 import { CacheManagerModule } from '../cache-manager/cache-manager.module';
+import { AsymmetricEncryptionModule } from '../../externals/asymmetric-encryption/asymmetric-encryption.module';
 
 @Module({
   imports: [
@@ -78,6 +79,7 @@ import { CacheManagerModule } from '../cache-manager/cache-manager.module';
     forwardRef(() => WorkspacesModule),
     forwardRef(() => BackupModule),
     CacheManagerModule,
+    AsymmetricEncryptionModule,
   ],
   controllers: [UserController],
   providers: [

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -226,6 +226,8 @@ export const newPreCreatedUser = (): PreCreatedUser => {
     privateKey: '',
     revocationKey: '',
     encryptVersion: UserKeysEncryptVersions.Ecc,
+    privateKyberKey: 'private-kyber-key',
+    publicKyberKey: 'public-kyber-key',
   });
 };
 


### PR DESCRIPTION
This is just a part of the code already approved here: https://github.com/internxt/drive-server-wip/pull/465. 

I am splitting that PR into multiple PRs so we can support this feature incrementally without breaking any platform. 
No hybrid encryption is going to be taken into account for pre created users yet, this just prepares the function to support it.

**Workspaces are not affected by this.**

Changes

1. Decrypt private key using hybrid decryption functions
2. Support for hybrid encryption when replacing pre created users sharings invitations