### PR TITLE
[PB-3702] feat(reset-account): empty workspace and sharings when user resets their account

### DIFF
--- a/src/modules/folder/folder.module.ts
+++ b/src/modules/folder/folder.module.ts
@@ -7,7 +7,6 @@ import { FileModule } from '../file/file.module';
 import { CryptoModule } from '../../externals/crypto/crypto.module';
 import { CryptoService } from '../../externals/crypto/crypto.service';
 import { FolderController } from './folder.controller';
-import { UserModel } from '../user/user.model';
 import { UserModule } from '../user/user.module';
 import { SharingModule } from '../sharing/sharing.module';
 import { WorkspacesModule } from '../workspaces/workspaces.module';
@@ -15,7 +14,7 @@ import { NotificationModule } from '../../externals/notifications/notifications.
 
 @Module({
   imports: [
-    SequelizeModule.forFeature([FolderModel, UserModel]),
+    SequelizeModule.forFeature([FolderModel]),
     forwardRef(() => FileModule),
     forwardRef(() => UserModule),
     CryptoModule,

--- a/src/modules/user/user.module.ts
+++ b/src/modules/user/user.module.ts
@@ -33,12 +33,10 @@ import { ShareModule } from '../share/share.module';
 import { KeyServerModel } from '../keyserver/key-server.model';
 import { AvatarService } from '../../externals/avatar/avatar.service';
 import { AppSumoModule } from '../app-sumo/app-sumo.module';
-import { AppSumoUseCase } from '../app-sumo/app-sumo.usecase';
 import { PlanModule } from '../plan/plan.module';
 import { SequelizePreCreatedUsersRepository } from './pre-created-users.repository';
 import { PreCreatedUserModel } from './pre-created-users.model';
 import { SharingModule } from '../sharing/sharing.module';
-import { SharingService } from '../sharing/sharing.service';
 import { SequelizeAttemptChangeEmailRepository } from './attempt-change-email.repository';
 import { AttemptChangeEmailModel } from './attempt-change-email.model';
 import { MailerService } from '../../externals/mailer/mailer.service';
@@ -98,10 +96,6 @@ import { AsymmetricEncryptionModule } from '../../externals/asymmetric-encryptio
     PaymentsService,
     NewsletterService,
     AvatarService,
-    BridgeService,
-    PaymentsService,
-    AppSumoUseCase,
-    SharingService,
     MailerService,
   ],
   exports: [

--- a/src/modules/workspaces/workspaces.usecase.ts
+++ b/src/modules/workspaces/workspaces.usecase.ts
@@ -2,6 +2,8 @@ import {
   BadRequestException,
   ConflictException,
   ForbiddenException,
+  forwardRef,
+  Inject,
   Injectable,
   InternalServerErrorException,
   Logger,
@@ -81,14 +83,18 @@ export class WorkspacesUsecases {
   constructor(
     private readonly teamRepository: SequelizeWorkspaceTeamRepository,
     private readonly workspaceRepository: SequelizeWorkspaceRepository,
+    @Inject(forwardRef(() => SharingService))
     private readonly sharingUseCases: SharingService,
     private readonly paymentService: PaymentsService,
     private readonly networkService: BridgeService,
     private readonly userRepository: SequelizeUserRepository,
+    @Inject(forwardRef(() => UserUseCases))
     private readonly userUsecases: UserUseCases,
     private readonly configService: ConfigService,
     private readonly mailerService: MailerService,
+    @Inject(forwardRef(() => FileUseCases))
     private readonly fileUseCases: FileUseCases,
+    @Inject(forwardRef(() => FolderUseCases))
     private readonly folderUseCases: FolderUseCases,
     private readonly avatarService: AvatarService,
     private readonly fuzzySearchUseCases: FuzzySearchUseCases,


### PR DESCRIPTION
### Changes

1. User is removed from non owned workspaces when they reset their password. All owned files are transferred to the owner.
2. Sharings are removed when users reset their account