### PR TITLE
[_]: feat/move get share domains endpoint

### DIFF
--- a/src/modules/sharing/sharing.controller.spec.ts
+++ b/src/modules/sharing/sharing.controller.spec.ts
@@ -4,6 +4,9 @@ import { UuidDto } from '../../common/dto/uuid.dto';
 import { createMock } from '@golevelup/ts-jest';
 import { Sharing } from './sharing.domain';
 import { newSharing } from '../../../test/fixtures';
+import getEnv from '../../config/configuration';
+
+jest.mock('../../config/configuration');
 
 describe('SharingController', () => {
   let controller: SharingController;
@@ -34,6 +37,25 @@ describe('SharingController', () => {
       expect(sharingService.getPublicSharingFolderSize).toHaveBeenCalledWith(
         sharing.id,
       );
+    });
+  });
+
+  describe('get public sharing domains', () => {
+    it('When requesting the get sharing domains method, then it should return the list of domains', async () => {
+      const expectedResult = [
+        'https://share.example.com',
+        'https://share.example.org',
+      ];
+
+      jest.mocked(getEnv).mockReturnValue({
+        apis: {
+          share: { url: expectedResult.join(',') },
+        },
+      } as any);
+
+      const result = await controller.getPublicSharingDomains();
+
+      expect(result).toStrictEqual({ list: expectedResult });
     });
   });
 });

--- a/src/modules/sharing/sharing.controller.ts
+++ b/src/modules/sharing/sharing.controller.ts
@@ -33,7 +33,6 @@ import {
   ApiResponse,
   ApiTags,
 } from '@nestjs/swagger';
-
 import { SharingService } from './sharing.service';
 import { User as UserDecorator } from '../auth/decorators/user.decorator';
 import { User } from '../user/user.domain';
@@ -64,6 +63,7 @@ import { WorkspaceLogAction } from '../workspaces/decorators/workspace-log-actio
 import { WorkspaceLogGlobalActionType } from '../workspaces/attributes/workspace-logs.attributes';
 import { ValidateUUIDPipe } from '../../common/pipes/validate-uuid.pipe';
 import { ItemSharingInfoDto } from './dto/response/get-item-sharing-info.dto';
+import getEnv from '../../config/configuration';
 
 @ApiTags('Sharing')
 @Controller('sharings')
@@ -1036,5 +1036,12 @@ export class SharingController {
     const size = await this.sharingService.getPublicSharingFolderSize(param.id);
 
     return { size };
+  }
+
+  @Get('public/domains')
+  @Public()
+  @UseGuards(ThrottlerGuard)
+  async getPublicSharingDomains() {
+    return { list: getEnv().apis.share.url.split(',') };
   }
 }


### PR DESCRIPTION
Introduce `GET /sharings/public/domains `which returns a list of domains specified in the env config.
This endpoint is meant as a replacement of `GET storage/share/domains`
