### PR TITLE
[_]: feat/completely clear workspace on reset

### DIFF
--- a/src/modules/workspaces/workspaces.usecase.ts
+++ b/src/modules/workspaces/workspaces.usecase.ts
@@ -3029,6 +3029,10 @@ export class WorkspacesUsecases {
       (member) => member.id !== ownerMember.id,
     );
 
+    const workspaceOwnerUser = await this.userRepository.findByUuid(
+      workspace.ownerId,
+    );
+
     await this.folderUseCases.deleteByUuids(
       workspaceNetworkUser,
       nonOwnerMembers.map((members) => members.rootFolderId),
@@ -3036,19 +3040,20 @@ export class WorkspacesUsecases {
 
     await this.workspaceRepository.deleteUsersFromWorkspace(
       workspace.id,
-      nonOwnerMembers.map((member) => member.memberId),
-    );
-
-    await this.workspaceRepository.deleteAllInvitationsByWorkspace(
-      workspace.id,
+      allMembers.map((member) => member.memberId),
     );
 
     const workspaceTotalSpace = await this.getWorkspaceNetworkLimit(workspace);
 
-    await this.workspaceRepository.updateWorkspaceUserBy(
-      { workspaceId: workspace.id, memberId: workspace.ownerId },
-      { spaceLimit: workspaceTotalSpace },
-    );
+    await Promise.all([
+      this.workspaceRepository.deleteAllInvitationsByWorkspace(workspace.id),
+      this.deleteWorkspaceContent(workspace.id, workspaceOwnerUser),
+      this.initiateWorkspace(workspace.ownerId, workspaceTotalSpace, {
+        numberOfSeats: workspace.numberOfSeats,
+        phoneNumber: workspace.phoneNumber,
+        address: workspace.address,
+      }),
+    ]);
   }
 
   async emptyAllUserOwnedWorkspaces(user: User): Promise<void> {


### PR DESCRIPTION
Delete workspace and its contents and initialize a new one upon resetting the user's account