### PR TITLE
[_] fix(folders-deletion): workspaces root folders are now deleted correctly.

### DIFF
--- a/src/modules/folder/folder.controller.spec.ts
+++ b/src/modules/folder/folder.controller.spec.ts
@@ -679,9 +679,10 @@ describe('FolderController', () => {
         folderUuidToDelete,
         userMocked,
       );
-      expect(folderUseCases.deleteByUser).toHaveBeenCalledWith(userMocked, [
-        folder,
-      ]);
+      expect(folderUseCases.deleteNotRootFolderByUser).toHaveBeenCalledWith(
+        userMocked,
+        [folder],
+      );
       expect(storageNotificationService.folderDeleted).toHaveBeenCalledWith({
         payload: {
           id: folder.id,
@@ -712,7 +713,7 @@ describe('FolderController', () => {
         .spyOn(folderUseCases, 'getFolderByUuidAndUser')
         .mockResolvedValue(folder);
       jest
-        .spyOn(folderUseCases, 'deleteByUser')
+        .spyOn(folderUseCases, 'deleteNotRootFolderByUser')
         .mockRejectedValue(new Error('Deletion failed'));
 
       await expect(

--- a/src/modules/folder/folder.controller.ts
+++ b/src/modules/folder/folder.controller.ts
@@ -920,7 +920,7 @@ export class FolderController {
     @Client() clientId: string,
   ) {
     const folder = await this.folderUseCases.getFolderByUuidAndUser(uuid, user);
-    await this.folderUseCases.deleteByUser(user, [folder]);
+    await this.folderUseCases.deleteNotRootFolderByUser(user, [folder]);
     this.storageNotificationService.folderDeleted({
       payload: { id: folder.id, uuid, userId: user.id },
       user: user,

--- a/src/modules/folder/folder.usecase.spec.ts
+++ b/src/modules/folder/folder.usecase.spec.ts
@@ -1401,7 +1401,7 @@ describe('FolderUseCases', () => {
     });
   });
 
-  describe('deleteByUser ', () => {
+  describe('deleteNotRootFolderByUser ', () => {
     const userMocked = newUser();
     userMocked.rootFolderId = 1;
     const folderMocked: Folder[] = [
@@ -1412,7 +1412,7 @@ describe('FolderUseCases', () => {
     it('When folders are deleted successfully, then it should call deleteByUser ', async () => {
       jest.spyOn(folderRepository, 'deleteByUser').mockResolvedValue(undefined);
 
-      await service.deleteByUser(userMocked, [folderMocked[0]]);
+      await service.deleteNotRootFolderByUser(userMocked, [folderMocked[0]]);
 
       expect(folderRepository.deleteByUser).toHaveBeenCalledWith(userMocked, [
         folderMocked[0],
@@ -1426,7 +1426,7 @@ describe('FolderUseCases', () => {
       } as Folder;
 
       await expect(
-        service.deleteByUser(userMocked, [rootFolder]),
+        service.deleteNotRootFolderByUser(userMocked, [rootFolder]),
       ).rejects.toThrow(NotAcceptableException);
     });
 
@@ -1436,7 +1436,7 @@ describe('FolderUseCases', () => {
         .mockRejectedValue(new Error('Deletion failed'));
 
       await expect(
-        service.deleteByUser(userMocked, [folderMocked[0]]),
+        service.deleteNotRootFolderByUser(userMocked, [folderMocked[0]]),
       ).rejects.toThrow('Deletion failed');
     });
   });

--- a/src/modules/folder/folder.usecase.ts
+++ b/src/modules/folder/folder.usecase.ts
@@ -914,6 +914,13 @@ export class FolderUseCases {
   }
 
   async deleteByUser(user: User, folders: Folder[]): Promise<void> {
+    await this.folderRepository.deleteByUser(user, folders);
+  }
+
+  async deleteNotRootFolderByUser(
+    user: User,
+    folders: Folder[],
+  ): Promise<void> {
     const isRootFolder = folders.some(
       (folder) => folder.id === user.rootFolderId || folder.parentId === null,
     );


### PR DESCRIPTION
There was a folderUsecases function that was modified a few months ago. It was used in multiple places, so by adding the logic to prevent rootFolders deletion, it broke the workspaces deletion flow.

Changes
1. Added another function that prevents the root folder deletion so it can be used from any controller if needed.
2. Changes made to deleteByUser were rolled back.