### PR TITLE
fix: add unique constraint to workspace_users table for workspace_id and member_id

### DIFF
--- a/migrations/20250430175953-add-unique-constraint-to-workspace_users.js
+++ b/migrations/20250430175953-add-unique-constraint-to-workspace_users.js
@@ -1,0 +1,21 @@
+'use strict';
+
+const tableName = 'workspace_users';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface) {
+    await queryInterface.addConstraint(tableName, {
+      type: 'unique',
+      fields: ['workspace_id', 'member_id'],
+      name: 'workspace_users_workspaceId_memberId_unique',
+    });
+  },
+
+  async down(queryInterface) {
+    await queryInterface.removeConstraint(
+      tableName,
+      'workspace_users_workspaceId_memberId_unique',
+    );
+  },
+};


### PR DESCRIPTION
There is currently a possible race condition on the setupWorkspace function, that may cause an owner to join their workspace twice. This is very similar to an error encountered a couple of months ago, in that case the race condition occured when accepting an invite. This Pr adds a unique constraint to workspaceUsers on the combination of memberId and workspaceId