### PR TITLE
[_] fix(tests): fixed tests failing randomly due to kyber provider

### DIFF
--- a/src/lib/import-esm-package.ts
+++ b/src/lib/import-esm-package.ts
@@ -2,9 +2,17 @@
  * Dynamically imports an ESM package in a CommonJS NestJS project,
  * avoiding TypeScript transpilation to `require()`, which ESM packages do not support.
  */
+
 export const importEsmPackage = async <ReturnType>(
   packageName: string,
-): Promise<ReturnType> =>
-  new Function(`return import('${packageName}')`)().then(
-    (loadedModule: unknown) => loadedModule['default'] ?? loadedModule,
-  );
+): Promise<ReturnType> => {
+  try {
+    const modulePromise = eval(`import('${packageName}')`);
+    const module = await modulePromise;
+
+    return (module.default || module) as ReturnType;
+  } catch (error) {
+    console.error(`Error importing ESM package ${packageName}:`, error);
+    throw error;
+  }
+};


### PR DESCRIPTION
We were getting  the `Test environment has been torn down` error randomly when running our unit tests on github actions. I was able to reproduce this on my local by setting `--verbose --detectOpenHandles --debug` flags in the test command in package.json. 

Note: 
We need to import ESM modules using this function due to NestJS limitations.

### Changes

1. Modified importEsmPackage function to prevent race conditions.