### PR TITLE
[_]: fix/optimistic cache updates

### DIFF
--- a/src/modules/cache-manager/cache-manager.service.spec.ts
+++ b/src/modules/cache-manager/cache-manager.service.spec.ts
@@ -125,5 +125,44 @@ describe('CacheManagerService', () => {
       );
       expect(result).toEqual(returnValue);
     });
+
+    it('When setting user storage limit with a custom TTL, then it should store the limit with the custom TTL', async () => {
+      const userUuid = v4();
+      const limit = 4096;
+      const customTtl = 5000 * 60;
+
+      await cacheManagerService.setUserStorageLimit(userUuid, limit, customTtl);
+
+      expect(cacheManager.set).toHaveBeenCalledWith(
+        `limit:${userUuid}`,
+        { limit },
+        customTtl,
+      );
+    });
+  });
+
+  describe('getUserStorageLimit', () => {
+    it('When getting user storage limit, then it should append the user uuid to the limit key prefix', async () => {
+      const userUuid = v4();
+      const cachedLimit = { limit: 1073741824 }; // 1GB
+
+      jest.spyOn(cacheManager, 'get').mockResolvedValue(cachedLimit);
+
+      const result = await cacheManagerService.getUserStorageLimit(userUuid);
+
+      expect(cacheManager.get).toHaveBeenCalledWith(`limit:${userUuid}`);
+      expect(result).toEqual(cachedLimit);
+    });
+
+    it('When cache returns null for user storage limit, then it should return null', async () => {
+      const userUuid = v4();
+
+      jest.spyOn(cacheManager, 'get').mockResolvedValue(null);
+
+      const result = await cacheManagerService.getUserStorageLimit(userUuid);
+
+      expect(cacheManager.get).toHaveBeenCalledWith(`limit:${userUuid}`);
+      expect(result).toBeNull();
+    });
   });
 });

--- a/src/modules/cache-manager/cache-manager.service.ts
+++ b/src/modules/cache-manager/cache-manager.service.ts
@@ -35,7 +35,7 @@ export class CacheManagerService {
   }
 
   async expireLimit(userUuid: string): Promise<void> {
-    const [delOldLimit, delNewLimit] = await Promise.all([
+    await Promise.all([
       // TODO: Remove this line when all clients stop using the old API
       this.cacheManager.del(`${userUuid}-limit`),
       this.cacheManager.del(`${this.LIMIT_KEY_PREFIX}${userUuid}`),

--- a/src/modules/gateway/gateway.usecase.ts
+++ b/src/modules/gateway/gateway.usecase.ts
@@ -166,16 +166,19 @@ export class GatewayUseCases {
   }
 
   async updateUser(user: User, newStorageSpaceBytes?: number) {
-    Logger.log(
-      `[GATEWAY/LIMIT_CACHE] Updating user ${user.uuid} with new storage space bytes: ${newStorageSpaceBytes}`,
-    );
     await this.userUseCases.updateUserStorage(user, newStorageSpaceBytes);
 
-    this.cacheManagerService.expireLimit(user.uuid).catch((error) => {
+    try {
+      await this.cacheManagerService.setUserStorageLimit(
+        user.uuid,
+        newStorageSpaceBytes,
+        1000 * 60,
+      );
+    } catch (error) {
       Logger.error(
-        `[GATEWAY/LIMIT_CACHE] Error deleting cache for user ${user.uuid}`,
+        `[GATEWAY/LIMIT_CACHE] Error proactively setting cache for user ${user.uuid} with new limit ${newStorageSpaceBytes}`,
         error,
       );
-    });
+    }
   }
 }

--- a/src/modules/gateway/gateway.usecase.ts
+++ b/src/modules/gateway/gateway.usecase.ts
@@ -169,6 +169,9 @@ export class GatewayUseCases {
     await this.userUseCases.updateUserStorage(user, newStorageSpaceBytes);
 
     try {
+      // We first expire cache to make sure the cache of old drive-server is deleted too.
+      await this.cacheManagerService.expireLimit(user.uuid);
+
       await this.cacheManagerService.setUserStorageLimit(
         user.uuid,
         newStorageSpaceBytes,

--- a/src/modules/user/user.usecase.ts
+++ b/src/modules/user/user.usecase.ts
@@ -1685,18 +1685,12 @@ export class UserUseCases {
   async getSpaceLimit(user: User): Promise<number> {
     const cachedLimit = await this.cacheManager.getUserStorageLimit(user.uuid);
     if (cachedLimit) {
-      Logger.log(
-        `[CACHE/DEBUG] Cache hit for User ${user.uuid} space limit: ${cachedLimit.limit}`,
-      );
       return cachedLimit.limit;
     }
 
     const limit = await this.networkService.getLimit(
       user.bridgeUser,
       user.userId,
-    );
-    Logger.log(
-      `[CACHE/DEBUG] Cache miss for User ${user.uuid} space limit: ${limit}`,
     );
     await this.cacheManager.setUserStorageLimit(user.uuid, limit);
 


### PR DESCRIPTION
Optimistically update the user limit in the cache when the gateway is triggered on a plan change. Instead of deleting the cache entry, we optimistically set the new value with a low TTL of one minute. This approach helps to avoid potential race conditions during orchestration.