### PR TITLE
fix(pre-created-users): increase encryption key size

### DIFF
--- a/migrations/20250425153614-increase-encryption-key-size.js
+++ b/migrations/20250425153614-increase-encryption-key-size.js
@@ -1,0 +1,16 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.changeColumn('sharings', 'encryption_key', {
+      type: Sequelize.STRING(2500),
+    });
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.changeColumn('sharings', 'encryption_key', {
+      type: Sequelize.STRING(2000),
+    });
+  },
+};

--- a/migrations/20250425153626-increase-sharing-invitation-encryption-key-size.js
+++ b/migrations/20250425153626-increase-sharing-invitation-encryption-key-size.js
@@ -1,0 +1,16 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.changeColumn('sharing_invites', 'encryption_key', {
+      type: Sequelize.STRING(2500),
+    });
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.changeColumn('sharing_invites', 'encryption_key', {
+      type: Sequelize.STRING(2000),
+    });
+  },
+};


### PR DESCRIPTION
This addresses the problem with some encryption keys being bigger than 2000 characters (approx 2080 characters).

Related:
https://github.com/internxt/drive-server-wip/pull/497