### PR TITLE
[_]: chore(eslint): update rules to improve code quality

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -25,5 +25,11 @@ module.exports = {
     '@typescript-eslint/explicit-function-return-type': 'off',
     '@typescript-eslint/explicit-module-boundary-types': 'off',
     '@typescript-eslint/no-explicit-any': 'off',
+    '@typescript-eslint/prefer-readonly': 'warn',
+    '@typescript-eslint/prefer-optional-chain': 'warn',
+    '@typescript-eslint/consistent-type-imports': [
+      'warn',
+      { prefer: 'type-imports' },
+    ],
   },
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -26,10 +26,6 @@ module.exports = {
     '@typescript-eslint/explicit-module-boundary-types': 'off',
     '@typescript-eslint/no-explicit-any': 'off',
     '@typescript-eslint/prefer-readonly': 'warn',
-    '@typescript-eslint/prefer-optional-chain': 'warn',
-    '@typescript-eslint/consistent-type-imports': [
-      'warn',
-      { prefer: 'type-imports' },
-    ],
+    '@typescript-eslint/prefer-optional-chain': 'warn'
   },
 };


### PR DESCRIPTION
Adding some new eslint rules to help prevent common issues marked by sonar.

`prefer-readonly`: variables not declared as readonly was possibly the biggest number of issues present in the codebase.
`prefer-optional-chain`: instead of doing `payload && payload.uuid` we should opt for `payload?.uuid`
`consistent-type-imports`: would help prevent cyclic imports. most of the cyclic imports I found while reviewing sonar issues could be fixed by simply opting to import types