### PR TITLE
[PB-4371] feat(files): populate file records with missing folder_uuid

### DIFF
--- a/migrations/20250508230425-populate-folder-uuid-files-table.js
+++ b/migrations/20250508230425-populate-folder-uuid-files-table.js
@@ -1,0 +1,62 @@
+'use strict';
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+const MAX_ATTEMPTS = 10;
+const BATCH_SIZE = 1000;
+const SLEEP_TIME_MS = 5000;
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    let updatedCount = 0;
+    let attempts = 0;
+
+    const updateQuery = `
+      WITH batch AS (
+        SELECT f.id, folders.uuid AS folder_uuid
+        FROM files f
+        JOIN folders ON f.folder_id = folders.id
+        WHERE f.folder_uuid IS NULL
+          AND f.folder_id IS NOT NULL
+          AND f.status != 'DELETED'
+        LIMIT ${BATCH_SIZE}
+      )
+      UPDATE files
+      SET folder_uuid = batch.folder_uuid
+      FROM batch
+      WHERE files.id = batch.id
+      RETURNING files.id;
+    `;
+
+    console.info(
+      'Starting migration: populating files with missing folder_uuid',
+    );
+
+    do {
+      try {
+        const [results] = await queryInterface.sequelize.query(updateQuery);
+        updatedCount = results.length;
+        attempts = 0;
+
+        console.info(`Updated ${updatedCount} files in this batch`);
+      } catch (err) {
+        attempts++;
+        console.error(
+          `[ERROR]: Error in batch (attempt ${attempts}/${MAX_ATTEMPTS}): ${err.message}`,
+        );
+
+        if (attempts >= MAX_ATTEMPTS) {
+          console.error(
+            '[ERROR]: Maximum retry attempts reached, exiting migration.',
+          );
+          break;
+        }
+        // In case of database disconnection, we wait and force next loop
+        await sleep(SLEEP_TIME_MS);
+        updatedCount = BATCH_SIZE;
+      }
+    } while (updatedCount === BATCH_SIZE);
+  },
+
+  async down(queryInterface, Sequelize) {},
+};


### PR DESCRIPTION
### What
As autoincremental IDs have a limit and as files are being related to folders by using the `folder_id` field, an autoincremental ID, we started using a `folder_uuid` field to avoid hitting the limit in the near future. The issue was that running an update on hundreds of millions of files was infeasible, hence, we did not set the field to NOT NULL, but that should be the ideal situation. The idea is to do this refilling incrementally.

### How
A migration is run. This migration contains a script that populates the records incrementally. A retry system is implemented in case of small downtimes. Also, the migration is idempotent; running it multiple times does not cause duplicate records.

The performance of the SELECT-based query to find, for each file, its parent folder UUID, is the following:

```sql
EXPLAIN ANALYZE 
SELECT f.id, folders.uuid AS folder_uuid
          FROM files f
          JOIN folders ON f.folder_id = folders.id
          WHERE f.folder_uuid IS NULL
            AND f.folder_id IS NOT null
            and f.status != 'DELETED'
          LIMIT 1000;

Limit  (cost=0.57..620.49 rows=1000 width=20) (actual time=0.075..1205.130 rows=1000 loops=1)
  ->  Nested Loop  (cost=0.57..35197000.36 rows=56777175 width=20) (actual time=0.075..1204.814 rows=1000 loops=1)
        ->  Seq Scan on files f  (cost=0.00..33477037.69 rows=56777175 width=8) (actual time=0.036..7.849 rows=1000 loops=1)
              Filter: ((folder_uuid IS NULL) AND (folder_id IS NOT NULL) AND (status <> 'DELETED'::enum_files_status))
              Rows Removed by Filter: 5901
        ->  Memoize  (cost=0.57..2.29 rows=1 width=20) (actual time=1.195..1.195 rows=1 loops=1000)
              Cache Key: f.folder_id
              Cache Mode: logical
              Hits: 102  Misses: 898  Evictions: 0  Overflows: 0  Memory Usage: 106kB
              ->  Index Scan using folders_pkey on folders  (cost=0.56..2.28 rows=1 width=20) (actual time=1.328..1.328 rows=1 loops=898)
                    Index Cond: (id = f.folder_id)
Planning Time: 0.417 ms
Execution Time: 1207.354 ms
```