### PR TITLE
[_]: feat(users)/implement get me/upload-status endpoint to determine wether a user has ever uploaded any files

### DIFF
--- a/src/modules/file/file.usecase.spec.ts
+++ b/src/modules/file/file.usecase.spec.ts
@@ -1457,4 +1457,29 @@ describe('FileUseCases', () => {
       );
     });
   });
+
+  describe('hasUploadedFiles', () => {
+    it('When user has uploaded files, then it should return true', async () => {
+      const mockFile = newFile();
+      jest.spyOn(fileRepository, 'findOneBy').mockResolvedValue(mockFile);
+
+      const result = await service.hasUploadedFiles(userMocked);
+
+      expect(result).toBe(true);
+      expect(fileRepository.findOneBy).toHaveBeenCalledWith({
+        userId: userMocked.id,
+      });
+    });
+
+    it('When user has not uploaded files, then it should return false', async () => {
+      jest.spyOn(fileRepository, 'findOneBy').mockResolvedValue(null);
+
+      const result = await service.hasUploadedFiles(userMocked);
+
+      expect(result).toBe(false);
+      expect(fileRepository.findOneBy).toHaveBeenCalledWith({
+        userId: userMocked.id,
+      });
+    });
+  });
 });

--- a/src/modules/file/file.usecase.ts
+++ b/src/modules/file/file.usecase.ts
@@ -816,4 +816,9 @@ export class FileUseCases {
   async getFile(where: Partial<File>): Promise<File> {
     return this.fileRepository.findOneBy(where);
   }
+
+  async hasUploadedFiles(user: User) {
+    const file = await this.fileRepository.findOneBy({ userId: user.id });
+    return file !== null;
+  }
 }

--- a/src/modules/user/dto/responses/get-upload-status.dto.ts
+++ b/src/modules/user/dto/responses/get-upload-status.dto.ts
@@ -1,0 +1,9 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class GetUploadStatusDto {
+  @ApiProperty({
+    description: 'Indicates whether the user has uploaded any files',
+    example: true,
+  })
+  hasUploadedFiles: boolean;
+}

--- a/src/modules/user/user.controller.spec.ts
+++ b/src/modules/user/user.controller.spec.ts
@@ -943,4 +943,38 @@ describe('User Controller', () => {
       );
     });
   });
+
+  describe('GET /me/upload-status', () => {
+    const userMocked = newUser();
+
+    it('When user has uploaded files, then it should return hasUploadedFiles as true', async () => {
+      userUseCases.hasUploadedFiles.mockResolvedValueOnce(true);
+
+      const result = await userController.getUploadStatus(userMocked);
+
+      expect(userUseCases.hasUploadedFiles).toHaveBeenCalledWith(userMocked);
+      expect(result).toEqual({ hasUploadedFiles: true });
+    });
+
+    it('When user has not uploaded files, then it should return hasUploadedFiles as false', async () => {
+      userUseCases.hasUploadedFiles.mockResolvedValueOnce(false);
+
+      const result = await userController.getUploadStatus(userMocked);
+
+      expect(userUseCases.hasUploadedFiles).toHaveBeenCalledWith(userMocked);
+      expect(result).toEqual({ hasUploadedFiles: false });
+    });
+
+    it('When an error occurs while checking upload status, then it should throw the error', async () => {
+      const errorMessage = 'Database error';
+      userUseCases.hasUploadedFiles.mockRejectedValueOnce(
+        new Error(errorMessage),
+      );
+
+      await expect(userController.getUploadStatus(userMocked)).rejects.toThrow(
+        errorMessage,
+      );
+      expect(userUseCases.hasUploadedFiles).toHaveBeenCalledWith(userMocked);
+    });
+  });
 });

--- a/src/modules/user/user.controller.ts
+++ b/src/modules/user/user.controller.ts
@@ -83,6 +83,7 @@ import { ConfirmAccountDeactivationDto } from './dto/confirm-deactivation.dto';
 import { GetUserUsageDto } from './dto/responses/get-user-usage.dto';
 import { RefreshTokenResponseDto } from './dto/responses/refresh-token.dto';
 import { GetUserLimitDto } from './dto/responses/get-user-limit.dto';
+import { GetUploadStatusDto } from './dto/responses/get-upload-status.dto';
 import { GenerateMnemonicResponseDto } from './dto/responses/generate-mnemonic.dto';
 import { LegacyRecoverAccountDto } from './dto/legacy-recover-account.dto';
 import { ClientEnum } from '../../common/enums/platform.enum';
@@ -1033,6 +1034,23 @@ export class UserController {
       );
       throw err;
     }
+  }
+
+  @Get('/me/upload-status')
+  @HttpCode(200)
+  @ApiBearerAuth()
+  @ApiOperation({
+    summary: 'Check if user has uploaded any files',
+  })
+  @ApiOkResponse({
+    description: 'Returns whether the user has uploaded any files',
+    type: GetUploadStatusDto,
+  })
+  async getUploadStatus(
+    @UserDecorator() user: User,
+  ): Promise<GetUploadStatusDto> {
+    const hasUploadedFiles = await this.userUseCases.hasUploadedFiles(user);
+    return { hasUploadedFiles };
   }
 
   @Get('/generate-mnemonic')

--- a/src/modules/user/user.usecase.spec.ts
+++ b/src/modules/user/user.usecase.spec.ts
@@ -2843,4 +2843,38 @@ describe('User use cases', () => {
       );
     });
   });
+
+  describe('hasUploadedFiles', () => {
+    const user = newUser();
+
+    it('When user has uploaded files, then it should return true', async () => {
+      jest.spyOn(fileUseCases, 'hasUploadedFiles').mockResolvedValue(true);
+
+      const result = await userUseCases.hasUploadedFiles(user);
+
+      expect(result).toBe(true);
+      expect(fileUseCases.hasUploadedFiles).toHaveBeenCalledWith(user);
+    });
+
+    it('When user has not uploaded files, then it should return false', async () => {
+      jest.spyOn(fileUseCases, 'hasUploadedFiles').mockResolvedValue(false);
+
+      const result = await userUseCases.hasUploadedFiles(user);
+
+      expect(result).toBe(false);
+      expect(fileUseCases.hasUploadedFiles).toHaveBeenCalledWith(user);
+    });
+
+    it('When fileUseCases throws an error, then it should propagate the error', async () => {
+      const errorMessage = 'Database connection failed';
+      jest
+        .spyOn(fileUseCases, 'hasUploadedFiles')
+        .mockRejectedValue(new Error(errorMessage));
+
+      await expect(userUseCases.hasUploadedFiles(user)).rejects.toThrow(
+        errorMessage,
+      );
+      expect(fileUseCases.hasUploadedFiles).toHaveBeenCalledWith(user);
+    });
+  });
 });

--- a/src/modules/user/user.usecase.ts
+++ b/src/modules/user/user.usecase.ts
@@ -1797,4 +1797,8 @@ export class UserUseCases {
     const mnemonic = generateMnemonic(256);
     return mnemonic;
   }
+
+  async hasUploadedFiles(user: User) {
+    return await this.fileUseCases.hasUploadedFiles(user);
+  }
 }


### PR DESCRIPTION
Created the `GET /users/me/upload-status ` to determine wether the user has uploaded any files. This takes into account files of any status so deleted files should be included. 

This is helpful in determining to show the onboarding tutorial on the web app.