### PR TITLE
chore(actions): added close stalled PRs action

### DIFF
--- a/.github/workflows/stale-and-close.yml
+++ b/.github/workflows/stale-and-close.yml
@@ -1,0 +1,30 @@
+name: 'Close stalled PRs'
+
+on:
+  schedule:
+    - cron: '30 1 * * *'
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          # Disable processing of issues (only handle PRs)
+          days-before-stale: -1
+          days-before-close: -1
+
+          # PR settings: 15 days to stale, then 30 more days to close
+          stale-pr-message: 'This PR is stale because it has been open for more than 15 days with no activity.'
+          close-pr-message: 'This PR was closed because it has been stalled for 30 days with no activity. If you would like to continue working on this, feel free to reopen the PR or create a new one.'
+          days-before-pr-stale: 15
+          days-before-pr-close: 30
+          stale-pr-label: 'stalled'
+          exempt-pr-labels: 'dependencies,blocked'
+          ascending: true


### PR DESCRIPTION
This PR adds a github action that will mark as stalled any inactive PR.

- Inactive PRs are marked as stalled if they have been inactive for more than 15 days.
- Any PR stalled for more than 30 days, will be closed. Branches won't be closed so contributors can reopen any PR again if needed.