### PR TITLE
feat(recover-account): add reset workspace functions

### DIFF
--- a/src/modules/folder/folder.repository.ts
+++ b/src/modules/folder/folder.repository.ts
@@ -691,6 +691,27 @@ export class SequelizeFolderRepository implements FolderRepository {
       },
     );
   }
+  async deleteByUserAndUuids(
+    user: User,
+    folderUuids: Folder['uuid'][],
+  ): Promise<void> {
+    await this.folderModel.update(
+      {
+        removed: true,
+        removedAt: new Date(),
+        deleted: true,
+        deletedAt: new Date(),
+      },
+      {
+        where: {
+          userId: user.id,
+          uuid: {
+            [Op.in]: folderUuids,
+          },
+        },
+      },
+    );
+  }
 
   async findAllCursorWhereUpdatedAfter(
     where: Partial<Folder>,

--- a/src/modules/folder/folder.usecase.ts
+++ b/src/modules/folder/folder.usecase.ts
@@ -464,6 +464,11 @@ export class FolderUseCases {
       deletedAt: new Date(),
     });
   }
+
+  async deleteByUuids(user: User, uuids: Folder['uuid'][]): Promise<void> {
+    await this.folderRepository.deleteByUserAndUuids(user, uuids);
+  }
+
   async moveFoldersToTrash(
     user: User,
     folderIds: FolderAttributes['id'][],

--- a/src/modules/workspaces/repositories/workspaces.repository.spec.ts
+++ b/src/modules/workspaces/repositories/workspaces.repository.spec.ts
@@ -665,4 +665,43 @@ describe('SequelizeWorkspaceRepository', () => {
       );
     });
   });
+
+  describe('findWorkspaceUsersByUserUuid', () => {
+    it('When workspaceUsers are found for respective user, then it should return instances of workspaceUser', async () => {
+      const mockUser = newUser();
+      const mockWorkspaceUser = newWorkspaceUser({ memberId: mockUser.uuid });
+      const mockWorkspaceUserModelResponse = {
+        ...mockWorkspaceUser,
+        toJSON: jest.fn().mockReturnValue({
+          ...mockWorkspaceUser,
+        }),
+      };
+
+      jest
+        .spyOn(workspaceUserModel, 'findAll')
+        .mockResolvedValueOnce([mockWorkspaceUserModelResponse] as any);
+
+      const result = await repository.findWorkspaceUsersByUserUuid(
+        mockUser.uuid,
+      );
+
+      expect(result).toBeInstanceOf(Array);
+      expect(result[0]).toBeInstanceOf(WorkspaceUser);
+      expect(result[0].id).toBe(mockWorkspaceUser.id);
+      expect(result[0].memberId).toBe(mockWorkspaceUser.memberId);
+    });
+
+    it('When workspaceUsers are not found for respective user, then it should return empty array', async () => {
+      const mockUser = newUser();
+
+      jest.spyOn(workspaceUserModel, 'findAll').mockResolvedValueOnce([]);
+
+      const result = await repository.findWorkspaceUsersByUserUuid(
+        mockUser.uuid,
+      );
+
+      expect(result).toBeInstanceOf(Array);
+      expect(result.length).toEqual(0);
+    });
+  });
 });

--- a/src/modules/workspaces/repositories/workspaces.repository.ts
+++ b/src/modules/workspaces/repositories/workspaces.repository.ts
@@ -361,6 +361,40 @@ export class SequelizeWorkspaceRepository {
     );
   }
 
