### PR TITLE
[_] refactor: stop using some deprecated functions and solved code smells

### DIFF
--- a/src/externals/bridge/bridge.service.spec.ts
+++ b/src/externals/bridge/bridge.service.spec.ts
@@ -1,5 +1,7 @@
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { Test, TestingModule } from '@nestjs/testing';
+import { Logger } from '@nestjs/common';
+import { createMock } from '@golevelup/ts-jest';
 import { User } from '../../modules/user/user.domain';
 import { CryptoService } from '../crypto/crypto.service';
 import { HttpClientModule } from '../http/http.module';
@@ -48,7 +50,9 @@ describe('Bridge Service', () => {
     const module: TestingModule = await Test.createTestingModule({
       imports: [ConfigModule, HttpClientModule, CryptoModule],
       providers: [BridgeService],
-    }).compile();
+    })
+      .setLogger(createMock<Logger>())
+      .compile();
 
     service = module.get<BridgeService>(BridgeService);
     httpClient = module.get<HttpClient>(HttpClient);
@@ -78,7 +82,7 @@ describe('Bridge Service', () => {
       );
 
       expect(httpClient.delete).toHaveBeenCalledTimes(1);
-      expect(httpClient.delete).toBeCalledWith(
+      expect(httpClient.delete).toHaveBeenCalledWith(
         testUrl +
           '/buckets/cc925fa0-a145-58b8-8959-8b3796fd025f/files/6c4f6109-0f64-565d-b0c4-25091a3ec247',
         {

--- a/src/modules/feature-limit/feature-limits.guard.spec.ts
+++ b/src/modules/feature-limit/feature-limits.guard.spec.ts
@@ -1,9 +1,10 @@
 import { DeepMocked, createMock } from '@golevelup/ts-jest';
+import { TestingModule, Test } from '@nestjs/testing';
 import { PaymentRequiredException } from './exceptions/payment-required.exception';
 import { FeatureLimitUsecases } from './feature-limit.usecase';
 import { newUser } from '../../../test/fixtures';
 import { LimitLabels } from './limits.enum';
-import { BadRequestException, ExecutionContext } from '@nestjs/common';
+import { BadRequestException, ExecutionContext, Logger } from '@nestjs/common';
 import { FeatureLimit } from './feature-limits.guard';
 import { Reflector } from '@nestjs/core';
 import {
@@ -15,13 +16,21 @@ const user = newUser();
 
 describe('FeatureLimitUsecases', () => {
   let guard: FeatureLimit;
-  let reflector: DeepMocked<Reflector>;
-  let featureLimitUsecases: DeepMocked<FeatureLimitUsecases>;
+  let reflector: Reflector;
+  let featureLimitUsecases: FeatureLimitUsecases;
 
   beforeEach(async () => {
-    reflector = createMock<Reflector>();
-    featureLimitUsecases = createMock<FeatureLimitUsecases>();
-    guard = new FeatureLimit(reflector, featureLimitUsecases);
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [FeatureLimit],
+    })
+      .useMocker(() => createMock())
+      .setLogger(createMock<Logger>())
+      .compile();
+
+    guard = module.get<FeatureLimit>(FeatureLimit);
+    featureLimitUsecases =
+      module.get<FeatureLimitUsecases>(FeatureLimitUsecases);
+    reflector = module.get<Reflector>(Reflector);
   });
 
   it('Guard should be defined', () => {

--- a/src/modules/file/file.controller.spec.ts
+++ b/src/modules/file/file.controller.spec.ts
@@ -3,6 +3,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import {
   BadRequestException,
   InternalServerErrorException,
+  Logger,
   NotFoundException,
 } from '@nestjs/common';
 import { v4 } from 'uuid';
@@ -71,6 +72,7 @@ describe('FileController', () => {
       providers: [FileUseCases, StorageNotificationService],
     })
       .useMocker(() => createMock())
+      .setLogger(createMock<Logger>())
       .compile();
 
     fileController = module.get<FileController>(FileController);

--- a/src/modules/folder/folder.usecase.spec.ts
+++ b/src/modules/folder/folder.usecase.spec.ts
@@ -322,7 +322,7 @@ describe('FolderUseCases', () => {
 
       await service.deleteOrphansFolders(userId);
 
-      expect(service.deleteOrphansFolders).toBeCalledTimes(4);
+      expect(service.deleteOrphansFolders).toHaveBeenCalledTimes(4);
     });
 
     it('should avoid recursion if not needed', async () => {
@@ -334,7 +334,7 @@ describe('FolderUseCases', () => {
 
       await service.deleteOrphansFolders(userId);
 
-      expect(service.deleteOrphansFolders).toBeCalledTimes(1);
+      expect(service.deleteOrphansFolders).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/src/modules/sharing/sharing.controller.ts
+++ b/src/modules/sharing/sharing.controller.ts
@@ -305,31 +305,23 @@ export class SharingController {
     description: 'Id of the invite to validate',
     type: String,
   })
-  async validateInvite(
-    @Param('id') id: SharingInvite['id'],
-    @Res({ passthrough: true }) res: Response,
-  ) {
+  async validateInvite(@Param('id') id: SharingInvite['id']) {
     try {
       return await this.sharingService.validateInvite(id);
     } catch (error) {
-      let errorMessage = error.message;
-
       if (
         error instanceof BadRequestException ||
         error instanceof NotFoundException
       ) {
         throw error;
-      } else {
-        Logger.error(
-          `[SHARING/VALIDATEINVITE] Error while trying to validate invitation ${id}, message: ${
-            error.message
-          }, ${error.stack ?? 'No stack trace'}`,
-        );
-
-        res.status(HttpStatus.INTERNAL_SERVER_ERROR);
-        errorMessage = 'Internal Server Error';
       }
-      return { error: errorMessage };
+      Logger.error(
+        `[SHARING/VALIDATEINVITE] Error while trying to validate invitation ${id}, message: ${
+          error.message
+        }, ${error.stack ?? 'No stack trace'}`,
+      );
+
+      throw new InternalServerErrorException();
     }
   }
 
@@ -390,7 +382,6 @@ export class SharingController {
   async getSharedFoldersInsideSharedFolder(
     @UserDecorator() user: User,
     @Param('sharedFolderId') sharedFolderId: Folder['uuid'],
-    @Res({ passthrough: true }) res: Response,
     @Query('orderBy') orderBy: OrderBy,
     @Query('token') token: string,
     @Query('page') page = 0,
@@ -410,22 +401,17 @@ export class SharingController {
         order,
       );
     } catch (error) {
-      let errorMessage = error.message;
-
       if (error instanceof ForbiddenException) {
         throw error;
-      } else {
-        Logger.error(
-          `[SHARING/LIST-FOLDERS] Error while getting shared folders by user ${
-            user.uuid
-          }, message: ${error.message}, ${error.stack ?? 'No stack trace'}`,
-        );
-
-        res.status(HttpStatus.INTERNAL_SERVER_ERROR);
-        errorMessage = 'Internal Server Error';
       }
 
-      return { error: errorMessage };
+      Logger.error(
+        `[SHARING/LIST-FOLDERS] Error while getting shared folders by user ${
+          user.uuid
+        }, message: ${error.message}, ${error.stack ?? 'No stack trace'}`,
+      );
+
+      throw new InternalServerErrorException();
     }
   }
 
@@ -466,7 +452,6 @@ export class SharingController {
   async getPrivateShareFiles(
     @UserDecorator() user: User,
     @Param('sharedFolderId') sharedFolderId: Folder['uuid'],
-    @Res({ passthrough: true }) res: Response,
     @Query('orderBy') orderBy: OrderBy,
     @Query('token') token: string,
     @Query('page') page = 0,
@@ -486,22 +471,17 @@ export class SharingController {
         order,
       );
     } catch (error) {
-      let errorMessage = error.message;
-
       if (error instanceof ForbiddenException) {
         throw error;
-      } else {
-        Logger.error(
-          `[SHARING/GETSHAREDFILES] Error while getting shared folders by folder ${
-            user.uuid
-          }, message: ${error.message}, ${error.stack ?? 'No stack trace'}`,
-        );
-
-        res.status(HttpStatus.INTERNAL_SERVER_ERROR);
-        errorMessage = 'Internal Server Error';
       }
 
-      return { error: errorMessage };
+      Logger.error(
+        `[SHARING/GETSHAREDFILES] Error while getting shared folders by folder ${
+          user.uuid
+        }, message: ${error.message}, ${error.stack ?? 'No stack trace'}`,
+      );
+
+      throw new InternalServerErrorException();
     }
   }
 
@@ -535,7 +515,6 @@ export class SharingController {
   @ApiOkResponse({ description: 'Get all items inside a shared folder' })
   async getPublicShareFiles(
     @Param('sharedFolderId') sharedFolderId: Folder['uuid'],
-    @Res({ passthrough: true }) res: Response,
     @Query('token') token: string,
     @Query('code') code: string,
     @Query('page') page = 0,
@@ -580,7 +559,6 @@ export class SharingController {
   @ApiOkResponse({ description: 'Get all items inside a shared folder' })
   async getPublicSharedFolders(
     @Param('sharedFolderId') sharedFolderId: Folder['uuid'],
-    @Res({ passthrough: true }) res: Response,
     @Query('token') token: string,
     @Query('code') code: string,
     @Query('page') page = 0,
@@ -960,7 +938,6 @@ export class SharingController {
     @Query('perPage') perPage = 50,
     @Query('orderBy') orderBy: OrderBy,
     @Param('folderId') folderId: Folder['uuid'],
-    @Res({ passthrough: true }) res: Response,
   ): Promise<{ users: Array<any> } | { error: string }> {
     try {
       const { offset, limit } = Pagination.calculatePagination(page, perPage);

--- a/src/modules/workspaces/guards/workspaces.guard.spec.ts
+++ b/src/modules/workspaces/guards/workspaces.guard.spec.ts
@@ -3,6 +3,7 @@ import {
   BadRequestException,
   ExecutionContext,
   ForbiddenException,
+  Logger,
   NotFoundException,
 } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
@@ -21,6 +22,7 @@ import {
 import { WorkspaceUser } from '../domains/workspace-user.domain';
 import { WorkspaceTeamUser } from '../domains/workspace-team-user.domain';
 import { v4 } from 'uuid';
+import { Test, TestingModule } from '@nestjs/testing';
 
 describe('WorkspaceGuard', () => {
   let guard: WorkspaceGuard;
@@ -28,9 +30,16 @@ describe('WorkspaceGuard', () => {
   let workspaceUseCases: DeepMocked<WorkspacesUsecases>;
 
   beforeEach(async () => {
-    reflector = createMock<Reflector>();
-    workspaceUseCases = createMock<WorkspacesUsecases>();
-    guard = new WorkspaceGuard(reflector, workspaceUseCases);
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [WorkspaceGuard],
+    })
+      .useMocker(createMock)
+      .setLogger(createMock<Logger>())
+      .compile();
+
+    guard = module.get(WorkspaceGuard);
+    reflector = module.get(Reflector);
+    workspaceUseCases = module.get(WorkspacesUsecases);
   });
 
   it('Guard should be defined', () => {


### PR DESCRIPTION
This PR removes the use of some deprecated function in our test suites and removes unused arguments in sharingController. It does not intend to increase the test coverage we have currently. 