### PR TITLE
[_] chore: reduce axios timeout to default value

### DIFF
--- a/src/externals/http/http.module.ts
+++ b/src/externals/http/http.module.ts
@@ -13,7 +13,7 @@ const agentConfig: HttpsOptions | HttpOptions = {
   keepAlive: true,
   maxSockets: 100,
   maxFreeSockets: 30,
-  timeout: 16000,
+  timeout: 8000, // Default timeout for the agent.
   freeSocketTimeout: 4000, // Set this value to prevent socket hang up errors as Nodejs timeout is 5000ms
 };
 


### PR DESCRIPTION
I set the timeout to 16 seconds due to a problem with the TLS handshake taking too much time between drive-server and notifications. The problem was identified and addressed, so we are going back to the default values.