### PR TITLE
feat(pre-created-users): pass new generated kyber key replacePreCreatedUser

### DIFF
--- a/src/modules/user/user.controller.ts
+++ b/src/modules/user/user.controller.ts
@@ -145,6 +145,7 @@ export class UserController {
           response.user.email,
           response.user.uuid,
           keys.ecc.publicKey,
+          keys.kyber?.publicKey,
         );
       }
 
@@ -314,6 +315,7 @@ export class UserController {
           userCreated.user.email,
           userCreated.user.uuid,
           keys.ecc.publicKey,
+          keys.kyber?.publicKey,
         );
       }
 


### PR DESCRIPTION
This passes the frontend generated new public kyber key to the replace precreated user function so any pre created user that has hybrid invitations and already existent private and public kyber keys can process those invitations.

Note: this flow is not going to be possible unless we start returning the public kyber key when precreated users are generated, so all the guest sharings are still being handled using ECC encryption for the moment.