+  async findWorkspaceUsersByUserUuid(
+    userUuid: string,
+  ): Promise<WorkspaceUser[]> {
+    const workspaceUsers = await this.modelWorkspaceUser.findAll({
+      where: { memberId: userUuid },
+    });
+    return workspaceUsers.map((user) => this.workspaceUserToDomain(user));
+  }
+
+  async deleteUsersFromWorkspace(
+    workspaceId: WorkspaceUser['id'],
+    memberIds: WorkspaceUser['memberId'][],
+  ): Promise<void> {
+    await this.modelWorkspaceUser.destroy({
+      where: { memberId: { [Op.in]: memberIds }, workspaceId },
+    });
+  }
+
+  async deleteAllInvitationsByWorkspace(
+    workspaceId: WorkspaceAttributes['id'],
+  ): Promise<void> {
+    await this.modelWorkspaceInvite.destroy({
+      where: { workspaceId },
+    });
+  }
+
+  async deleteAllInvitationByUser(
+    userUUid: WorkspaceInviteAttributes['invitedUser'],
+  ): Promise<void> {
+    await this.modelWorkspaceInvite.destroy<WorkspaceInviteModel>({
+      where: { invitedUser: userUUid },
+    });
+  }
+
   async findUserAvailableWorkspaces(userUuid: string) {
     const userWorkspaces = await this.modelWorkspaceUser.findAll({
       where: { memberId: userUuid },

--- a/src/modules/workspaces/workspaces.usecase.ts
+++ b/src/modules/workspaces/workspaces.usecase.ts
@@ -3007,4 +3007,73 @@ export class WorkspacesUsecases {
       plainName: f.plainName,
     }));
   }
+
+  async resetWorkspace(workspace: Workspace): Promise<void> {
+    const workspaceNetworkUser = await this.userRepository.findByUuid(
+      workspace.workspaceUserId,
+    );
+
+    const allMembers = await this.workspaceRepository.findWorkspaceUsers(
+      workspace.id,
+    );
+    const ownerMember = allMembers.find(
+      (member) => member.memberId === workspace.ownerId,
+    );
+    const nonOwnerMembers = allMembers.filter(
+      (member) => member.id !== ownerMember.id,
+    );
+
+    await this.folderUseCases.deleteByUuids(
+      workspaceNetworkUser,
+      nonOwnerMembers.map((members) => members.rootFolderId),
+    );
+
+    await this.workspaceRepository.deleteUsersFromWorkspace(
+      workspace.id,
+      nonOwnerMembers.map((member) => member.memberId),
+    );
+
+    await this.workspaceRepository.deleteAllInvitationsByWorkspace(
+      workspace.id,
+    );
+
+    const workspaceTotalSpace = await this.getWorkspaceNetworkLimit(workspace);
+
+    await this.workspaceRepository.updateWorkspaceUserBy(
+      { workspaceId: workspace.id, memberId: workspace.ownerId },
+      { spaceLimit: workspaceTotalSpace },
+    );
+  }
+
+  async emptyAllUserOwnedWorkspaces(user: User): Promise<void> {
+    const workspaces = await this.workspaceRepository.findByOwner(user.uuid);
+
+    await Promise.all(
+      workspaces.map((workspace) => this.resetWorkspace(workspace)),
+    );
+  }
+
+  async removeUserFromNonOwnedWorkspaces(user: User): Promise<void> {
+    const ownedWorkspaces = await this.workspaceRepository.findByOwner(
+      user.uuid,
+    );
+
+    const allWorkspaceMemberships =
+      await this.workspaceRepository.findWorkspaceUsersByUserUuid(user.uuid);
+
+    const nonOwnedWorkspaceMemberships = allWorkspaceMemberships.filter(
+      (membership) =>
+        !ownedWorkspaces.some(
+          (workspace) => workspace.id === membership.workspaceId,
+        ),
+    );
+
+    await this.workspaceRepository.deleteAllInvitationByUser(user.uuid);
+
+    await Promise.all(
+      nonOwnedWorkspaceMemberships.map((membership) =>
+        this.leaveWorkspace(membership.workspaceId, user),
+      ),
+    );
+  }
 }


### PR DESCRIPTION
This is just a PR that adds some of the functions we will need for recovering/resetting users' accounts. This just takes functions from https://github.com/internxt/drive-server-wip/pull/506 to split the PR into small pieces.

### Changes

1. Added empty workspace function. 
2. Added remove user from all invited workspaces.
