### PR TITLE
Revert "chore(thumbnails): add debug logging for deprecated fileId usage and null fileUuid"

### DIFF
--- a/src/modules/file/file.controller.spec.ts
+++ b/src/modules/file/file.controller.spec.ts
@@ -315,7 +315,6 @@ describe('FileController', () => {
       const result = await fileController.createThumbnail(
         userMocked,
         createThumbnailDto,
-        ClientEnum.Web,
       );
       expect(result).toEqual(thumbnailDto);
       expect(thumbnailUseCases.createThumbnail).toHaveBeenCalledWith(
@@ -329,11 +328,7 @@ describe('FileController', () => {
         .spyOn(thumbnailUseCases, 'createThumbnail')
         .mockRejectedValue(new InternalServerErrorException());
       await expect(
-        fileController.createThumbnail(
-          userMocked,
-          createThumbnailDto,
-          ClientEnum.Web,
-        ),
+        fileController.createThumbnail(userMocked, createThumbnailDto),
       ).rejects.toThrow(InternalServerErrorException);
     });
   });

--- a/src/modules/file/file.controller.ts
+++ b/src/modules/file/file.controller.ts
@@ -474,22 +474,8 @@ export class FileController {
   async createThumbnail(
     @UserDecorator() user: User,
     @Body() body: CreateThumbnailDto,
-    @Client() clientId: string,
   ): Promise<ThumbnailDto> {
-    if (!body.fileUuid) {
-      Logger.warn(
-        `[FILE/THUMBNAIL] Requested using deprecated fileId platform: ${clientId}, fileId: ${body.fileId}`,
-      );
-    }
-    const thumbnail = await this.thumbnailUseCases.createThumbnail(user, body);
-
-    if (!thumbnail.fileUuid) {
-      Logger.warn(
-        `[FILE/THUMBNAIL] Thumbnail created with null fileUuid: ${clientId}, fileId: ${body.fileId}`,
-      );
-    }
-
-    return thumbnail;
+    return this.thumbnailUseCases.createThumbnail(user, body);
   }
 
   @Delete('/:uuid')


### PR DESCRIPTION
Reverts internxt/drive-server-wip#587. Confirmed the cause of the thumbnails without fileUuid.