### PR TITLE
fix(backups): update_at is updated 

### DIFF
--- a/src/modules/backups/backup.usecase.spec.ts
+++ b/src/modules/backups/backup.usecase.spec.ts
@@ -244,7 +244,7 @@ describe('BackupUseCase', () => {
         .spyOn(cryptoService, 'encryptName')
         .mockReturnValue('New Encrypted Name');
       jest
-        .spyOn(folderUseCases, 'updateByFolderId')
+        .spyOn(folderUseCases, 'updateByFolderIdAndForceUpdatedAt')
         .mockResolvedValue(updatedFolder);
 
       const result = await backupUseCase.updateDeviceAsFolder(

--- a/src/modules/backups/backup.usecase.ts
+++ b/src/modules/backups/backup.usecase.ts
@@ -162,10 +162,11 @@ export class BackupUseCase {
       folder.bucket,
     );
 
-    const updatedFolder = await this.folderUsecases.updateByFolderId(folder, {
-      name: encryptedName,
-      plainName: deviceName,
-    });
+    const updatedFolder =
+      await this.folderUsecases.updateByFolderIdAndForceUpdatedAt(folder, {
+        name: encryptedName,
+        plainName: deviceName,
+      });
 
     return this.addDeviceProperties(user, updatedFolder);
   }

--- a/src/modules/folder/folder.repository.ts
+++ b/src/modules/folder/folder.repository.ts
@@ -130,6 +130,10 @@ export interface FolderRepository {
     update: Partial<FolderAttributes>,
     where: Partial<FolderAttributes>,
   ): Promise<number>;
+  updateById(
+    folderId: FolderAttributes['id'],
+    update: Partial<Folder>,
+  ): Promise<Folder | null>;
 }
 
 @Injectable()
@@ -467,6 +471,18 @@ export class SequelizeFolderRepository implements FolderRepository {
     folder.set(update);
     await folder.save();
     return this.toDomain(folder);
+  }
+
+  async updateById(
+    folderId: FolderAttributes['id'],
+    update: Partial<Folder>,
+  ): Promise<Folder | null> {
+    const [_, updatedFolder] = await this.folderModel.update(update, {
+      where: { id: folderId },
+      returning: true,
+    });
+
+    return updatedFolder.length > 0 ? this.toDomain(updatedFolder[0]) : null;
   }
 
   async updateManyByFolderId(

--- a/src/modules/folder/folder.usecase.spec.ts
+++ b/src/modules/folder/folder.usecase.spec.ts
@@ -1440,4 +1440,73 @@ describe('FolderUseCases', () => {
       ).rejects.toThrow('Deletion failed');
     });
   });
+
+  describe('updateByFolderIdAndForceUpdatedAt', () => {
+    const folder = newFolder();
+    const folderData = {
+      plainName: 'Updated Folder Name',
+    };
+    const mockedCurrentDate = new Date('2024-10-02T12:00:00Z');
+
+    beforeEach(() => {
+      jest.useFakeTimers();
+      jest.setSystemTime(mockedCurrentDate);
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    it('When folderData includes updatedAt, then it should use the provided value', async () => {
+      const customDate = new Date('2024-10-01T12:00:00Z');
+      const folderDataWithDate = {
+        ...folderData,
+        updatedAt: customDate,
+      };
+      const updatedFolder = newFolder({
+        attributes: {
+          ...folderDataWithDate,
+        },
+      });
+
+      jest
+        .spyOn(folderRepository, 'updateById')
+        .mockResolvedValueOnce(updatedFolder);
+
+      await service.updateByFolderIdAndForceUpdatedAt(
+        folder,
+        folderDataWithDate,
+      );
+
+      expect(folderRepository.updateById).toHaveBeenCalledWith(
+        folder.id,
+        expect.objectContaining({
+          plainName: folderData.plainName,
+          updatedAt: customDate,
+        }),
+      );
+    });
+
+    it('When folderData does not include updatedAt, then it should add the current date', async () => {
+      const updatedFolder = newFolder({
+        attributes: {
+          ...folderData,
+        },
+      });
+
+      jest
+        .spyOn(folderRepository, 'updateById')
+        .mockResolvedValueOnce(updatedFolder);
+
+      await service.updateByFolderIdAndForceUpdatedAt(folder, folderData);
+
+      expect(folderRepository.updateById).toHaveBeenCalledWith(
+        folder.id,
+        expect.objectContaining({
+          plainName: folderData.plainName,
+          updatedAt: mockedCurrentDate,
+        }),
+      );
+    });
+  });
 });

--- a/src/modules/folder/folder.usecase.ts
+++ b/src/modules/folder/folder.usecase.ts
@@ -949,10 +949,16 @@ export class FolderUseCases {
     );
   }
 
-  async updateByFolderId(
+  async updateByFolderIdAndForceUpdatedAt(
     folder: Folder,
     folderData: Partial<FolderAttributes>,
   ): Promise<Folder> {
-    return this.folderRepository.updateByFolderId(folder.id, folderData);
+    const updatedFields = { ...folderData };
+
+    if (!updatedFields.updatedAt) {
+      updatedFields.updatedAt = new Date();
+    }
+
+    return this.folderRepository.updateById(folder.id, updatedFields);
   }
 }


### PR DESCRIPTION
This PR forces updated_at when the endpoint Patch /backup/deviceAsFolder is reached. This aligns with the drive-server's behavior, the mac team was having problems because of this. 

However, I do not feel it is the best approach to force the `updated_at` despite the name of the backup being the same, I would suggest another endpoint for this in the future. It seems this endpoint is misused by the apps.