### PR TITLE
[PB-4092]: fix/find-files-with-empty-type

### DIFF
--- a/src/externals/asymmetric-encryption/asymmetric-encryption.service.spec.ts
+++ b/src/externals/asymmetric-encryption/asymmetric-encryption.service.spec.ts
@@ -8,15 +8,22 @@ import {
 
 describe('AsymmetricEncryptionService', () => {
   let service: AsymmetricEncryptionService;
+  let moduleFixture: TestingModule;
 
   beforeEach(async () => {
-    const module: TestingModule = await Test.createTestingModule({
+    moduleFixture = await Test.createTestingModule({
       providers: [AsymmetricEncryptionService, KyberProvider],
     }).compile();
 
-    service = module.get<AsymmetricEncryptionService>(
+    await moduleFixture.init();
+
+    service = moduleFixture.get<AsymmetricEncryptionService>(
       AsymmetricEncryptionService,
     );
+  });
+
+  afterAll(async () => {
+    await moduleFixture.close();
   });
 
   it('When tests are created, then expected mocks should be created', () => {

--- a/src/externals/asymmetric-encryption/asymmetric-encryption.service.spec.ts
+++ b/src/externals/asymmetric-encryption/asymmetric-encryption.service.spec.ts
@@ -8,10 +8,9 @@ import {
 
 describe('AsymmetricEncryptionService', () => {
   let service: AsymmetricEncryptionService;
-  let moduleFixture: TestingModule;
 
   beforeEach(async () => {
-    moduleFixture = await Test.createTestingModule({
+    const moduleFixture: TestingModule = await Test.createTestingModule({
       providers: [AsymmetricEncryptionService, KyberProvider],
     }).compile();
 
@@ -20,10 +19,6 @@ describe('AsymmetricEncryptionService', () => {
     service = moduleFixture.get<AsymmetricEncryptionService>(
       AsymmetricEncryptionService,
     );
-  });
-
-  afterAll(async () => {
-    await moduleFixture.close();
   });
 
   it('When tests are created, then expected mocks should be created', () => {

--- a/src/externals/asymmetric-encryption/asymmetric-encryption.service.spec.ts
+++ b/src/externals/asymmetric-encryption/asymmetric-encryption.service.spec.ts
@@ -10,13 +10,13 @@ describe('AsymmetricEncryptionService', () => {
   let service: AsymmetricEncryptionService;
 
   beforeEach(async () => {
-    const moduleFixture: TestingModule = await Test.createTestingModule({
+    const module: TestingModule = await Test.createTestingModule({
       providers: [AsymmetricEncryptionService, KyberProvider],
     }).compile();
 
-    await moduleFixture.init();
+    await module.init();
 
-    service = moduleFixture.get<AsymmetricEncryptionService>(
+    service = module.get<AsymmetricEncryptionService>(
       AsymmetricEncryptionService,
     );
   });

--- a/src/lib/path.spec.ts
+++ b/src/lib/path.spec.ts
@@ -10,12 +10,28 @@ describe('Path class', () => {
       expect(path.folderPath).toBe('/folder1/folder2');
     });
 
+    it('When getPathFileData is called with a file with extension, then it returns its current data', () => {
+      const testPath = '/rootfilewithextension.test';
+      const path = service.getPathFileData(testPath);
+      expect(path.fileName).toBe('rootfilewithextension');
+      expect(path.fileType).toBe('test');
+      expect(path.folderPath).toBe('/');
+    });
+
     it('When getPathFileData is called with a file without extension, then it returns its current data', () => {
       const testPath = '/rootfilewithoutextension';
       const path = service.getPathFileData(testPath);
       expect(path.fileName).toBe('rootfilewithoutextension');
       expect(path.fileType).toBeNull();
       expect(path.folderPath).toBe('/');
+    });
+
+    it('When getPathFileData is called with a file without extension, then it returns its current data', () => {
+      const testPath = '/folder1/folder2/file';
+      const path = service.getPathFileData(testPath);
+      expect(path.fileName).toBe('file');
+      expect(path.fileType).toBeNull();
+      expect(path.folderPath).toBe('/folder1/folder2');
     });
   });
 

--- a/src/modules/file/file.repository.spec.ts
+++ b/src/modules/file/file.repository.spec.ts
@@ -1,7 +1,12 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { getModelToken } from '@nestjs/sequelize';
 import { createMock } from '@golevelup/ts-jest';
-import { newFile, newUser, newWorkspace } from '../../../test/fixtures';
+import {
+  newFile,
+  newFolder,
+  newUser,
+  newWorkspace,
+} from '../../../test/fixtures';
 import { FileAttributes, FileStatus } from './file.domain';
 import { FileModel } from './file.model';
 import { FileRepository, SequelizeFileRepository } from './file.repository';
@@ -127,6 +132,101 @@ describe('FileRepository', () => {
               plainName: 'Report',
             },
           ],
+        }),
+      });
+    });
+  });
+
+  describe('findByPlainNameAndFolderId', () => {
+    it('When file is searched with empty type, it should find it', async () => {
+      const mockFile = newFile({ attributes: { type: '' } });
+
+      const model: FileModel = {
+        ...mockFile,
+        user: newUser(),
+        folder: newFolder(),
+        toJSON: mockFile.toJSON,
+      } as any;
+
+      jest.spyOn(fileModel, 'findOne').mockResolvedValueOnce(model);
+
+      await repository.findByPlainNameAndFolderId(
+        mockFile.userId,
+        mockFile.plainName,
+        mockFile.type,
+        mockFile.folderId,
+        mockFile.status,
+      );
+
+      expect(fileModel.findOne).toHaveBeenCalledWith({
+        where: expect.objectContaining({
+          userId: { [Op.eq]: mockFile.userId },
+          plainName: { [Op.eq]: mockFile.plainName },
+          type: { [Op.or]: [{ [Op.is]: null }, { [Op.eq]: '' }] },
+          folderId: { [Op.eq]: mockFile.folderId },
+          status: { [Op.eq]: mockFile.status },
+        }),
+      });
+    });
+
+    it('When file is searched with null type, it should find it', async () => {
+      const mockFile = newFile({ attributes: { type: null } });
+
+      const model: FileModel = {
+        ...mockFile,
+        user: newUser(),
+        folder: newFolder(),
+        toJSON: mockFile.toJSON,
+      } as any;
+
+      jest.spyOn(fileModel, 'findOne').mockResolvedValueOnce(model);
+
+      await repository.findByPlainNameAndFolderId(
+        mockFile.userId,
+        mockFile.plainName,
+        mockFile.type,
+        mockFile.folderId,
+        mockFile.status,
+      );
+
+      expect(fileModel.findOne).toHaveBeenCalledWith({
+        where: expect.objectContaining({
+          userId: { [Op.eq]: mockFile.userId },
+          plainName: { [Op.eq]: mockFile.plainName },
+          type: { [Op.or]: [{ [Op.is]: null }, { [Op.eq]: '' }] },
+          folderId: { [Op.eq]: mockFile.folderId },
+          status: { [Op.eq]: mockFile.status },
+        }),
+      });
+    });
+
+    it('When file is searched with type, it should find it', async () => {
+      const mockFile = newFile();
+
+      const model: FileModel = {
+        ...mockFile,
+        user: newUser(),
+        folder: newFolder(),
+        toJSON: mockFile.toJSON,
+      } as any;
+
+      jest.spyOn(fileModel, 'findOne').mockResolvedValueOnce(model);
+
+      await repository.findByPlainNameAndFolderId(
+        mockFile.userId,
+        mockFile.plainName,
+        mockFile.type,
+        mockFile.folderId,
+        mockFile.status,
+      );
+
+      expect(fileModel.findOne).toHaveBeenCalledWith({
+        where: expect.objectContaining({
+          userId: { [Op.eq]: mockFile.userId },
+          plainName: { [Op.eq]: mockFile.plainName },
+          type: { [Op.eq]: mockFile.type },
+          folderId: { [Op.eq]: mockFile.folderId },
+          status: { [Op.eq]: mockFile.status },
         }),
       });
     });

--- a/src/modules/file/file.repository.ts
+++ b/src/modules/file/file.repository.ts
@@ -215,11 +215,16 @@ export class SequelizeFileRepository implements FileRepository {
     folderId: FileAttributes['folderId'],
     status: FileAttributes['status'],
   ): Promise<File | null> {
+    const typeCondition =
+      type == null || type.trim() === ''
+        ? { [Op.or]: [{ [Op.is]: null }, { [Op.eq]: '' }] }
+        : { [Op.eq]: type };
+
     const file = await this.fileModel.findOne({
       where: {
         userId: { [Op.eq]: userId },
         plainName: { [Op.eq]: plainName },
-        type: { [Op.eq]: type },
+        type: typeCondition,
         folderId: { [Op.eq]: folderId },
         status: { [Op.eq]: status },
       },

--- a/src/modules/user/user.usecase.spec.ts
+++ b/src/modules/user/user.usecase.spec.ts
@@ -1,4 +1,4 @@
-import { Test } from '@nestjs/testing';
+import { Test, TestingModule } from '@nestjs/testing';
 import { createMock, DeepMocked } from '@golevelup/ts-jest';
 import { AttemptChangeEmailModel } from './attempt-change-email.model';
 import { UserEmailAlreadyInUseException } from './exception/user-email-already-in-use.exception';
@@ -113,6 +113,7 @@ describe('User use cases', () => {
   let sharingRepository: SequelizeSharingRepository;
   let preCreatedUsersRepository: SequelizePreCreatedUsersRepository;
   let asymmetricEncryptionService: AsymmetricEncryptionService;
+  let moduleFixture: TestingModule;
 
   const user = User.build({
     id: 1,
@@ -148,7 +149,7 @@ describe('User use cases', () => {
     jest.clearAllMocks();
     loggerMock = createMock<Logger>();
 
-    const moduleRef = await Test.createTestingModule({
+    moduleFixture = await Test.createTestingModule({
       controllers: [],
       providers: [UserUseCases, AsymmetricEncryptionService, KyberProvider],
     })
@@ -156,55 +157,62 @@ describe('User use cases', () => {
       .setLogger(loggerMock)
       .compile();
 
-    shareUseCases = moduleRef.get<ShareUseCases>(ShareUseCases);
-    folderUseCases = moduleRef.get<FolderUseCases>(FolderUseCases);
-    fileUseCases = moduleRef.get<FileUseCases>(FileUseCases);
-    userUseCases = moduleRef.get<UserUseCases>(UserUseCases);
-    configService = moduleRef.get<ConfigService>(ConfigService);
-    userRepository = moduleRef.get<SequelizeUserRepository>(
+    await moduleFixture.init();
+
+    shareUseCases = moduleFixture.get<ShareUseCases>(ShareUseCases);
+    folderUseCases = moduleFixture.get<FolderUseCases>(FolderUseCases);
+    fileUseCases = moduleFixture.get<FileUseCases>(FileUseCases);
+    userUseCases = moduleFixture.get<UserUseCases>(UserUseCases);
+    configService = moduleFixture.get<ConfigService>(ConfigService);
+    userRepository = moduleFixture.get<SequelizeUserRepository>(
       SequelizeUserRepository,
     );
-    keyServerRepository = moduleRef.get<SequelizeKeyServerRepository>(
+    keyServerRepository = moduleFixture.get<SequelizeKeyServerRepository>(
       SequelizeKeyServerRepository,
     );
-    bridgeService = moduleRef.get<BridgeService>(BridgeService);
-    userRepository = moduleRef.get<SequelizeUserRepository>(
+    bridgeService = moduleFixture.get<BridgeService>(BridgeService);
+    userRepository = moduleFixture.get<SequelizeUserRepository>(
       SequelizeUserRepository,
     );
     sharedWorkspaceRepository =
-      moduleRef.get<SequelizeSharedWorkspaceRepository>(
+      moduleFixture.get<SequelizeSharedWorkspaceRepository>(
         SequelizeSharedWorkspaceRepository,
       );
-    cryptoService = moduleRef.get<CryptoService>(CryptoService);
+    cryptoService = moduleFixture.get<CryptoService>(CryptoService);
     attemptChangeEmailRepository =
-      moduleRef.get<SequelizeAttemptChangeEmailRepository>(
+      moduleFixture.get<SequelizeAttemptChangeEmailRepository>(
         SequelizeAttemptChangeEmailRepository,
       );
-    configService = moduleRef.get<ConfigService>(ConfigService);
-    mailLimitRepository = moduleRef.get<SequelizeMailLimitRepository>(
+    configService = moduleFixture.get<ConfigService>(ConfigService);
+    mailLimitRepository = moduleFixture.get<SequelizeMailLimitRepository>(
       SequelizeMailLimitRepository,
     );
-    workspaceRepository = moduleRef.get<SequelizeWorkspaceRepository>(
+    workspaceRepository = moduleFixture.get<SequelizeWorkspaceRepository>(
       SequelizeWorkspaceRepository,
     );
-    mailerService = moduleRef.get<MailerService>(MailerService);
-    avatarService = moduleRef.get<AvatarService>(AvatarService);
-    keyServerUseCases = moduleRef.get<KeyServerUseCases>(KeyServerUseCases);
+    mailerService = moduleFixture.get<MailerService>(MailerService);
+    avatarService = moduleFixture.get<AvatarService>(AvatarService);
+    keyServerUseCases = moduleFixture.get<KeyServerUseCases>(KeyServerUseCases);
 
-    appSumoUseCases = moduleRef.get<AppSumoUseCase>(AppSumoUseCase);
-    backupUseCases = moduleRef.get<BackupUseCase>(BackupUseCase);
+    appSumoUseCases = moduleFixture.get<AppSumoUseCase>(AppSumoUseCase);
+    backupUseCases = moduleFixture.get<BackupUseCase>(BackupUseCase);
     cacheManagerService =
-      moduleRef.get<CacheManagerService>(CacheManagerService);
-    sharingRepository = moduleRef.get<SequelizeSharingRepository>(
+      moduleFixture.get<CacheManagerService>(CacheManagerService);
+    sharingRepository = moduleFixture.get<SequelizeSharingRepository>(
       SequelizeSharingRepository,
     );
     preCreatedUsersRepository =
-      moduleRef.get<SequelizePreCreatedUsersRepository>(
+      moduleFixture.get<SequelizePreCreatedUsersRepository>(
         SequelizePreCreatedUsersRepository,
       );
-    asymmetricEncryptionService = moduleRef.get<AsymmetricEncryptionService>(
-      AsymmetricEncryptionService,
-    );
+    asymmetricEncryptionService =
+      moduleFixture.get<AsymmetricEncryptionService>(
+        AsymmetricEncryptionService,
+      );
+  });
+
+  afterAll(async () => {
+    await moduleFixture.close();
   });
 
   describe('Resetting a user', () => {

--- a/src/modules/user/user.usecase.spec.ts
+++ b/src/modules/user/user.usecase.spec.ts
@@ -113,7 +113,6 @@ describe('User use cases', () => {
   let sharingRepository: SequelizeSharingRepository;
   let preCreatedUsersRepository: SequelizePreCreatedUsersRepository;
   let asymmetricEncryptionService: AsymmetricEncryptionService;
-  let moduleFixture: TestingModule;
 
   const user = User.build({
     id: 1,
@@ -149,7 +148,7 @@ describe('User use cases', () => {
     jest.clearAllMocks();
     loggerMock = createMock<Logger>();
 
-    moduleFixture = await Test.createTestingModule({
+    const moduleFixture: TestingModule = await Test.createTestingModule({
       controllers: [],
       providers: [UserUseCases, AsymmetricEncryptionService, KyberProvider],
     })
@@ -209,10 +208,6 @@ describe('User use cases', () => {
       moduleFixture.get<AsymmetricEncryptionService>(
         AsymmetricEncryptionService,
       );
-  });
-
-  afterAll(async () => {
-    await moduleFixture.close();
   });
 
   describe('Resetting a user', () => {

--- a/src/modules/user/user.usecase.spec.ts
+++ b/src/modules/user/user.usecase.spec.ts
@@ -148,7 +148,7 @@ describe('User use cases', () => {
     jest.clearAllMocks();
     loggerMock = createMock<Logger>();
 
-    const moduleFixture: TestingModule = await Test.createTestingModule({
+    const moduleRef: TestingModule = await Test.createTestingModule({
       controllers: [],
       providers: [UserUseCases, AsymmetricEncryptionService, KyberProvider],
     })
@@ -156,58 +156,57 @@ describe('User use cases', () => {
       .setLogger(loggerMock)
       .compile();
 
-    await moduleFixture.init();
+    await moduleRef.init();
 
-    shareUseCases = moduleFixture.get<ShareUseCases>(ShareUseCases);
-    folderUseCases = moduleFixture.get<FolderUseCases>(FolderUseCases);
-    fileUseCases = moduleFixture.get<FileUseCases>(FileUseCases);
-    userUseCases = moduleFixture.get<UserUseCases>(UserUseCases);
-    configService = moduleFixture.get<ConfigService>(ConfigService);
-    userRepository = moduleFixture.get<SequelizeUserRepository>(
+    shareUseCases = moduleRef.get<ShareUseCases>(ShareUseCases);
+    folderUseCases = moduleRef.get<FolderUseCases>(FolderUseCases);
+    fileUseCases = moduleRef.get<FileUseCases>(FileUseCases);
+    userUseCases = moduleRef.get<UserUseCases>(UserUseCases);
+    configService = moduleRef.get<ConfigService>(ConfigService);
+    userRepository = moduleRef.get<SequelizeUserRepository>(
       SequelizeUserRepository,
     );
-    keyServerRepository = moduleFixture.get<SequelizeKeyServerRepository>(
+    keyServerRepository = moduleRef.get<SequelizeKeyServerRepository>(
       SequelizeKeyServerRepository,
     );
-    bridgeService = moduleFixture.get<BridgeService>(BridgeService);
-    userRepository = moduleFixture.get<SequelizeUserRepository>(
+    bridgeService = moduleRef.get<BridgeService>(BridgeService);
+    userRepository = moduleRef.get<SequelizeUserRepository>(
       SequelizeUserRepository,
     );
     sharedWorkspaceRepository =
-      moduleFixture.get<SequelizeSharedWorkspaceRepository>(
+      moduleRef.get<SequelizeSharedWorkspaceRepository>(
         SequelizeSharedWorkspaceRepository,
       );
-    cryptoService = moduleFixture.get<CryptoService>(CryptoService);
+    cryptoService = moduleRef.get<CryptoService>(CryptoService);
     attemptChangeEmailRepository =
-      moduleFixture.get<SequelizeAttemptChangeEmailRepository>(
+      moduleRef.get<SequelizeAttemptChangeEmailRepository>(
         SequelizeAttemptChangeEmailRepository,
       );
-    configService = moduleFixture.get<ConfigService>(ConfigService);
-    mailLimitRepository = moduleFixture.get<SequelizeMailLimitRepository>(
+    configService = moduleRef.get<ConfigService>(ConfigService);
+    mailLimitRepository = moduleRef.get<SequelizeMailLimitRepository>(
       SequelizeMailLimitRepository,
     );
-    workspaceRepository = moduleFixture.get<SequelizeWorkspaceRepository>(
+    workspaceRepository = moduleRef.get<SequelizeWorkspaceRepository>(
       SequelizeWorkspaceRepository,
     );
-    mailerService = moduleFixture.get<MailerService>(MailerService);
-    avatarService = moduleFixture.get<AvatarService>(AvatarService);
-    keyServerUseCases = moduleFixture.get<KeyServerUseCases>(KeyServerUseCases);
+    mailerService = moduleRef.get<MailerService>(MailerService);
+    avatarService = moduleRef.get<AvatarService>(AvatarService);
+    keyServerUseCases = moduleRef.get<KeyServerUseCases>(KeyServerUseCases);
 
-    appSumoUseCases = moduleFixture.get<AppSumoUseCase>(AppSumoUseCase);
-    backupUseCases = moduleFixture.get<BackupUseCase>(BackupUseCase);
+    appSumoUseCases = moduleRef.get<AppSumoUseCase>(AppSumoUseCase);
+    backupUseCases = moduleRef.get<BackupUseCase>(BackupUseCase);
     cacheManagerService =
-      moduleFixture.get<CacheManagerService>(CacheManagerService);
-    sharingRepository = moduleFixture.get<SequelizeSharingRepository>(
+      moduleRef.get<CacheManagerService>(CacheManagerService);
+    sharingRepository = moduleRef.get<SequelizeSharingRepository>(
       SequelizeSharingRepository,
     );
     preCreatedUsersRepository =
-      moduleFixture.get<SequelizePreCreatedUsersRepository>(
+      moduleRef.get<SequelizePreCreatedUsersRepository>(
         SequelizePreCreatedUsersRepository,
       );
-    asymmetricEncryptionService =
-      moduleFixture.get<AsymmetricEncryptionService>(
-        AsymmetricEncryptionService,
-      );
+    asymmetricEncryptionService = moduleRef.get<AsymmetricEncryptionService>(
+      AsymmetricEncryptionService,
+    );
   });
 
   describe('Resetting a user', () => {


### PR DESCRIPTION
- Files without an extension are now found regardless of their empty-null value

Another PR will be needed to address this duality (empty vs. null) by setting only one as the default and preventing the other from occurring