### PR TITLE
[PB-4416]: feat(thumbnails)/add file_uuid column to thumbnails and populate exsting records

### DIFF
--- a/migrations/20250616160910-add-fileuuid-to-thumbnails.js
+++ b/migrations/20250616160910-add-fileuuid-to-thumbnails.js
@@ -1,0 +1,27 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.addColumn('thumbnails', 'file_uuid', {
+      type: Sequelize.UUID,
+      allowNull: true, // Initially nullable to allow population
+      references: {
+        model: 'files',
+        key: 'uuid',
+      },
+      onUpdate: 'CASCADE',
+      onDelete: 'CASCADE',
+    });
+
+    await queryInterface.addIndex('thumbnails', ['file_uuid'], {
+      name: 'thumbnails_file_uuid_idx',
+    });
+  },
+
+  async down(queryInterface) {
+    await queryInterface.removeIndex('thumbnails', 'thumbnails_file_uuid_idx');
+
+    await queryInterface.removeColumn('thumbnails', 'file_uuid');
+  },
+};

--- a/migrations/20250617204500-populate-fileuuids-in-thumbnails-batch.js
+++ b/migrations/20250617204500-populate-fileuuids-in-thumbnails-batch.js
@@ -1,0 +1,73 @@
+'use strict';
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+const MAX_ATTEMPTS = 10;
+const BATCH_SIZE = 1000;
+const SLEEP_TIME_MS = 5000;
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface) {
+    let updatedCount = 0;
+    let attempts = 0;
+
+    const updateQuery = `
+      WITH batch AS (
+        SELECT t.id, f.uuid AS file_uuid
+        FROM thumbnails t
+        JOIN files f ON t.file_id = f.id
+        WHERE t.file_uuid IS NULL
+          AND t.file_id IS NOT NULL
+        LIMIT ${BATCH_SIZE}
+      )
+      UPDATE thumbnails
+      SET file_uuid = batch.file_uuid
+      FROM batch
+      WHERE thumbnails.id = batch.id
+      RETURNING thumbnails.id;
+    `;
+
+    console.info(
+      'Starting migration: populating thumbnails with missing file_uuid',
+    );
+
+    do {
+      try {
+        const [results] = await queryInterface.sequelize.query(updateQuery);
+        updatedCount = results.length;
+        attempts = 0;
+
+        console.info(`Updated ${updatedCount} thumbnails in this batch`);
+      } catch (err) {
+        attempts++;
+        console.error(
+          `[ERROR]: Error in batch (attempt ${attempts}/${MAX_ATTEMPTS}): ${err.message}`,
+        );
+
+        if (attempts >= MAX_ATTEMPTS) {
+          console.error(
+            '[ERROR]: Maximum retry attempts reached, exiting migration.',
+          );
+          break;
+        }
+        // In case of database disconnection, we wait and force next loop
+        await sleep(SLEEP_TIME_MS);
+        updatedCount = BATCH_SIZE;
+      }
+    } while (updatedCount === BATCH_SIZE);
+
+    console.info('Migration completed: thumbnails file_uuid population');
+  },
+
+  async down(queryInterface) {
+    console.info('Rolling back: setting all thumbnails file_uuid to NULL');
+
+    await queryInterface.sequelize.query(`
+      UPDATE thumbnails 
+      SET file_uuid = NULL
+      WHERE file_uuid IS NOT NULL
+    `);
+
+    console.info('Rollback completed: thumbnails file_uuid cleared');
+  },
+};


### PR DESCRIPTION
Add folderUuid field to thumbnails model as currentlythumbnails only relate to files using their numeric autoincremental ids. We are initially setting this field as nullable until we are able to populate existing records, this pr also introduces a script with this intention.

Based on the script in #542, we will attempt to populate thumbnails in batches, idempotently and with a retry mechanism