### PR TITLE
[_]: refactor/ update legacy account recovery to use token from request body

### DIFF
--- a/src/modules/user/dto/legacy-recover-account.dto.ts
+++ b/src/modules/user/dto/legacy-recover-account.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsNotEmpty, ValidateNested } from 'class-validator';
+import { IsBase64, IsNotEmpty, ValidateNested } from 'class-validator';
 import { Type } from 'class-transformer';
 
 class EncryptedMnemonicDto {
@@ -62,6 +62,14 @@ class NewGeneratedKeysDto {
 }
 
 export class LegacyRecoverAccountDto {
+  @ApiProperty({
+    example: 'temporary_auth_token',
+    description: 'Base64 encoded temporary auth token',
+  })
+  @IsNotEmpty()
+  @IsBase64()
+  token: string;
+
   @ApiProperty({
     example: 'hashed_password',
     description: 'New user pass hashed',

--- a/src/modules/user/user.controller.spec.ts
+++ b/src/modules/user/user.controller.spec.ts
@@ -1251,8 +1251,8 @@ describe('User Controller', () => {
 
   describe('PUT /legacy-recover-account', () => {
     const mockUser = newUser();
-    const validToken = 'valid_token';
     const mockLegacyRecoverAccountDto: LegacyRecoverAccountDto = {
+      token: 'valid_token',
       mnemonic: 'encrypted_mnemonic',
       password: 'encrypted_password',
       salt: 'encrypted_salt',
@@ -1290,7 +1290,6 @@ describe('User Controller', () => {
     it('When token is missing, then it throws BadRequestException', async () => {
       await expect(
         userController.requestLegacyAccountRecovery(
-          '',
           mockLegacyRecoverAccountDto,
         ),
       ).rejects.toThrow(BadRequestException);
@@ -1303,13 +1302,12 @@ describe('User Controller', () => {
 
     it('When token is provided and valid, then it recovers account with legacy method', async () => {
       await userController.requestLegacyAccountRecovery(
-        validToken,
         mockLegacyRecoverAccountDto,
       );
 
       expect(
         userUseCases.verifyAndDecodeAccountRecoveryToken,
-      ).toHaveBeenCalledWith(validToken);
+      ).toHaveBeenCalledWith(mockLegacyRecoverAccountDto.token);
       expect(userUseCases.recoverAccountLegacy).toHaveBeenCalledWith(
         mockUser.uuid,
         mockLegacyRecoverAccountDto,
@@ -1326,7 +1324,6 @@ describe('User Controller', () => {
 
       await expect(
         userController.requestLegacyAccountRecovery(
-          'invalid_token',
           mockLegacyRecoverAccountDto,
         ),
       ).rejects.toThrow(tokenError);
@@ -1342,14 +1339,13 @@ describe('User Controller', () => {
 
       await expect(
         userController.requestLegacyAccountRecovery(
-          validToken,
           mockLegacyRecoverAccountDto,
         ),
       ).rejects.toThrow(recoveryError);
 
       expect(
         userUseCases.verifyAndDecodeAccountRecoveryToken,
-      ).toHaveBeenCalledWith(validToken);
+      ).toHaveBeenCalledWith(mockLegacyRecoverAccountDto.token);
     });
   });
 

--- a/src/modules/user/user.controller.ts
+++ b/src/modules/user/user.controller.ts
@@ -837,13 +837,13 @@ export class UserController {
       'Recover account with legacy backup file, mnemonic only files should be used',
     summary: 'Recover accocunt with legacy backup file',
   })
-  async requestLegacyAccountRecovery(
-    @Query('token') token: string,
-    @Body() body: LegacyRecoverAccountDto,
-  ) {
+  async requestLegacyAccountRecovery(@Body() body: LegacyRecoverAccountDto) {
+    const { token } = body;
+
     if (!token) {
       throw new BadRequestException('Token is required');
     }
+
     const decodedToken =
       this.userUseCases.verifyAndDecodeAccountRecoveryToken(token);
 


### PR DESCRIPTION
Move token from query params to the request body in legacy-account-recover