### PR TITLE
feat(recover-account): recover account with legacy backup file 

### DIFF
--- a/src/externals/crypto/crypto.service.ts
+++ b/src/externals/crypto/crypto.service.ts
@@ -22,7 +22,7 @@ export class CryptoService {
       this.configService.get('secrets.magicSalt'),
       this.configService.get('secrets.cryptoSecret2'),
     );
-    this.cryptoSecret = process.env.CRYPTO_SECRET;
+    this.cryptoSecret = this.configService.get('secrets.cryptoSecret');
   }
 
   encrypt(text: string, buffer?: Buffer) {

--- a/src/lib/jwt.ts
+++ b/src/lib/jwt.ts
@@ -1,4 +1,4 @@
-import { sign, SignOptions, verify } from 'jsonwebtoken';
+import { JwtPayload, sign, SignOptions, verify } from 'jsonwebtoken';
 import getEnv from '../config/configuration';
 import { SignWithRS256AndHeader } from '../middlewares/passport';
 import {
@@ -41,8 +41,11 @@ export function generateWithDefaultSecret(
   return generateTokenWithPlainSecret(payload, duration, getEnv().secrets.jwt);
 }
 
-export function verifyToken(token: string, secret: string) {
-  return verify(token, secret);
+export function verifyToken<T = JwtPayload>(
+  token: string,
+  secret: string,
+): T | string {
+  return verify(token, secret) as T | string;
 }
 
 export function verifyWithDefaultSecret(token: string) {

--- a/src/modules/user/dto/legacy-recover-account.dto.ts
+++ b/src/modules/user/dto/legacy-recover-account.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsNotEmpty, IsOptional, ValidateNested } from 'class-validator';
+import { IsNotEmpty, ValidateNested } from 'class-validator';
 import { Type } from 'class-transformer';
 
 class EncryptedMnemonicDto {
@@ -43,7 +43,7 @@ class EccKeysStructureDto extends BaseKeysStructureDto {
   revocationKey: string;
 }
 
-class newGeneratedKeysDto {
+class NewGeneratedKeysDto {
   @ApiProperty({
     type: EccKeysStructureDto,
     description: 'ECC keys (public and private)',
@@ -93,11 +93,11 @@ export class LegacyRecoverAccountDto {
   asymmetricEncryptedMnemonic: EncryptedMnemonicDto;
 
   @ApiProperty({
-    type: newGeneratedKeysDto,
+    type: NewGeneratedKeysDto,
     description: 'User ecc and kyber keys',
   })
   @IsNotEmpty()
   @ValidateNested()
-  @Type(() => newGeneratedKeysDto)
-  keys: newGeneratedKeysDto;
+  @Type(() => NewGeneratedKeysDto)
+  keys: NewGeneratedKeysDto;
 }

--- a/src/modules/user/dto/legacy-recover-account.dto.ts
+++ b/src/modules/user/dto/legacy-recover-account.dto.ts
@@ -1,0 +1,103 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsOptional, ValidateNested } from 'class-validator';
+import { Type } from 'class-transformer';
+
+class EncryptedMnemonicDto {
+  @ApiProperty({
+    example: 'mnemonic_encrypted_with_ecc_method',
+    description: 'Mnemonic encrypted with ECC method',
+  })
+  @IsNotEmpty()
+  ecc: string;
+
+  @ApiProperty({
+    example: 'mnemonic_encrypted_with_hybrid_method',
+    description: 'Mnemonic encrypted with hybrid method',
+  })
+  @IsOptional()
+  hybrid: string;
+}
+
+class BaseKeysStructureDto {
+  @ApiProperty({
+    example: 'public_key',
+    description: 'public key',
+  })
+  @IsNotEmpty()
+  public: string;
+
+  @ApiProperty({
+    example: 'private_key',
+    description: 'private key encrypted with password',
+  })
+  @IsNotEmpty()
+  private: string;
+}
+
+class EccKeysStructureDto extends BaseKeysStructureDto {
+  @ApiProperty({
+    example: 'revocation_key',
+    description: 'Key used for revocation',
+  })
+  @IsNotEmpty()
+  revocationKey: string;
+}
+
+class newGeneratedKeysDto {
+  @ApiProperty({
+    type: EccKeysStructureDto,
+    description: 'ECC keys (public and private)',
+  })
+  @ValidateNested()
+  @Type(() => EccKeysStructureDto)
+  ecc: EccKeysStructureDto;
+
+  @ApiProperty({
+    type: BaseKeysStructureDto,
+    description: 'Kyber keys (public and private)',
+  })
+  @ValidateNested()
+  @Type(() => BaseKeysStructureDto)
+  kyber: BaseKeysStructureDto;
+}
+
+export class LegacyRecoverAccountDto {
+  @ApiProperty({
+    example: 'hashed_password',
+    description: 'New user pass hashed',
+  })
+  @IsNotEmpty()
+  password: string;
+
+  @ApiProperty({
+    example: 'password_salt',
+    description: 'Hashed password salt',
+  })
+  @IsNotEmpty()
+  salt: string;
+
+  @ApiProperty({
+    example: 'password_encrypted_mnemonic',
+    description: 'User mnemonic encrypted with the new pass',
+  })
+  @IsNotEmpty()
+  mnemonic: string;
+
+  @ApiProperty({
+    type: EncryptedMnemonicDto,
+    description: 'Mnemonic encrypted with asymmetric encryption algorithms',
+  })
+  @IsNotEmpty()
+  @ValidateNested()
+  @Type(() => EncryptedMnemonicDto)
+  asymmetricEncryptedMnemonic: EncryptedMnemonicDto;
+
+  @ApiProperty({
+    type: newGeneratedKeysDto,
+    description: 'User ecc and kyber keys',
+  })
+  @IsNotEmpty()
+  @ValidateNested()
+  @Type(() => newGeneratedKeysDto)
+  keys: newGeneratedKeysDto;
+}

--- a/src/modules/user/dto/legacy-recover-account.dto.ts
+++ b/src/modules/user/dto/legacy-recover-account.dto.ts
@@ -14,7 +14,7 @@ class EncryptedMnemonicDto {
     example: 'mnemonic_encrypted_with_hybrid_method',
     description: 'Mnemonic encrypted with hybrid method',
   })
-  @IsOptional()
+  @IsNotEmpty()
   hybrid: string;
 }
 

--- a/src/modules/user/dto/legacy-recover-account.dto.ts
+++ b/src/modules/user/dto/legacy-recover-account.dto.ts
@@ -18,7 +18,7 @@ class EncryptedMnemonicDto {
   hybrid: string;
 }
 
-class BaseKeysStructureDto {
+class RecoverAccountKeysPairDto {
   @ApiProperty({
     example: 'public_key',
     description: 'public key',
@@ -34,7 +34,7 @@ class BaseKeysStructureDto {
   private: string;
 }
 
-class EccKeysStructureDto extends BaseKeysStructureDto {
+class RecoverAccountEccKeysDto extends RecoverAccountKeysPairDto {
   @ApiProperty({
     example: 'revocation_key',
     description: 'Key used for revocation',
@@ -45,20 +45,20 @@ class EccKeysStructureDto extends BaseKeysStructureDto {
 
 class NewGeneratedKeysDto {
   @ApiProperty({
-    type: EccKeysStructureDto,
+    type: RecoverAccountEccKeysDto,
     description: 'ECC keys (public and private)',
   })
   @ValidateNested()
-  @Type(() => EccKeysStructureDto)
-  ecc: EccKeysStructureDto;
+  @Type(() => RecoverAccountEccKeysDto)
+  ecc: RecoverAccountEccKeysDto;
 
   @ApiProperty({
-    type: BaseKeysStructureDto,
+    type: RecoverAccountKeysPairDto,
     description: 'Kyber keys (public and private)',
   })
   @ValidateNested()
-  @Type(() => BaseKeysStructureDto)
-  kyber: BaseKeysStructureDto;
+  @Type(() => RecoverAccountKeysPairDto)
+  kyber: RecoverAccountKeysPairDto;
 }
 
 export class LegacyRecoverAccountDto {

--- a/src/modules/user/user.controller.ts
+++ b/src/modules/user/user.controller.ts
@@ -85,6 +85,7 @@ import { RefreshTokenResponseDto } from './dto/responses/refresh-token.dto';
 import { GetUserLimitDto } from './dto/responses/get-user-limit.dto';
 import { ClientEnum } from '../../common/enums/platform.enum';
 import { GenerateMnemonicResponseDto } from './dto/responses/generate-mnemonic.dto';
+import { LegacyRecoverAccountDto } from './dto/legacy-recover-account.dto';
 
 @ApiTags('User')
 @Controller('users')
@@ -564,6 +565,21 @@ export class UserController {
 
       throw err;
     }
+  }
+
+  @UseGuards(ThrottlerGuard)
+  @Put('/legacy-recover-account')
+  @Public()
+  @ApiOperation({
+    description:
+      'Recover account with legacy backup file, mnemonic only files should be used',
+    summary: 'Recover accocunt with legacy backup file',
+  })
+  async requestLegacyAccountRecovery(
+    @UserDecorator() user: User,
+    @Body() body: LegacyRecoverAccountDto,
+  ) {
+    await this.userUseCases.recoverAccountLegacy(user.uuid, body);
   }
 
   @UseGuards(ThrottlerGuard)

--- a/src/modules/user/user.controller.ts
+++ b/src/modules/user/user.controller.ts
@@ -86,7 +86,6 @@ import { GetUserLimitDto } from './dto/responses/get-user-limit.dto';
 import { ClientEnum } from '../../common/enums/platform.enum';
 import { GenerateMnemonicResponseDto } from './dto/responses/generate-mnemonic.dto';
 import { LegacyRecoverAccountDto } from './dto/legacy-recover-account.dto';
-import { TokenExpiredError } from 'jsonwebtoken';
 
 @ApiTags('User')
 @Controller('users')

--- a/src/modules/user/user.usecase.spec.ts
+++ b/src/modules/user/user.usecase.spec.ts
@@ -2680,7 +2680,6 @@ describe('User use cases', () => {
       jest
         .spyOn(workspaceRepository, 'findWorkspaceUsersOfOwnedWorkspaces')
         .mockResolvedValue([]);
-      jest.spyOn(userUseCases, 'resetUser').mockResolvedValue(undefined);
 
       await userUseCases.recoverAccountLegacy(userUuid, credentials);
 
@@ -2706,7 +2705,6 @@ describe('User use cases', () => {
       jest
         .spyOn(workspaceRepository, 'findWorkspaceUsersOfOwnedWorkspaces')
         .mockResolvedValue([]);
-      jest.spyOn(userUseCases, 'resetUser').mockResolvedValue(undefined);
 
       await userUseCases.recoverAccountLegacy(userUuid, credentials);
 
@@ -2748,7 +2746,6 @@ describe('User use cases', () => {
       jest
         .spyOn(workspaceRepository, 'updateWorkspaceUserEncryptedKeyByMemberId')
         .mockResolvedValue(undefined);
-      jest.spyOn(userUseCases, 'resetUser').mockResolvedValue(undefined);
 
       await userUseCases.recoverAccountLegacy(userUuid, credentials);
 

--- a/src/modules/user/user.usecase.spec.ts
+++ b/src/modules/user/user.usecase.spec.ts
@@ -2670,8 +2670,9 @@ describe('User use cases', () => {
       const keys = await asymmetricEncryptionService.generateNewKeys();
       newCredentials = {
         mnemonic: mnemonicEncryptedWithPassword,
-        password: cryptoService.encryptText(decryptedPasswordHash),
-        salt: cryptoService.encryptText(decryptedSalt),
+        password:
+          '53616c7465645f5f48c4064882e75747c5db100136d111d08892ee5db2e1bb8c8d5dc91a0906fcaf0aa66dd13624e05736ef0d4e934e083a84ed7c1c82b7b64a8e51bad006ea18075bdcabcf0c1bd38cd47cca00c4be3cb9a794c4b87bf761be',
+        salt: '53616c7465645f5f0d114ce687f8728ea7db82dff0acea6bfd924275f74cc1c7725a70febf9caef83f2a49651122f8889bfb523513dec25a99910ebd339f15fd',
         asymmetricEncryptedMnemonic: {
           ecc: await asymmetricEncryptionService.hybridEncryptMessageWithPublicKey(
             {

--- a/src/modules/user/user.usecase.spec.ts
+++ b/src/modules/user/user.usecase.spec.ts
@@ -2745,6 +2745,7 @@ describe('User use cases', () => {
       ).toHaveBeenCalledWith(user.id, UserKeysEncryptVersions.Ecc, {
         privateKey: newCredentials.keys.ecc.private,
         publicKey: newCredentials.keys.ecc.public,
+        revocationKey: newCredentials.keys.ecc.revocationKey,
       });
       expect(
         keyServerUseCases.updateByUserAndEncryptVersion,

--- a/src/modules/user/user.usecase.ts
+++ b/src/modules/user/user.usecase.ts
@@ -1046,12 +1046,12 @@ export class UserUseCases {
       );
     }
 
-    await this.resetUser(user, {
-      deleteFiles: false,
-      deleteFolders: false,
-      deleteShares: true,
-      deleteWorkspaces: false,
-    });
+    //  New keys were created, so we need to delete invitations made with the old keys
+    await Promise.all([
+      await this.sharingRepository.deleteSharingsBy({ sharedWith: user.uuid }),
+      await this.sharingRepository.deleteInvitesBy({ sharedWith: user.uuid }),
+      await this.workspaceUseCases.removeUserFromNonOwnedWorkspaces(user),
+    ]);
   }
 
   verifyAndDecodeAccountRecoveryToken(token: string): {

--- a/src/modules/user/user.usecase.ts
+++ b/src/modules/user/user.usecase.ts
@@ -1012,13 +1012,18 @@ export class UserUseCases {
 
     for (const version of keyVersions) {
       const key = keys[version];
-      if (key) {
-        await this.keyServerUseCases.updateByUserAndEncryptVersion(
-          user.id,
-          version,
-          { privateKey: key.private, publicKey: key.public },
-        );
-      }
+      const revocationKey =
+        'revocationKey' in key ? key.revocationKey : undefined;
+
+      await this.keyServerUseCases.updateByUserAndEncryptVersion(
+        user.id,
+        version,
+        {
+          privateKey: key.private,
+          publicKey: key.public,
+          revocationKey,
+        },
+      );
     }
 
     const ownedWorkspaceAndUsers =

--- a/src/modules/user/user.usecase.ts
+++ b/src/modules/user/user.usecase.ts
@@ -1058,9 +1058,10 @@ export class UserUseCases {
     userUuid: string;
   } {
     try {
+      const jwtSecret = this.configService.get('secrets.jwt');
       const decoded = verifyToken<{
         payload: { uuid?: string; action?: string };
-      }>(token, this.configService.get('secrets.jwt'));
+      }>(token, jwtSecret);
 
       if (typeof decoded === 'string') {
         throw new ForbiddenException('Invalid token');

--- a/src/modules/user/user.usecase.ts
+++ b/src/modules/user/user.usecase.ts
@@ -1074,9 +1074,8 @@ export class UserUseCases {
       const decodedContent = decoded?.payload;
 
       if (
-        !decodedContent ||
-        !decodedContent.uuid ||
-        decodedContent.action !== 'recover-account' ||
+        !decodedContent?.uuid ||
+        decodedContent?.action !== 'recover-account' ||
         !validate(decodedContent.uuid)
       ) {
         throw new ForbiddenException('Invalid token');


### PR DESCRIPTION
### Changes

- Added `legacy-recover-account` endpoint.
- WorkspaceUsers encrypted key of owned workspaces are updated with ecc encrypted mnemonic when account is recovered.
- User is removed from invited sharings and workspaces due to new keys generated. **We should warn users about this.**
- New generated keys are also saved