### PR TITLE
[PB-4523]: feat(backups)/implement deleteDeviceAsFolder functionality

### DIFF
--- a/src/modules/backups/backup.controller.spec.ts
+++ b/src/modules/backups/backup.controller.spec.ts
@@ -225,4 +225,29 @@ describe('BackupController', () => {
       ).rejects.toThrow(NotFoundException);
     });
   });
+
+  describe('deleteDeviceAsFolder', () => {
+    it('When deleteDeviceAsFolder is called with a valid uuid, then it should call the usecase method', async () => {
+      jest
+        .spyOn(backupUseCase, 'deleteDeviceAsFolder')
+        .mockResolvedValue(undefined);
+
+      await backupController.deleteDeviceAsFolder(userMocked, 'folder-uuid');
+
+      expect(backupUseCase.deleteDeviceAsFolder).toHaveBeenCalledWith(
+        userMocked,
+        'folder-uuid',
+      );
+    });
+
+    it('When folder is not found, then it should throw a NotFoundException', async () => {
+      jest
+        .spyOn(backupUseCase, 'deleteDeviceAsFolder')
+        .mockRejectedValue(new NotFoundException());
+
+      await expect(
+        backupController.deleteDeviceAsFolder(userMocked, 'folder-uuid'),
+      ).rejects.toThrow(NotFoundException);
+    });
+  });
 });

--- a/src/modules/backups/backup.controller.ts
+++ b/src/modules/backups/backup.controller.ts
@@ -48,6 +48,18 @@ export class BackupController {
     return this.backupUseCases.createDeviceAsFolder(user, body.deviceName);
   }
 
+  @Delete('/deviceAsFolder/:uuid')
+  @ApiOperation({
+    summary: 'Delete device as folder by uuid',
+  })
+  @ApiBearerAuth()
+  async deleteDeviceAsFolder(
+    @UserDecorator() user: User,
+    @Param('uuid', ValidateUUIDPipe) uuid: string,
+  ) {
+    return this.backupUseCases.deleteDeviceAsFolder(user, uuid);
+  }
+
   @Get('/deviceAsFolder/:uuid')
   @ApiOperation({
     summary: 'Get device as folder by uuid',

--- a/src/modules/backups/backup.usecase.ts
+++ b/src/modules/backups/backup.usecase.ts
@@ -111,6 +111,21 @@ export class BackupUseCase {
     return this.addDeviceProperties(user, createdFolder);
   }
 
+  async deleteDeviceAsFolder(user: User, uuid: FolderAttributes['uuid']) {
+    const folder = await this.folderUsecases.getFolderByUuid(uuid, user);
+    if (!folder) {
+      throw new NotFoundException('Folder not found');
+    }
+
+    const { backupsBucket } = user;
+
+    if (folder.bucket !== backupsBucket) {
+      throw new BadRequestException('Folder is not in the backups bucket');
+    }
+
+    await this.folderUsecases.deleteByUser(user, [folder]);
+  }
+
   async getDevicesAsFolder(user: User) {
     const { backupsBucket } = user;
     if (!backupsBucket) {


### PR DESCRIPTION
Add a `delete backup/deviceAsFolder/:uuid` endpoint to delete backups folders, as currently `delete folders/:uuid` prevents deletion of folders that have no parent