### PR TITLE
feat(pre-created-users): generate hidden kyber keys

### DIFF
--- a/src/modules/user/user.usecase.ts
+++ b/src/modules/user/user.usecase.ts
@@ -629,10 +629,21 @@ export class UserUseCases {
     const keysCreationDate = new Date();
     keysCreationDate.setHours(keysCreationDate.getHours() - 1);
 
-    const { privateKeyArmored, publicKeyArmored, revocationCertificate } =
-      await generateNewKeys(keysCreationDate);
+    const {
+      privateKeyArmored,
+      publicKeyArmored,
+      revocationCertificate,
+      privateKyberKeyBase64,
+      publicKyberKeyBase64,
+    } =
+      await this.asymmetricEncryptionService.generateNewKeys(keysCreationDate);
 
     const encPrivateKey = aes.encrypt(privateKeyArmored, defaultPass, {
+      iv: this.configService.get('secrets.magicIv'),
+      salt: this.configService.get('secrets.magicSalt'),
+    });
+
+    const encPrivateKyberKey = aes.encrypt(privateKyberKeyBase64, defaultPass, {
       iv: this.configService.get('secrets.magicIv'),
       salt: this.configService.get('secrets.magicSalt'),
     });
@@ -646,6 +657,8 @@ export class UserUseCases {
       mnemonic: encMnemonic,
       publicKey: publicKeyArmored,
       privateKey: encPrivateKey,
+      privateKyberKey: encPrivateKyberKey,
+      publicKyberKey: publicKyberKeyBase64,
       revocationKey: revocationCertificate,
       encryptVersion: UserKeysEncryptVersions.Ecc,
     });


### PR DESCRIPTION
This is part of already closed and approved https://github.com/internxt/drive-server-wip/pull/465. I am just adding parts of it to prevent production from breaking as mentioned here https://github.com/internxt/drive-server-wip/pull/497

We do not return the kyber keys yet to prevent the frontend from using hybrid encryption due to some conflict with the encrypted value length. It seems that sometimes the encrypted mnemonic has a length longer than the limit of the field in the database. 