### PR TITLE
[PB-4369]: fix/include backup usage in usage response

### DIFF
--- a/src/modules/backups/backup.repository.spec.ts
+++ b/src/modules/backups/backup.repository.spec.ts
@@ -5,6 +5,7 @@ import { DeviceModel } from './models/device.model';
 import { BackupModel } from './models/backup.model';
 import { createMock } from '@golevelup/ts-jest';
 import { getModelToken } from '@nestjs/sequelize';
+import { Sequelize } from 'sequelize';
 
 describe('SequelizeBackupRepository', () => {
   let repository: SequelizeBackupRepository;
@@ -267,10 +268,19 @@ describe('SequelizeBackupRepository', () => {
 
   describe('sumExistentBackupSizes', () => {
     it('When sumExistentBackupSizes is called, then it should return the sum of the backup sizes', async () => {
-      jest.spyOn(backupModel, 'sum').mockResolvedValue(1024);
+      const totalSize = 1024;
+      const sizesSum = [{ total: totalSize }];
+
+      jest.spyOn(backupModel, 'findAll').mockResolvedValueOnce(sizesSum as any);
 
       const result = await repository.sumExistentBackupSizes(userMocked.id);
-      expect(result).toBe(1024);
+
+      expect(backupModel.findAll).toHaveBeenCalledWith({
+        attributes: [[Sequelize.fn(`SUM`, Sequelize.col('size')), 'total']],
+        where: { userId: userMocked.id },
+        raw: true,
+      });
+      expect(result).toBe(totalSize);
     });
   });
 

--- a/src/modules/backups/backup.repository.spec.ts
+++ b/src/modules/backups/backup.repository.spec.ts
@@ -265,6 +265,15 @@ describe('SequelizeBackupRepository', () => {
     });
   });
 
+  describe('sumExistentBackupSizes', () => {
+    it('When sumExistentBackupSizes is called, then it should return the sum of the backup sizes', async () => {
+      jest.spyOn(backupModel, 'sum').mockResolvedValue(1024);
+
+      const result = await repository.sumExistentBackupSizes(userMocked.id);
+      expect(result).toBe(1024);
+    });
+  });
+
   describe('toDomainDevice', () => {
     const deviceModelMock = {
       toJSON: jest.fn().mockReturnValue({

--- a/src/modules/backups/backup.repository.ts
+++ b/src/modules/backups/backup.repository.ts
@@ -82,6 +82,10 @@ export class SequelizeBackupRepository {
     });
   }
 
+  async sumExistentBackupSizes(userId: number) {
+    return this.backupModel.sum('size', { where: { userId } });
+  }
+
   private toDomainDevice(deviceModel: DeviceModel): Device {
     const backups =
       deviceModel.backups?.map((b) => Backup.build(b.toJSON())) || [];

--- a/src/modules/backups/backup.repository.ts
+++ b/src/modules/backups/backup.repository.ts
@@ -83,7 +83,13 @@ export class SequelizeBackupRepository {
   }
 
   async sumExistentBackupSizes(userId: number) {
-    return this.backupModel.sum('size', { where: { userId } });
+    const result = await this.backupModel.findAll({
+      attributes: [[Sequelize.fn(`SUM`, Sequelize.col('size')), 'total']],
+      where: { userId },
+      raw: true,
+    });
+
+    return Number(result[0]['total']) as unknown as number;
   }
 
   private toDomainDevice(deviceModel: DeviceModel): Device {

--- a/src/modules/backups/backup.usecase.spec.ts
+++ b/src/modules/backups/backup.usecase.spec.ts
@@ -159,6 +159,17 @@ describe('BackupUseCase', () => {
     });
   });
 
+  describe('sumExistentBackupSizes', () => {
+    it('When sumExistentBackupSizes is called, then it should return the sum of the backup sizes', async () => {
+      jest
+        .spyOn(backupRepository, 'sumExistentBackupSizes')
+        .mockResolvedValue(1024);
+
+      const result = await backupUseCase.sumExistentBackupSizes(userMocked.id);
+      expect(result).toBe(1024);
+    });
+  });
+
   describe('getDeviceAsFolder', () => {
     it('When the folder does not exist, then it should throw a NotFoundException', async () => {
       jest

--- a/src/modules/backups/backup.usecase.ts
+++ b/src/modules/backups/backup.usecase.ts
@@ -208,6 +208,10 @@ export class BackupUseCase {
     return folders.length === 0 && files.length === 0;
   }
 
+  async sumExistentBackupSizes(userId: number) {
+    return this.backupRepository.sumExistentBackupSizes(userId);
+  }
+
   private async addDeviceProperties(user: User, folder: Folder) {
     const isEmpty = await this.isFolderEmpty(user, folder);
     return {

--- a/src/modules/user/dto/responses/get-user-usage.dto.ts
+++ b/src/modules/user/dto/responses/get-user-usage.dto.ts
@@ -6,4 +6,7 @@ export class GetUserUsageDto {
 
   @ApiProperty()
   backup: number;
+
+  @ApiProperty()
+  total: number;
 }

--- a/src/modules/user/dto/responses/get-user-usage.dto.ts
+++ b/src/modules/user/dto/responses/get-user-usage.dto.ts
@@ -3,4 +3,7 @@ import { ApiProperty } from '@nestjs/swagger';
 export class GetUserUsageDto {
   @ApiProperty()
   drive: number;
+
+  @ApiProperty()
+  backup: number;
 }

--- a/src/modules/user/user.controller.spec.ts
+++ b/src/modules/user/user.controller.spec.ts
@@ -882,8 +882,13 @@ describe('User Controller', () => {
     const user = newUser();
 
     it('When storage usage is requested, then it should return the user usage data', async () => {
+      const driveUsage = 1024000;
+      const backupUsage = 2048000;
+      const totalUsage = driveUsage + backupUsage;
       const mockUsage = {
-        drive: 1024000,
+        drive: driveUsage,
+        backup: backupUsage,
+        total: totalUsage,
       };
 
       userUseCases.getUserUsage.mockResolvedValueOnce(mockUsage);

--- a/src/modules/user/user.usecase.spec.ts
+++ b/src/modules/user/user.usecase.spec.ts
@@ -2136,6 +2136,7 @@ describe('User use cases', () => {
     it('When cache has user usage data, then it should return the cached data', async () => {
       const cachedUsage = { usage: 1024 };
       const backupUsage = 1024;
+      const totalUsage = cachedUsage.usage + backupUsage;
 
       jest
         .spyOn(cacheManagerService, 'getUserUsage')
@@ -2154,12 +2155,14 @@ describe('User use cases', () => {
       expect(result).toEqual({
         drive: cachedUsage.usage,
         backup: backupUsage,
+        total: totalUsage,
       });
     });
 
     it('When cache does not have user usage data, then it should get data from database and cache it', async () => {
       const driveUsage = 2048;
       const backupUsage = 1024;
+      const totalUsage = driveUsage + backupUsage;
       jest.spyOn(cacheManagerService, 'getUserUsage').mockResolvedValue(null);
       jest
         .spyOn(fileUseCases, 'getUserUsedStorage')
@@ -2179,7 +2182,11 @@ describe('User use cases', () => {
         user.uuid,
         driveUsage,
       );
-      expect(result).toEqual({ drive: driveUsage, backup: backupUsage });
+      expect(result).toEqual({
+        drive: driveUsage,
+        backup: backupUsage,
+        total: totalUsage,
+      });
     });
   });
 

--- a/src/modules/user/user.usecase.spec.ts
+++ b/src/modules/user/user.usecase.spec.ts
@@ -2135,24 +2135,31 @@ describe('User use cases', () => {
   describe('getUserUsage', () => {
     it('When cache has user usage data, then it should return the cached data', async () => {
       const cachedUsage = { usage: 1024 };
+      const backupUsage = 1024;
 
       jest
         .spyOn(cacheManagerService, 'getUserUsage')
         .mockResolvedValue(cachedUsage);
       jest.spyOn(fileUseCases, 'getUserUsedStorage');
       jest.spyOn(cacheManagerService, 'setUserUsage');
+      jest
+        .spyOn(backupUseCases, 'sumExistentBackupSizes')
+        .mockResolvedValue(backupUsage);
 
       const result = await userUseCases.getUserUsage(user);
 
       expect(cacheManagerService.getUserUsage).toHaveBeenCalledWith(user.uuid);
       expect(fileUseCases.getUserUsedStorage).not.toHaveBeenCalled();
       expect(cacheManagerService.setUserUsage).not.toHaveBeenCalled();
-      expect(result).toEqual({ drive: cachedUsage.usage });
+      expect(result).toEqual({
+        drive: cachedUsage.usage,
+        backup: backupUsage,
+      });
     });
 
     it('When cache does not have user usage data, then it should get data from database and cache it', async () => {
       const driveUsage = 2048;
-
+      const backupUsage = 1024;
       jest.spyOn(cacheManagerService, 'getUserUsage').mockResolvedValue(null);
       jest
         .spyOn(fileUseCases, 'getUserUsedStorage')
@@ -2160,6 +2167,9 @@ describe('User use cases', () => {
       jest
         .spyOn(cacheManagerService, 'setUserUsage')
         .mockResolvedValue(undefined);
+      jest
+        .spyOn(backupUseCases, 'sumExistentBackupSizes')
+        .mockResolvedValue(backupUsage);
 
       const result = await userUseCases.getUserUsage(user);
 
@@ -2169,7 +2179,7 @@ describe('User use cases', () => {
         user.uuid,
         driveUsage,
       );
-      expect(result).toEqual({ drive: driveUsage });
+      expect(result).toEqual({ drive: driveUsage, backup: backupUsage });
     });
   });
 

--- a/src/modules/user/user.usecase.ts
+++ b/src/modules/user/user.usecase.ts
@@ -1603,7 +1603,7 @@ export class UserUseCases {
     );
   }
 
-  async getUserUsage(user: User): Promise<{ drive: number }> {
+  async getUserUsage(user: User): Promise<{ drive: number; backup: number }> {
     let totalDriveUsage = 0;
     const cachedUsage = await this.cacheManager.getUserUsage(user.uuid);
 
@@ -1615,7 +1615,11 @@ export class UserUseCases {
       totalDriveUsage = driveUsage;
     }
 
-    return { drive: totalDriveUsage };
+    const backupUsage = await this.backupUseCases.sumExistentBackupSizes(
+      user.id,
+    );
+
+    return { drive: totalDriveUsage, backup: backupUsage };
   }
 
   async confirmDeactivation(token: string) {

--- a/src/modules/user/user.usecase.ts
+++ b/src/modules/user/user.usecase.ts
@@ -1603,7 +1603,9 @@ export class UserUseCases {
     );
   }
 
-  async getUserUsage(user: User): Promise<{ drive: number; backup: number }> {
+  async getUserUsage(
+    user: User,
+  ): Promise<{ drive: number; backup: number; total: number }> {
     let totalDriveUsage = 0;
     const cachedUsage = await this.cacheManager.getUserUsage(user.uuid);
 
@@ -1619,7 +1621,11 @@ export class UserUseCases {
       user.id,
     );
 
-    return { drive: totalDriveUsage, backup: backupUsage };
+    return {
+      drive: totalDriveUsage,
+      backup: backupUsage,
+      total: totalDriveUsage + backupUsage,
+    };
   }
 
   async confirmDeactivation(token: string) {


### PR DESCRIPTION
Added backups usage and total usage to the usage endpoint response to allign with what is currently expected by each platform