### PR TITLE
[_]: fix/update JWT secret retrieval and add debug logging

### DIFF
--- a/src/modules/user/user.usecase.spec.ts
+++ b/src/modules/user/user.usecase.spec.ts
@@ -87,6 +87,7 @@ import { AsymmetricEncryptionModule } from '../../externals/asymmetric-encryptio
 import { PreCreateUserDto } from './dto/pre-create-user.dto';
 import { Environment } from '@internxt/inxt-js';
 import * as bip39 from 'bip39';
+import getEnv from '../../config/configuration';
 
 const TEST_MNEMONIC =
   'album middle away ecology napkin quote buffalo method tooth mask laundry film add path suggest heart unaware project neck bird force heavy put latin';
@@ -2822,7 +2823,6 @@ describe('User use cases', () => {
     it('When token is valid, then it should return the user UUID', () => {
       const userUuid = v4();
       const token = 'validToken';
-      const jwtSecret = 'jwt-secret';
       const decodedToken = {
         payload: {
           uuid: userUuid,
@@ -2830,7 +2830,6 @@ describe('User use cases', () => {
         },
       };
 
-      jest.spyOn(configService, 'get').mockReturnValue(jwtSecret);
       const verifyTokenSpy = jest
         .spyOn(jwtLibrary, 'verifyToken')
         .mockReturnValue(decodedToken);
@@ -2838,7 +2837,7 @@ describe('User use cases', () => {
       const result = userUseCases.verifyAndDecodeAccountRecoveryToken(token);
 
       expect(result).toEqual({ userUuid });
-      expect(verifyTokenSpy).toHaveBeenCalledWith(token, jwtSecret);
+      expect(verifyTokenSpy).toHaveBeenCalledWith(token, getEnv().secrets.jwt);
     });
 
     it('When token verification returns a string, then it should throw ForbiddenException', () => {

--- a/src/modules/user/user.usecase.ts
+++ b/src/modules/user/user.usecase.ts
@@ -66,6 +66,7 @@ import { AttemptChangeEmailNotFoundException } from './exception/attempt-change-
 import { UserEmailAlreadyInUseException } from './exception/user-email-already-in-use.exception';
 import { UserNotFoundException } from './exception/user-not-found.exception';
 import { getTokenDefaultIat, verifyToken } from '../../lib/jwt';
+import getEnv from '../../config/configuration';
 import { MailTypes } from '../security/mail-limit/mailTypes';
 import { SequelizeMailLimitRepository } from '../security/mail-limit/mail-limit.repository';
 import { Time } from '../../lib/time';
@@ -1100,12 +1101,15 @@ export class UserUseCases {
     userUuid: string;
   } {
     try {
-      const jwtSecret = this.configService.get('secrets.jwt');
+      const jwtSecret = getEnv().secrets.jwt;
       const decoded = verifyToken<{
         payload: { uuid?: string; action?: string };
       }>(token, jwtSecret);
 
       if (typeof decoded === 'string') {
+        Logger.error(
+          `[RECOVER-ACCOUNT/VERIFY-AND-DECODE-TOKEN]: Token is a string`,
+        );
         throw new ForbiddenException('Invalid token');
       }
 
@@ -1116,6 +1120,11 @@ export class UserUseCases {
         decodedContent?.action !== 'recover-account' ||
         !validate(decodedContent.uuid)
       ) {
+        Logger.error(
+          `[RECOVER-ACCOUNT/VERIFY-AND-DECODE-TOKEN]: Invalid token structure ${JSON.stringify(
+            decoded,
+          )}`,
+        );
         throw new ForbiddenException('Invalid token');
       }
 


### PR DESCRIPTION
Update `verifyAndDecodeAccountRecoveryToken` to use getEnv() instead of configService.get to try and fix the 403 forbidden error that only happens in this endpoint