### PR TITLE
chore(thumbnails): add debug logging for deprecated fileId usage and null fileUuid

### DIFF
--- a/src/modules/file/file.controller.spec.ts
+++ b/src/modules/file/file.controller.spec.ts
@@ -315,6 +315,7 @@ describe('FileController', () => {
       const result = await fileController.createThumbnail(
         userMocked,
         createThumbnailDto,
+        ClientEnum.Web,
       );
       expect(result).toEqual(thumbnailDto);
       expect(thumbnailUseCases.createThumbnail).toHaveBeenCalledWith(
@@ -328,7 +329,11 @@ describe('FileController', () => {
         .spyOn(thumbnailUseCases, 'createThumbnail')
         .mockRejectedValue(new InternalServerErrorException());
       await expect(
-        fileController.createThumbnail(userMocked, createThumbnailDto),
+        fileController.createThumbnail(
+          userMocked,
+          createThumbnailDto,
+          ClientEnum.Web,
+        ),
       ).rejects.toThrow(InternalServerErrorException);
     });
   });

--- a/src/modules/file/file.controller.ts
+++ b/src/modules/file/file.controller.ts
@@ -474,8 +474,22 @@ export class FileController {
   async createThumbnail(
     @UserDecorator() user: User,
     @Body() body: CreateThumbnailDto,
+    @Client() clientId: string,
   ): Promise<ThumbnailDto> {
-    return this.thumbnailUseCases.createThumbnail(user, body);
+    if (!body.fileUuid) {
+      Logger.warn(
+        `[FILE/THUMBNAIL] Requested using deprecated fileId platform: ${clientId}, fileId: ${body.fileId}`,
+      );
+    }
+    const thumbnail = await this.thumbnailUseCases.createThumbnail(user, body);
+
+    if (!thumbnail.fileUuid) {
+      Logger.warn(
+        `[FILE/THUMBNAIL] Thumbnail created with null fileUuid: ${clientId}, fileId: ${body.fileId}`,
+      );
+    }
+
+    return thumbnail;
   }
 
   @Delete('/:uuid')


### PR DESCRIPTION
Add debug logs, as some files are being created with null uuids