### PR TITLE
[PB-4416]: refactor/replace-fileid-usage-with-uuid-in-trash-and-file-modules

### DIFF
--- a/src/modules/file/file.repository.spec.ts
+++ b/src/modules/file/file.repository.spec.ts
@@ -657,8 +657,8 @@ describe('FileRepository', () => {
         {
           where: {
             userId: user.id,
-            id: {
-              [Op.in]: files.map(({ id }) => id),
+            uuid: {
+              [Op.in]: files.map(({ uuid }) => uuid),
             },
           },
         },

--- a/src/modules/file/file.repository.ts
+++ b/src/modules/file/file.repository.ts
@@ -23,10 +23,6 @@ export interface FileRepository {
   deleteByFileId(fileId: any): Promise<any>;
   deleteFilesByUser(user: User, files: File[]): Promise<void>;
   destroyFile(where: Partial<FileModel>): Promise<void>;
-  findByIdNotDeleted(
-    id: FileAttributes['id'],
-    where: Partial<FileAttributes>,
-  ): Promise<File | null>;
   findAll(): Promise<Array<File> | []>;
   findAllByFolderIdAndUserId(
     folderId: FileAttributes['folderId'],
@@ -58,11 +54,6 @@ export interface FileRepository {
     offset: number,
     order: Array<[keyof FileModel, string]>,
   ): Promise<Array<File> | []>;
-  findOne(
-    fileId: FileAttributes['id'],
-    userId: FileAttributes['userId'],
-    options: FileOptions,
-  ): Promise<File | null>;
   findOneBy(where: Partial<FileAttributes>): Promise<File | null>;
   findByUuid(
     fileUuid: FileAttributes['uuid'],
@@ -486,14 +477,6 @@ export class SequelizeFileRepository implements FileRepository {
     return files.map(this.toDomain.bind(this));
   }
 
-  async findByIdNotDeleted(id: number): Promise<File> {
-    const file = await this.fileModel.findOne({
-      where: { id, deleted: false },
-    });
-
-    return file ? this.toDomain(file) : null;
-  }
-
   async findByUuidNotDeleted(uuid: FileAttributes['uuid']): Promise<File> {
     const file = await this.fileModel.findOne({
       where: { uuid, deleted: false },
@@ -572,21 +555,6 @@ export class SequelizeFileRepository implements FileRepository {
     return files.map((file) => {
       return this.toDomain(file);
     });
-  }
-
-  async findOne(
-    fileId: FileAttributes['id'],
-    userId: FileAttributes['userId'],
-    { deleted }: FileOptions,
-  ): Promise<File | null> {
-    const file = await this.fileModel.findOne({
-      where: {
-        id: fileId,
-        userId,
-        deleted,
-      },
-    });
-    return file ? this.toDomain(file) : null;
   }
 
   async findOneBy(where: Partial<FileAttributes>): Promise<File | null> {
@@ -754,8 +722,8 @@ export class SequelizeFileRepository implements FileRepository {
       {
         where: {
           userId: user.id,
-          id: {
-            [Op.in]: files.map(({ id }) => id),
+          uuid: {
+            [Op.in]: files.map(({ uuid }) => uuid),
           },
         },
       },

--- a/src/modules/file/file.usecase.spec.ts
+++ b/src/modules/file/file.usecase.spec.ts
@@ -263,7 +263,7 @@ describe('FileUseCases', () => {
       jest.spyOn(fileRepository, 'findOneBy').mockResolvedValueOnce(mockFile);
       jest.spyOn(sharingService, 'bulkRemoveSharings').mockResolvedValueOnce();
       jest
-        .spyOn(thumbnailUseCases, 'deleteThumbnailByFileId')
+        .spyOn(thumbnailUseCases, 'deleteThumbnailByFileUuid')
         .mockResolvedValueOnce();
       jest.spyOn(fileRepository, 'deleteFilesByUser').mockResolvedValueOnce();
 
@@ -277,9 +277,9 @@ describe('FileUseCases', () => {
         SharingItemType.File,
       );
 
-      expect(thumbnailUseCases.deleteThumbnailByFileId).toHaveBeenCalledWith(
+      expect(thumbnailUseCases.deleteThumbnailByFileUuid).toHaveBeenCalledWith(
         mockUser,
-        mockFile.id,
+        mockFile.uuid,
       );
 
       expect(fileRepository.deleteFilesByUser).toHaveBeenCalledWith(mockUser, [

--- a/src/modules/file/file.usecase.spec.ts
+++ b/src/modules/file/file.usecase.spec.ts
@@ -233,112 +233,61 @@ describe('FileUseCases', () => {
     });
   });
 
-  describe('delete file use case', () => {
-    const incrementalUserId = 15494;
-    const fileId = '2618494108';
-    const bucket = 'test';
-    const userMock = User.build({
-      id: incrementalUserId,
-      userId: 'userId',
-      name: 'User Owner',
-      lastname: 'Lastname',
-      email: 'fake@internxt.com',
-      username: 'fake',
-      bridgeUser: null,
-      rootFolderId: 1,
-      errorLoginCount: 0,
-      isEmailActivitySended: 1,
-      referralCode: null,
-      referrer: null,
-      syncDate: new Date(),
-      uuid: 'uuid',
-      lastResend: new Date(),
-      credit: null,
-      welcomePack: true,
-      registerCompleted: true,
-      backupsBucket: 'bucket',
-      sharedWorkspace: true,
-      avatar: 'avatar',
-      password: '',
-      mnemonic: '',
-      hKey: undefined,
-      secret_2FA: '',
-      lastPasswordChangedAt: new Date(),
-      emailVerified: false,
-    });
+  describe('deleteFilePermanently', () => {
+    const mockUser = newUser();
 
-    it.skip('should be able to delete a trashed file', async () => {
-      jest
-        .spyOn(fileRepository, 'deleteByFileId')
-        .mockImplementationOnce(() => Promise.resolve());
-
-      jest
-        .spyOn(bridgeService, 'deleteFile')
-        .mockImplementationOnce(() => Promise.resolve());
-
-      await service.deleteFilePermanently(userMock, { fileId, bucket });
-
-      expect(fileRepository.deleteByFileId).toHaveBeenCalledWith(fileId);
-    });
-
-    it.skip('should fail when the folder trying to delete has not been trashed', async () => {
-      jest.spyOn(fileRepository, 'deleteByFileId');
-
-      await service.deleteFilePermanently(userMock, { fileId, bucket });
-      expect(fileRepository.deleteByFileId).not.toHaveBeenCalled();
-    });
-
-    it.skip('should fail when the folder trying to delete is not owned by the user', async () => {
-      jest.spyOn(bridgeService, 'deleteFile');
-      jest.spyOn(fileRepository, 'deleteByFileId');
+    it('When file is not found then, thow NotFoundException', () => {
+      jest.spyOn(fileRepository, 'findOneBy').mockResolvedValueOnce(undefined);
 
       expect(
-        service.deleteFilePermanently(userMock, { fileId, bucket }),
-      ).rejects.toThrow(
-        new ForbiddenException(`You are not owner of this share`),
+        service.deleteFilePermanently(mockUser, { uuid: v4() }),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('When user is not owner of the file, then throw ForbiddenException', () => {
+      const unownedFile = newFile();
+      jest
+        .spyOn(fileRepository, 'findOneBy')
+        .mockResolvedValueOnce(unownedFile);
+
+      expect(
+        service.deleteFilePermanently(mockUser, { uuid: v4() }),
+      ).rejects.toThrow(ForbiddenException);
+    });
+
+    it('When the file is found and owned by the requesting user, then delete file', async () => {
+      const mockFile = newFile({
+        attributes: { user: mockUser, userId: mockUser.id },
+      });
+
+      jest.spyOn(fileRepository, 'findOneBy').mockResolvedValueOnce(mockFile);
+      jest.spyOn(sharingService, 'bulkRemoveSharings').mockResolvedValueOnce();
+      jest
+        .spyOn(thumbnailUseCases, 'deleteThumbnailByFileId')
+        .mockResolvedValueOnce();
+      jest.spyOn(fileRepository, 'deleteFilesByUser').mockResolvedValueOnce();
+
+      const { id, uuid } = await service.deleteFilePermanently(mockUser, {
+        uuid: mockFile.uuid,
+      });
+
+      expect(sharingService.bulkRemoveSharings).toHaveBeenCalledWith(
+        mockUser,
+        [mockFile.uuid],
+        SharingItemType.File,
       );
-      expect(bridgeService.deleteFile).not.toHaveBeenCalled();
-      expect(fileRepository.deleteByFileId).not.toHaveBeenCalled();
-    });
 
-    it.skip('should not delete a file from storage if delete shares fails', async () => {
-      const errorReason = new Error('reason');
+      expect(thumbnailUseCases.deleteThumbnailByFileId).toHaveBeenCalledWith(
+        mockUser,
+        mockFile.id,
+      );
 
-      jest
-        .spyOn(fileRepository, 'deleteByFileId')
-        .mockImplementationOnce(() => Promise.resolve());
-      jest.spyOn(bridgeService, 'deleteFile');
+      expect(fileRepository.deleteFilesByUser).toHaveBeenCalledWith(mockUser, [
+        mockFile,
+      ]);
 
-      expect.assertions(3);
-      try {
-        await service.deleteFilePermanently(userMock, { fileId, bucket });
-      } catch (err) {
-        expect(err).toBe(errorReason);
-      }
-
-      expect(bridgeService.deleteFile).not.toHaveBeenCalled();
-      expect(fileRepository.deleteByFileId).not.toHaveBeenCalled();
-    });
-
-    it.skip('should not delete a file from databse if could not be deleted from storage', async () => {
-      const errorReason = new Error('reason');
-
-      jest
-        .spyOn(fileRepository, 'deleteByFileId')
-        .mockImplementationOnce(() => Promise.resolve());
-
-      jest
-        .spyOn(bridgeService, 'deleteFile')
-        .mockImplementationOnce(() => Promise.reject(errorReason));
-
-      expect.assertions(2);
-      try {
-        await service.deleteFilePermanently(userMock, { fileId, bucket });
-      } catch (err) {
-        expect(err).toBe(errorReason);
-      }
-
-      expect(fileRepository.deleteByFileId).not.toHaveBeenCalled();
+      expect(id).toBe(mockFile.id);
+      expect(uuid).toBe(mockFile.uuid);
     });
   });
 
@@ -1218,6 +1167,7 @@ describe('FileUseCases', () => {
     it('When file exists, then it should return the file', async () => {
       const mockFile = newFile({ owner: userMocked });
       jest.spyOn(fileRepository, 'findByUuid').mockResolvedValue(mockFile);
+      jest.spyOn(cryptoService, 'decryptName').mockReturnValue('');
 
       const result = await service.getFileMetadata(userMocked, mockFile.uuid);
 

--- a/src/modules/file/file.usecase.ts
+++ b/src/modules/file/file.usecase.ts
@@ -70,14 +70,6 @@ export class FileUseCases {
     return this.fileRepository.sumExistentFileSizes(user.id);
   }
 
-  getByUserExceptParents(arg: any): Promise<File[]> {
-    throw new Error('Method not implemented.');
-  }
-
-  getByFileIdAndUser(arg: any): Promise<File> {
-    throw new Error('Method not implemented.');
-  }
-
   async deleteFilePermanently(
     user: User,
     where: Partial<File>,

--- a/src/modules/trash/dto/controllers/delete-item.dto.ts
+++ b/src/modules/trash/dto/controllers/delete-item.dto.ts
@@ -17,7 +17,9 @@ export enum DeleteItemType {
 export class DeleteItem {
   @ApiProperty({
     example: '4',
-    description: 'Id of file or folder',
+    description: 'Id of file or folder (deprecated in favor of uuid)',
+    deprecated: true,
+    nullable: true,
   })
   id?: string;
 

--- a/src/modules/trash/dto/controllers/move-items-to-trash.dto.ts
+++ b/src/modules/trash/dto/controllers/move-items-to-trash.dto.ts
@@ -18,8 +18,9 @@ export enum ItemType {
 export class ItemToTrash {
   @ApiProperty({
     example: '4',
-    description: 'Id of file or folder',
+    description: 'Id of file or folder (deprecated in favor of uuid)',
     nullable: true,
+    deprecated: true,
   })
   @IsOptional()
   id?: string;

--- a/src/modules/trash/trash.controller.ts
+++ b/src/modules/trash/trash.controller.ts
@@ -274,11 +274,13 @@ export class TrashController {
 
     for (const item of items) {
       if (item.type === DeleteItemType.FILE) {
-        if (item.id) filesIds.push(parseInt(item.id, 10));
-        if (item.uuid) filesUuids.push(item.uuid);
+        item.uuid
+          ? filesUuids.push(item.uuid)
+          : filesIds.push(parseInt(item.id, 10));
       } else if (item.type === DeleteItemType.FOLDER) {
-        if (item.id) foldersIds.push(parseInt(item.id, 10));
-        if (item.uuid) foldersUuids.push(item.uuid);
+        item.uuid
+          ? foldersUuids.push(item.uuid)
+          : foldersIds.push(parseInt(item.id, 10));
       }
     }
 

--- a/src/modules/trash/trash.usecase.spec.ts
+++ b/src/modules/trash/trash.usecase.spec.ts
@@ -199,34 +199,5 @@ describe('Trash Use Cases', () => {
         8,
       ); // Last folder chunk
     });
-
-    it('should fail if a folder is not found', async () => {
-      const error = Error('random error');
-      const foldersIdToDelete: Array<FolderAttributes['id']> = [
-        2176796544, 505779655, 724413021,
-      ];
-
-      jest.spyOn(fileUseCases, 'getByFileIdAndUser');
-      jest
-        .spyOn(folderUseCases, 'getFolder')
-        .mockImplementationOnce(() => Promise.resolve({} as Folder))
-        .mockImplementationOnce(() => Promise.reject(error))
-        .mockImplementationOnce(() => Promise.resolve({} as Folder));
-      jest.spyOn(fileUseCases, 'deleteFilePermanently');
-      jest.spyOn(folderUseCases, 'deleteFolderPermanently');
-
-      try {
-        await service.deleteItems(
-          {} as User,
-          [],
-          foldersIdToDelete as unknown as Folder[], // must be updated to be a list of folders
-        );
-      } catch (err) {
-        expect(err).toBeDefined();
-      }
-
-      expect(fileUseCases.deleteFilePermanently).not.toHaveBeenCalled();
-      expect(folderUseCases.deleteFolderPermanently).not.toHaveBeenCalled();
-    });
   });
 });


### PR DESCRIPTION
Continuing with the codebase migration to get rid of logic that still relies on numeric fileIds this pr introduces:
- Delete old unreferenced code that relied on numeric ileId usages
- deleteFilesByUser in file.repository now performs a where based on uuid instead of the numeric id
- Refactor in delete /trash/ to first search based on file uuid, although the fileId search logic might be safely delleted?
- Updated test logic to reflect any changes