### PR TITLE
[PB-4416]:  chore/file UUID in thumbnails

### DIFF
--- a/src/modules/file/file.model.ts
+++ b/src/modules/file/file.model.ts
@@ -128,7 +128,10 @@ export class FileModel extends Model implements FileAttributes {
   @HasMany(() => ShareModel, 'fileId')
   shares: Share[];
 
-  @HasMany(() => ThumbnailModel, 'fileId')
+  @HasMany(() => ThumbnailModel, {
+    foreignKey: 'fileUuid',
+    sourceKey: 'uuid',
+  })
   thumbnails: ThumbnailModel[];
 
   @HasMany(() => SharingModel, { sourceKey: 'uuid', foreignKey: 'itemId' })

--- a/src/modules/file/file.usecase.spec.ts
+++ b/src/modules/file/file.usecase.spec.ts
@@ -1059,7 +1059,7 @@ describe('FileUseCases', () => {
         .spyOn(sharingService, 'bulkRemoveSharings')
         .mockResolvedValue(undefined);
       jest
-        .spyOn(thumbnailUseCases, 'deleteThumbnailByFileId')
+        .spyOn(thumbnailUseCases, 'deleteThumbnailByFileUuid')
         .mockResolvedValue(undefined);
       jest
         .spyOn(fileRepository, 'deleteFilesByUser')
@@ -1079,9 +1079,9 @@ describe('FileUseCases', () => {
         [mockFile.uuid],
         SharingItemType.File,
       );
-      expect(thumbnailUseCases.deleteThumbnailByFileId).toHaveBeenCalledWith(
+      expect(thumbnailUseCases.deleteThumbnailByFileUuid).toHaveBeenCalledWith(
         userMocked,
-        mockFile.id,
+        mockFile.uuid,
       );
       expect(fileRepository.deleteFilesByUser).toHaveBeenCalledWith(
         userMocked,

--- a/src/modules/file/file.usecase.ts
+++ b/src/modules/file/file.usecase.ts
@@ -107,7 +107,7 @@ export class FileUseCases {
         [uuid],
         SharingItemType.File,
       ),
-      this.thumbnailUsecases.deleteThumbnailByFileId(user, id),
+      this.thumbnailUsecases.deleteThumbnailByFileUuid(user, uuid),
     ]);
 
     await this.fileRepository.deleteFilesByUser(user, [file]);

--- a/src/modules/thumbnail/dto/thumbnail.dto.ts
+++ b/src/modules/thumbnail/dto/thumbnail.dto.ts
@@ -6,6 +6,8 @@ export class ThumbnailDto {
   @ApiProperty()
   fileId: number;
   @ApiProperty()
+  fileUuid: string;
+  @ApiProperty()
   maxWidth: number;
   @ApiProperty()
   maxHeight: number;

--- a/src/modules/thumbnail/thumbnail.attributes.ts
+++ b/src/modules/thumbnail/thumbnail.attributes.ts
@@ -1,6 +1,7 @@
 export interface ThumbnailAttributes {
   id: number;
   fileId: number;
+  fileUuid: string;
   type: string;
   size: number;
   bucket_id?: string;

--- a/src/modules/thumbnail/thumbnail.domain.ts
+++ b/src/modules/thumbnail/thumbnail.domain.ts
@@ -3,6 +3,7 @@ import { ThumbnailAttributes } from './thumbnail.attributes';
 export class Thumbnail implements ThumbnailAttributes {
   id: number;
   fileId: number;
+  fileUuid: string;
   type: string;
   size: number;
   bucket_id?: string;
@@ -18,6 +19,7 @@ export class Thumbnail implements ThumbnailAttributes {
   constructor(attributes: ThumbnailAttributes) {
     this.id = attributes.id;
     this.fileId = attributes.fileId;
+    this.fileUuid = attributes.fileUuid;
     this.type = attributes.type;
     this.size = attributes.size;
     this.bucketId = attributes.bucket_id;

--- a/src/modules/thumbnail/thumbnail.model.ts
+++ b/src/modules/thumbnail/thumbnail.model.ts
@@ -27,8 +27,12 @@ export class ThumbnailModel extends Model implements ThumbnailAttributes {
   @Column(DataType.INTEGER)
   fileId: number;
 
-  @BelongsTo(() => FileModel, 'id')
-  file: FileModel;
+  @ForeignKey(() => FileModel)
+  @Column(DataType.UUID)
+  fileUuid: string;
+
+  @BelongsTo(() => FileModel, { foreignKey: 'fileUuid', targetKey: 'uuid' })
+  fileByUuid: FileModel;
 
   @Column
   type: string;

--- a/src/modules/thumbnail/thumbnail.repository.spec.ts
+++ b/src/modules/thumbnail/thumbnail.repository.spec.ts
@@ -3,6 +3,7 @@ import { getModelToken } from '@nestjs/sequelize';
 import { SequelizeThumbnailRepository } from './thumbnail.repository';
 import { ThumbnailModel } from './thumbnail.model';
 import { createMock } from '@golevelup/ts-jest';
+import { v4 } from 'uuid';
 
 describe('SequelizeThumbnailRepository', () => {
   let repository: SequelizeThumbnailRepository;
@@ -25,12 +26,24 @@ describe('SequelizeThumbnailRepository', () => {
 
   describe('findById', () => {
     it('When id exists then return the corresponding thumbnail', async () => {
-      const mockThumbnail = { id: 1, fileId: 2 } as ThumbnailModel;
-      jest.spyOn(thumbnailModel, 'findByPk').mockResolvedValue(mockThumbnail);
+      const mockThumbnail = {
+        id: 1,
+        fileId: 2,
+        fileUuid: v4(),
+      };
+      jest
+        .spyOn(thumbnailModel, 'findByPk')
+        .mockResolvedValue(mockThumbnail as any);
 
       const result = await repository.findById(1);
 
-      expect(result).toEqual(expect.objectContaining({ id: 1, fileId: 2 }));
+      expect(result).toEqual(
+        expect.objectContaining({
+          id: 1,
+          fileId: 2,
+          fileUuid: mockThumbnail.fileUuid,
+        }),
+      );
       expect(thumbnailModel.findByPk).toHaveBeenCalledWith(1);
     });
 
@@ -44,27 +57,33 @@ describe('SequelizeThumbnailRepository', () => {
     });
   });
 
-  describe('findByFileId', () => {
-    it('When fileId exists then return the corresponding thumbnail', async () => {
-      const mockThumbnail = { id: 1, fileId: 2 } as ThumbnailModel;
+  describe('findByFileUuid', () => {
+    it('When fileUuid exists then return the corresponding thumbnail', async () => {
+      const mockThumbnail = {
+        id: 1,
+        fileId: 2,
+        fileUuid: 'test-uuid',
+      } as ThumbnailModel;
       jest.spyOn(thumbnailModel, 'findOne').mockResolvedValue(mockThumbnail);
 
-      const result = await repository.findByFileId(2);
+      const result = await repository.findByFileUuid('test-uuid');
 
-      expect(result).toEqual(expect.objectContaining({ id: 1, fileId: 2 }));
+      expect(result).toEqual(
+        expect.objectContaining({ id: 1, fileId: 2, fileUuid: 'test-uuid' }),
+      );
       expect(thumbnailModel.findOne).toHaveBeenCalledWith({
-        where: { file_id: 2 },
+        where: { file_uuid: 'test-uuid' },
       });
     });
 
-    it('When fileId does not exist then return null', async () => {
+    it('When fileUuid does not exist then return null', async () => {
       jest.spyOn(thumbnailModel, 'findOne').mockResolvedValue(null);
 
-      const result = await repository.findByFileId(999);
+      const result = await repository.findByFileUuid('non-existent-uuid');
 
       expect(result).toBeNull();
       expect(thumbnailModel.findOne).toHaveBeenCalledWith({
-        where: { file_id: 999 },
+        where: { file_uuid: 'non-existent-uuid' },
       });
     });
   });

--- a/src/modules/thumbnail/thumbnail.repository.ts
+++ b/src/modules/thumbnail/thumbnail.repository.ts
@@ -7,7 +7,7 @@ import { ThumbnailAttributes } from './thumbnail.attributes';
 
 export interface ThumbnailRepository {
   findById(id: Thumbnail['id']): Promise<Thumbnail | null>;
-  findByFileId(fileId: FileAttributes['id']): Promise<Thumbnail | null>;
+  findByFileUuid(fileUuid: FileAttributes['uuid']): Promise<Thumbnail | null>;
   findAll(where?: Partial<ThumbnailAttributes>): Promise<Thumbnail[]>;
   create(thumbnail: Omit<ThumbnailAttributes, 'id'>): Promise<Thumbnail>;
   update(
@@ -30,9 +30,11 @@ export class SequelizeThumbnailRepository implements ThumbnailRepository {
     return thumbnail ? this.toDomain(thumbnail) : null;
   }
 
-  async findByFileId(fileId: FileAttributes['id']): Promise<Thumbnail | null> {
+  async findByFileUuid(
+    fileUuid: FileAttributes['uuid'],
+  ): Promise<Thumbnail | null> {
     const thumbnail = await this.thumbnailModel.findOne({
-      where: { file_id: fileId },
+      where: { file_uuid: fileUuid },
     });
     return thumbnail ? this.toDomain(thumbnail) : null;
   }
@@ -70,6 +72,7 @@ export class SequelizeThumbnailRepository implements ThumbnailRepository {
     return {
       id: model.id,
       fileId: model.fileId,
+      fileUuid: model.fileUuid,
       type: model.type,
       size: model.size,
       bucketId: model.bucketId,
@@ -86,6 +89,7 @@ export class SequelizeThumbnailRepository implements ThumbnailRepository {
     return {
       id: thumbnail.id,
       fileId: thumbnail.fileId,
+      fileUuid: thumbnail.fileUuid,
       type: thumbnail.type,
       size: thumbnail.size,
       bucketId: thumbnail.bucket_id,

--- a/src/modules/thumbnail/thumbnail.usecase.ts
+++ b/src/modules/thumbnail/thumbnail.usecase.ts
@@ -34,8 +34,8 @@ export class ThumbnailUseCases {
         'You do not have permission to modify this file',
       );
     }
-    const existingThumbnail = await this.thumbnailRepository.findByFileId(
-      file.id,
+    const existingThumbnail = await this.thumbnailRepository.findByFileUuid(
+      file.uuid,
     );
     if (existingThumbnail) {
       try {
@@ -51,14 +51,15 @@ export class ThumbnailUseCases {
       }
       await this.thumbnailRepository.update(thumbnail, {
         id: existingThumbnail.id,
-        fileId: existingThumbnail.fileId,
+        fileUuid: existingThumbnail.fileUuid,
       });
-      return this.thumbnailRepository.findByFileId(file.id);
+      return this.thumbnailRepository.findByFileUuid(file.uuid);
     }
 
     const newThumbnailObject = {
       ...thumbnail,
       fileId: file.id,
+      fileUuid: file.uuid,
       createdAt: new Date(),
       updatedAt: new Date(),
     };
@@ -66,8 +67,8 @@ export class ThumbnailUseCases {
     return this.thumbnailRepository.create(newThumbnailObject);
   }
 
-  async deleteThumbnailByFileId(user: User, fileId: number) {
-    const thumbnail = await this.thumbnailRepository.findByFileId(fileId);
+  async deleteThumbnailByFileUuid(user: User, fileUuid: string) {
+    const thumbnail = await this.thumbnailRepository.findByFileUuid(fileUuid);
     if (!thumbnail) {
       return;
     }
@@ -76,7 +77,7 @@ export class ThumbnailUseCases {
       thumbnail.bucket_id,
       thumbnail.bucket_file,
     );
-    await this.thumbnailRepository.deleteBy({ fileId });
+    await this.thumbnailRepository.deleteBy({ fileUuid });
   }
 
   async findAll(where: Partial<ThumbnailAttributes>): Promise<Thumbnail[]> {


### PR DESCRIPTION
After introducing fileUuid field to the thumbnails model in #584 this PR updates the thumbnail relationships in the codebase to utilize UUIDs instead of incremental IDs.

- Refactored SequelizeThumbnailRepository to replace findByFileId with findByFileUuid, allowing retrieval of thumbnails based on UUIDs.
- Updated ThumbnailUseCases to utilize the new UUID-based methods, including changes to createThumbnail and deleteThumbnailByFileUuid.
