### PR TITLE
[PB-4689]: feat/implement user action audit logging

### DIFF
--- a/migrations/20250717172203-create-user-logs-table.js
+++ b/migrations/20250717172203-create-user-logs-table.js
@@ -1,0 +1,65 @@
+'use strict';
+
+const tableName = 'audit_logs';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.createTable(tableName, {
+      id: {
+        type: Sequelize.DataTypes.UUID,
+        primaryKey: true,
+        defaultValue: Sequelize.DataTypes.UUIDV4,
+      },
+      entity_type: {
+        type: Sequelize.ENUM('user', 'workspace'),
+        allowNull: false,
+      },
+      entity_id: {
+        type: Sequelize.DataTypes.UUID,
+        allowNull: false,
+      },
+      action: {
+        type: Sequelize.ENUM(
+          // User actions
+          'storage-changed',
+          'email-changed',
+          'password-changed',
+          '2fa-enabled',
+          '2fa-disabled',
+          'account-reset',
+          'account-recovery',
+          // Workspace actions
+          'workspace-created',
+          'workspace-storage-changed',
+          'workspace-deleted',
+        ),
+        allowNull: false,
+      },
+      performer_type: {
+        type: Sequelize.ENUM('user', 'gateway', 'system'),
+        allowNull: false,
+      },
+      performer_id: {
+        type: Sequelize.DataTypes.UUID,
+        allowNull: true,
+      },
+      metadata: {
+        type: Sequelize.DataTypes.JSONB,
+        allowNull: true,
+      },
+      created_at: {
+        type: Sequelize.DataTypes.DATE,
+        allowNull: false,
+        defaultValue: Sequelize.DataTypes.NOW,
+      },
+    });
+
+    await queryInterface.addIndex(tableName, ['entity_id']);
+    await queryInterface.addIndex(tableName, ['performer_type']);
+  },
+
+  async down(queryInterface) {
+    await queryInterface.dropTable(tableName);
+  },
+};

--- a/src/externals/notifications/audit-log.service.spec.ts
+++ b/src/externals/notifications/audit-log.service.spec.ts
@@ -1,0 +1,153 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { createMock } from '@golevelup/ts-jest';
+import { AuditLogService } from './audit-log.service';
+import { NotificationService } from './notification.service';
+import { AuditActionEvent } from './events/audit-log.event';
+import { AuditAction } from '../../modules/user/audit-logs.attributes';
+import { newUser } from '../../../test/fixtures';
+
+describe('AuditLogService', () => {
+  let service: AuditLogService;
+  let notificationService: NotificationService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [AuditLogService],
+    })
+      .useMocker(createMock)
+      .compile();
+
+    service = module.get<AuditLogService>(AuditLogService);
+    notificationService = module.get<NotificationService>(NotificationService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('logUserAction', () => {
+    it('When user and action are provided, then it should emit a UserActionEvent', () => {
+      const user = newUser();
+      const action = AuditAction.PasswordChanged;
+
+      service.logUserAction(user, action);
+
+      expect(notificationService.add).toHaveBeenCalledWith(
+        expect.any(AuditActionEvent),
+      );
+    });
+  });
+
+  describe('logStorageChanged', () => {
+    it('When user is provided, then it should log storage changed action', () => {
+      const user = newUser();
+      jest.spyOn(service, 'logUserAction');
+
+      service.logStorageChanged(user);
+
+      expect(service.logUserAction).toHaveBeenCalledWith(
+        user,
+        AuditAction.StorageChanged,
+        undefined,
+      );
+    });
+
+    it('When user and maxSpaceBytes are provided, then it should log storage changed action with metadata', () => {
+      const user = newUser();
+      const maxSpaceBytes = 1000000;
+      jest.spyOn(service, 'logUserAction');
+
+      service.logStorageChanged(user, maxSpaceBytes);
+
+      expect(service.logUserAction).toHaveBeenCalledWith(
+        user,
+        AuditAction.StorageChanged,
+        { maxSpaceBytes },
+      );
+    });
+  });
+
+  describe('logEmailChanged', () => {
+    it('When user is provided, then it should log email changed action', () => {
+      const user = newUser();
+      jest.spyOn(service, 'logUserAction');
+
+      service.logEmailChanged(user);
+
+      expect(service.logUserAction).toHaveBeenCalledWith(
+        user,
+        AuditAction.EmailChanged,
+      );
+    });
+  });
+
+  describe('logPasswordChanged', () => {
+    it('When user is provided, then it should log password changed action', () => {
+      const user = newUser();
+      jest.spyOn(service, 'logUserAction');
+
+      service.logPasswordChanged(user);
+
+      expect(service.logUserAction).toHaveBeenCalledWith(
+        user,
+        AuditAction.PasswordChanged,
+      );
+    });
+  });
+
+  describe('logTfaEnabled', () => {
+    it('When user is provided, then it should log 2FA enabled action', () => {
+      const user = newUser();
+      jest.spyOn(service, 'logUserAction');
+
+      service.logTfaEnabled(user);
+
+      expect(service.logUserAction).toHaveBeenCalledWith(
+        user,
+        AuditAction.TfaEnabled,
+      );
+    });
+  });
+
+  describe('logTfaDisabled', () => {
+    it('When user is provided, then it should log 2FA disabled action', () => {
+      const user = newUser();
+      jest.spyOn(service, 'logUserAction');
+
+      service.logTfaDisabled(user);
+
+      expect(service.logUserAction).toHaveBeenCalledWith(
+        user,
+        AuditAction.TfaDisabled,
+      );
+    });
+  });
+
+  describe('logAccountReset', () => {
+    it('When user is provided, then it should log account reset action', () => {
+      const user = newUser();
+      jest.spyOn(service, 'logUserAction');
+
+      service.logAccountReset(user);
+
+      expect(service.logUserAction).toHaveBeenCalledWith(
+        user,
+        AuditAction.AccountReset,
+      );
+    });
+  });
+
+  describe('logAccountRecovery', () => {
+    it('When user is provided, then it should log account recovery action', () => {
+      const user = newUser();
+      jest.spyOn(service, 'logUserAction');
+
+      service.logAccountRecovery(user);
+
+      expect(service.logUserAction).toHaveBeenCalledWith(
+        user,
+        AuditAction.AccountRecovery,
+      );
+    });
+  });
+});

--- a/src/externals/notifications/audit-log.service.ts
+++ b/src/externals/notifications/audit-log.service.ts
@@ -1,0 +1,162 @@
+import { Injectable } from '@nestjs/common';
+import { NotificationService } from './notification.service';
+import { AuditActionEvent } from './events/audit-log.event';
+import { User } from '../../modules/user/user.domain';
+import {
+  AuditAction,
+  AuditEntityType,
+  AuditPerformerType,
+} from '../../modules/user/audit-logs.attributes';
+
+@Injectable()
+export class AuditLogService {
+  constructor(private readonly notificationService: NotificationService) {}
+
+  /**
+   * Log a generic activity action by emitting an event
+   * @param entityType - The type of entity (user, workspace)
+   * @param entityId - The ID of the entity
+   * @param action - The action that was performed
+   * @param performerType - Who performed the action (user, gateway, system)
+   * @param performerId - The ID of the performer
+   * @param metadata - Optional metadata to include
+   */
+  logActivity(
+    entityType: AuditEntityType,
+    entityId: string,
+    action: AuditAction,
+    performerType: AuditPerformerType,
+    performerId?: string,
+    metadata?: Record<string, any>,
+  ): void {
+    const event = new AuditActionEvent(
+      entityType,
+      entityId,
+      action,
+      performerType,
+      performerId,
+      metadata,
+    );
+    this.notificationService.add(event);
+  }
+
+  /**
+   * Log a user action performed by the user themselves
+   * @param user - The user who performed the action
+   * @param action - The action that was performed
+   * @param metadata - Optional metadata to include
+   */
+  logUserAction(
+    user: User,
+    action: AuditAction,
+    metadata?: Record<string, any>,
+  ): void {
+    this.logActivity(
+      AuditEntityType.User,
+      user.uuid,
+      action,
+      AuditPerformerType.User,
+      user.uuid,
+      metadata,
+    );
+  }
+
+  /**
+   * Log a user action performed by the gateway
+   * @param user - The user affected by the action
+   * @param action - The action that was performed
+   * @param metadata - Optional metadata to include
+   */
+  logGatewayUserAction(
+    user: User,
+    action: AuditAction,
+    metadata?: Record<string, any>,
+  ): void {
+    this.logActivity(
+      AuditEntityType.User,
+      user.uuid,
+      action,
+      AuditPerformerType.Gateway,
+      undefined,
+      metadata,
+    );
+  }
+
+  /**
+   * Log a workspace action
+   * @param workspaceId - The workspace ID
+   * @param action - The action that was performed
+   * @param performerType - Who performed the action
+   * @param performerId - The ID of the performer
+   * @param metadata - Optional metadata to include
+   */
+  logWorkspaceAction(
+    workspaceId: string,
+    action: AuditAction,
+    performerType: AuditPerformerType,
+    performerId?: string,
+    metadata?: Record<string, any>,
+  ): void {
+    this.logActivity(
+      AuditEntityType.Workspace,
+      workspaceId,
+      action,
+      performerType,
+      performerId,
+      metadata,
+    );
+  }
+
+  /**
+   * Log storage changed action
+   */
+  logStorageChanged(user: User, maxSpaceBytes?: number): void {
+    this.logUserAction(
+      user,
+      AuditAction.StorageChanged,
+      maxSpaceBytes ? { maxSpaceBytes } : undefined,
+    );
+  }
+
+  /**
+   * Log email changed action
+   */
+  logEmailChanged(user: User): void {
+    this.logUserAction(user, AuditAction.EmailChanged);
+  }
+
+  /**
+   * Log password changed action
+   */
+  logPasswordChanged(user: User): void {
+    this.logUserAction(user, AuditAction.PasswordChanged);
+  }
+
+  /**
+   * Log 2FA enabled action
+   */
+  logTfaEnabled(user: User): void {
+    this.logUserAction(user, AuditAction.TfaEnabled);
+  }
+
+  /**
+   * Log 2FA disabled action
+   */
+  logTfaDisabled(user: User): void {
+    this.logUserAction(user, AuditAction.TfaDisabled);
+  }
+
+  /**
+   * Log account reset action
+   */
+  logAccountReset(user: User): void {
+    this.logUserAction(user, AuditAction.AccountReset);
+  }
+
+  /**
+   * Log account recovery action
+   */
+  logAccountRecovery(user: User): void {
+    this.logUserAction(user, AuditAction.AccountRecovery);
+  }
+}

--- a/src/externals/notifications/events/audit-log.event.ts
+++ b/src/externals/notifications/events/audit-log.event.ts
@@ -1,0 +1,43 @@
+import {
+  AuditAction,
+  AuditEntityType,
+  AuditPerformerType,
+} from '../../../modules/user/audit-logs.attributes';
+import { Event } from './event';
+
+export class AuditActionEvent extends Event {
+  entityType: AuditEntityType;
+  entityId: string;
+  action: AuditAction;
+  performerType: AuditPerformerType;
+  performerId?: string;
+  metadata?: Record<string, any>;
+
+  constructor(
+    entityType: AuditEntityType,
+    entityId: string,
+    action: AuditAction,
+    performerType: AuditPerformerType,
+    performerId?: string,
+    metadata?: Record<string, any>,
+  ) {
+    super(AuditActionEvent.id, {
+      entityType,
+      entityId,
+      action,
+      performerType,
+      performerId,
+      metadata,
+    });
+    this.entityType = entityType;
+    this.entityId = entityId;
+    this.action = action;
+    this.performerType = performerType;
+    this.performerId = performerId;
+    this.metadata = metadata;
+  }
+
+  static get id(): string {
+    return 'audit.logged';
+  }
+}

--- a/src/externals/notifications/listeners/audit-log.listener.spec.ts
+++ b/src/externals/notifications/listeners/audit-log.listener.spec.ts
@@ -1,0 +1,225 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { createMock, DeepMocked } from '@golevelup/ts-jest';
+import { Logger } from '@nestjs/common';
+import { AuditLogListener } from './audit-log.listener';
+import { SequelizeAuditLogRepository } from '../../../modules/user/audit-logs.repository';
+import { AuditActionEvent } from '../events/audit-log.event';
+import {
+  AuditAction,
+  AuditEntityType,
+  AuditPerformerType,
+} from '../../../modules/user/audit-logs.attributes';
+import { AuditLog } from '../../../modules/user/audit-logs.domain';
+import { newUser, newAuditLog } from '../../../../test/fixtures';
+
+describe('AuditLogListener', () => {
+  let listener: AuditLogListener;
+  let auditLogRepository: SequelizeAuditLogRepository;
+  let loggerMock: DeepMocked<Logger>;
+
+  beforeEach(async () => {
+    loggerMock = createMock<Logger>();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [AuditLogListener],
+    })
+      .setLogger(loggerMock)
+      .useMocker(createMock)
+      .compile();
+
+    listener = module.get<AuditLogListener>(AuditLogListener);
+    auditLogRepository = module.get<SequelizeAuditLogRepository>(
+      SequelizeAuditLogRepository,
+    );
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('handleAuditAction', () => {
+    it('When AuditActionEvent is received, then it should create an audit log and log success', async () => {
+      const user = newUser();
+      const action = AuditAction.PasswordChanged;
+      const event = new AuditActionEvent(
+        AuditEntityType.User,
+        user.uuid,
+        action,
+        AuditPerformerType.User,
+        user.uuid,
+      );
+
+      const mockAuditLog = newAuditLog({
+        entityType: AuditEntityType.User,
+        entityId: user.uuid,
+        action,
+        performerType: AuditPerformerType.User,
+        performerId: user.uuid,
+      });
+
+      jest.spyOn(auditLogRepository, 'create').mockResolvedValue(mockAuditLog);
+      const logSpy = jest.spyOn(loggerMock, 'log');
+
+      await listener.handleAuditAction(event);
+
+      expect(auditLogRepository.create).toHaveBeenCalledWith({
+        entityType: AuditEntityType.User,
+        entityId: user.uuid,
+        action,
+        performerType: AuditPerformerType.User,
+        performerId: user.uuid,
+        metadata: undefined,
+      });
+      expect(logSpy).toHaveBeenCalledWith(
+        {
+          user: user.uuid,
+          id: 'AUDIT_LOGGED',
+          entity: {
+            entityType: AuditEntityType.User,
+            action,
+            performerType: AuditPerformerType.User,
+          },
+          message: `Audit '${action}' logged successfully for ${AuditEntityType.User}:${user.uuid}`,
+        },
+        'AuditLogListener',
+      );
+    });
+
+    it('When repository throws an error, then it should log the error and not throw', async () => {
+      const user = newUser();
+      const action = AuditAction.EmailChanged;
+      const event = new AuditActionEvent(
+        AuditEntityType.User,
+        user.uuid,
+        action,
+        AuditPerformerType.User,
+        user.uuid,
+      );
+      const error = new Error('Database connection failed');
+
+      jest.spyOn(auditLogRepository, 'create').mockRejectedValue(error);
+      const errorSpy = jest.spyOn(loggerMock, 'error');
+
+      await listener.handleAuditAction(event);
+
+      expect(auditLogRepository.create).toHaveBeenCalledWith({
+        entityType: AuditEntityType.User,
+        entityId: user.uuid,
+        action,
+        performerType: AuditPerformerType.User,
+        performerId: user.uuid,
+        metadata: undefined,
+      });
+      expect(errorSpy).toHaveBeenCalled();
+      const errorCall = errorSpy.mock.calls[0][0];
+      expect(errorCall).toMatchObject({
+        user: user.uuid,
+        id: 'AUDIT_LOG_ERROR',
+        entity: {
+          entityType: AuditEntityType.User,
+          action,
+          performerType: AuditPerformerType.User,
+        },
+      });
+      expect(errorCall.message).toContain('Failed to log audit');
+    });
+
+    it('When different action types are received, then it should handle them all correctly', async () => {
+      const user = newUser();
+      const actions = [
+        AuditAction.TfaEnabled,
+        AuditAction.TfaDisabled,
+        AuditAction.AccountReset,
+        AuditAction.StorageChanged,
+      ];
+
+      jest
+        .spyOn(auditLogRepository, 'create')
+        .mockResolvedValue({} as AuditLog);
+
+      for (const action of actions) {
+        const event = new AuditActionEvent(
+          AuditEntityType.User,
+          user.uuid,
+          action,
+          AuditPerformerType.User,
+          user.uuid,
+        );
+        await listener.handleAuditAction(event);
+      }
+
+      expect(auditLogRepository.create).toHaveBeenCalledTimes(actions.length);
+      actions.forEach((action) => {
+        expect(auditLogRepository.create).toHaveBeenCalledWith({
+          entityType: AuditEntityType.User,
+          entityId: user.uuid,
+          action,
+          performerType: AuditPerformerType.User,
+          performerId: user.uuid,
+          metadata: undefined,
+        });
+      });
+    });
+
+    it('When multiple events are received for same user, then it should process them all', async () => {
+      const user = newUser();
+      const events = [
+        new AuditActionEvent(
+          AuditEntityType.User,
+          user.uuid,
+          AuditAction.PasswordChanged,
+          AuditPerformerType.User,
+          user.uuid,
+        ),
+        new AuditActionEvent(
+          AuditEntityType.User,
+          user.uuid,
+          AuditAction.EmailChanged,
+          AuditPerformerType.User,
+          user.uuid,
+        ),
+        new AuditActionEvent(
+          AuditEntityType.User,
+          user.uuid,
+          AuditAction.TfaEnabled,
+          AuditPerformerType.User,
+          user.uuid,
+        ),
+      ];
+
+      jest
+        .spyOn(auditLogRepository, 'create')
+        .mockResolvedValue({} as AuditLog);
+
+      for (const event of events) {
+        await listener.handleAuditAction(event);
+      }
+
+      expect(auditLogRepository.create).toHaveBeenCalledTimes(3);
+      expect(auditLogRepository.create).toHaveBeenCalledWith({
+        entityType: AuditEntityType.User,
+        entityId: user.uuid,
+        action: AuditAction.PasswordChanged,
+        performerType: AuditPerformerType.User,
+        performerId: user.uuid,
+        metadata: undefined,
+      });
+      expect(auditLogRepository.create).toHaveBeenCalledWith({
+        entityType: AuditEntityType.User,
+        entityId: user.uuid,
+        action: AuditAction.EmailChanged,
+        performerType: AuditPerformerType.User,
+        performerId: user.uuid,
+        metadata: undefined,
+      });
+      expect(auditLogRepository.create).toHaveBeenCalledWith({
+        entityType: AuditEntityType.User,
+        entityId: user.uuid,
+        action: AuditAction.TfaEnabled,
+        performerType: AuditPerformerType.User,
+        performerId: user.uuid,
+        metadata: undefined,
+      });
+    });
+  });
+});

--- a/src/externals/notifications/listeners/audit-log.listener.ts
+++ b/src/externals/notifications/listeners/audit-log.listener.ts
@@ -1,0 +1,50 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { OnEvent } from '@nestjs/event-emitter';
+import { AuditActionEvent } from '../events/audit-log.event';
+import { SequelizeAuditLogRepository } from '../../../modules/user/audit-logs.repository';
+
+@Injectable()
+export class AuditLogListener {
+  private readonly logger = new Logger(AuditLogListener.name);
+
+  constructor(
+    private readonly auditLogRepository: SequelizeAuditLogRepository,
+  ) {}
+
+  @OnEvent(AuditActionEvent.id)
+  async handleAuditAction(event: AuditActionEvent) {
+    try {
+      await this.auditLogRepository.create({
+        entityType: event.entityType,
+        entityId: event.entityId,
+        action: event.action,
+        performerType: event.performerType,
+        performerId: event.performerId,
+        metadata: event.metadata,
+      });
+
+      this.logger.log({
+        user: event.entityId,
+        id: 'AUDIT_LOGGED',
+        entity: {
+          entityType: event.entityType,
+          action: event.action,
+          performerType: event.performerType,
+        },
+        message: `Audit '${event.action}' logged successfully for ${event.entityType}:${event.entityId}`,
+      });
+    } catch (error) {
+      this.logger.error({
+        user: event.entityId,
+        id: 'AUDIT_LOG_ERROR',
+        entity: {
+          entityType: event.entityType,
+          action: event.action,
+          performerType: event.performerType,
+        },
+        message: `Failed to log audit '${event.action}' for ${event.entityType}:${event.entityId}: ${error.message}`,
+        stack: error.stack,
+      });
+    }
+  }
+}

--- a/src/externals/notifications/notifications.module.ts
+++ b/src/externals/notifications/notifications.module.ts
@@ -16,13 +16,21 @@ import {
 } from '../../modules/user/user.repository';
 import { SequelizeModule } from '@nestjs/sequelize';
 import { UserNotificationTokensModel } from '../../modules/user/user-notification-tokens.model';
+import { AuditLogModel } from '../../modules/user/audit-logs.model';
+import { SequelizeAuditLogRepository } from '../../modules/user/audit-logs.repository';
+import { AuditLogListener } from './listeners/audit-log.listener';
+import { AuditLogService } from './audit-log.service';
 
 @Module({
   imports: [
     ConfigModule,
     HttpClientModule,
     MailerModule,
-    SequelizeModule.forFeature([UserModel, UserNotificationTokensModel]),
+    SequelizeModule.forFeature([
+      UserModel,
+      UserNotificationTokensModel,
+      AuditLogModel,
+    ]),
     ApnModule,
   ],
   controllers: [],
@@ -33,9 +41,12 @@ import { UserNotificationTokensModel } from '../../modules/user/user-notificatio
     AnalyticsListener,
     SendLinkListener,
     AuthListener,
+    AuditLogListener,
     NewsletterService,
     SequelizeUserRepository,
+    SequelizeAuditLogRepository,
+    AuditLogService,
   ],
-  exports: [NotificationService, StorageNotificationService],
+  exports: [NotificationService, StorageNotificationService, AuditLogService],
 })
 export class NotificationModule {}

--- a/src/modules/auth/auth.module.ts
+++ b/src/modules/auth/auth.module.ts
@@ -16,6 +16,8 @@ import { TwoFactorAuthService } from './two-factor-auth.service';
 import { CacheManagerModule } from '../cache-manager/cache-manager.module';
 import { AuthUsecases } from './auth.usecase';
 import { CaptchaService } from '../../externals/captcha/captcha.service';
+import { AuditLogService } from '../../externals/notifications/audit-log.service';
+import { NotificationModule } from '../../externals/notifications/notifications.module';
 
 @Module({
   imports: [
@@ -37,6 +39,7 @@ import { CaptchaService } from '../../externals/captcha/captcha.service';
     KeyServerModule,
     forwardRef(() => WorkspacesModule),
     CacheManagerModule,
+    NotificationModule,
   ],
   providers: [
     CaptchaService,

--- a/src/modules/gateway/gateway.usecase.ts
+++ b/src/modules/gateway/gateway.usecase.ts
@@ -11,6 +11,7 @@ import { User } from '../user/user.domain';
 import { UserUseCases } from '../user/user.usecase';
 import { CacheManagerService } from '../cache-manager/cache-manager.service';
 import { StorageNotificationService } from '../../externals/notifications/storage.notifications.service';
+import { Workspace } from '../workspaces/domains/workspaces.domain';
 
 @Injectable()
 export class GatewayUseCases {
@@ -49,7 +50,7 @@ export class GatewayUseCases {
     ownerId: string,
     maxSpaceBytes: number,
     numberOfSeats: number,
-  ): Promise<void> {
+  ): Promise<Workspace> {
     try {
       const owner = await this.userRepository.findByUuid(ownerId);
       if (!owner) {
@@ -76,6 +77,8 @@ export class GatewayUseCases {
           numberOfSeats,
         );
       }
+
+      return workspace;
     } catch (error) {
       Logger.error(
         `[GATEWAY/WORKSPACE] Error updating workspace for owner ${ownerId}`,
@@ -110,7 +113,7 @@ export class GatewayUseCases {
     );
   }
 
-  async destroyWorkspace(ownerId: string): Promise<void> {
+  async destroyWorkspace(ownerId: string): Promise<Workspace> {
     const owner = await this.userRepository.findByUuid(ownerId);
     if (!owner) {
       throw new BadRequestException();
@@ -132,6 +135,8 @@ export class GatewayUseCases {
         clientId: 'gateway',
       });
     });
+
+    return workspace;
   }
 
   async getUserByEmail(email: string): Promise<User> {

--- a/src/modules/user/audit-logs.attributes.ts
+++ b/src/modules/user/audit-logs.attributes.ts
@@ -1,0 +1,41 @@
+import type { WorkspaceModel } from '../workspaces/models/workspace.model';
+import type { UserModel } from './user.model';
+
+export enum AuditEntityType {
+  User = 'user',
+  Workspace = 'workspace',
+}
+
+export enum AuditPerformerType {
+  User = 'user',
+  Gateway = 'gateway',
+  System = 'system', // for possible future cron jobs
+}
+
+export enum AuditAction {
+  // User actions
+  StorageChanged = 'storage-changed',
+  EmailChanged = 'email-changed',
+  PasswordChanged = 'password-changed',
+  TfaEnabled = '2fa-enabled',
+  TfaDisabled = '2fa-disabled',
+  AccountReset = 'account-reset',
+  AccountRecovery = 'account-recovery',
+  // Workspace actions
+  WorkspaceCreated = 'workspace-created',
+  WorkspaceDeleted = 'workspace-deleted',
+  WorkspaceStorageChanged = 'workspace-storage-changed',
+}
+
+export interface AuditLogAttributes {
+  id: string;
+  entityType: AuditEntityType;
+  entityId: string;
+  action: AuditAction;
+  performerType: AuditPerformerType;
+  performerId?: string;
+  metadata?: Record<string, any>;
+  createdAt: Date;
+  user?: UserModel;
+  workspace?: WorkspaceModel;
+}

--- a/src/modules/user/audit-logs.domain.ts
+++ b/src/modules/user/audit-logs.domain.ts
@@ -1,0 +1,58 @@
+import {
+  AuditLogAttributes,
+  AuditAction,
+  AuditEntityType,
+  AuditPerformerType,
+} from './audit-logs.attributes';
+
+export class AuditLog implements AuditLogAttributes {
+  id: string;
+  entityType: AuditEntityType;
+  entityId: string;
+  action: AuditAction;
+  performerType: AuditPerformerType;
+  performerId?: string;
+  metadata?: Record<string, any>;
+  createdAt: Date;
+
+  constructor(attributes: AuditLogAttributes) {
+    Object.assign(this, attributes);
+  }
+
+  static build(activityLog: AuditLogAttributes): AuditLog {
+    return new AuditLog(activityLog);
+  }
+
+  isUserAction(): boolean {
+    return this.entityType === AuditEntityType.User;
+  }
+
+  isWorkspaceAction(): boolean {
+    return this.entityType === AuditEntityType.Workspace;
+  }
+
+  isPerformedByUser(): boolean {
+    return this.performerType === AuditPerformerType.User;
+  }
+
+  isPerformedByGateway(): boolean {
+    return this.performerType === AuditPerformerType.Gateway;
+  }
+
+  isPerformedBySystem(): boolean {
+    return this.performerType === AuditPerformerType.System;
+  }
+
+  toJSON() {
+    return {
+      id: this.id,
+      entityType: this.entityType,
+      entityId: this.entityId,
+      action: this.action,
+      performerType: this.performerType,
+      performerId: this.performerId,
+      metadata: this.metadata,
+      createdAt: this.createdAt,
+    };
+  }
+}

--- a/src/modules/user/audit-logs.model.ts
+++ b/src/modules/user/audit-logs.model.ts
@@ -1,0 +1,87 @@
+import {
+  Model,
+  Table,
+  Column,
+  DataType,
+  PrimaryKey,
+  BelongsTo,
+} from 'sequelize-typescript';
+import { UserModel } from './user.model';
+import { WorkspaceModel } from '../workspaces/models/workspace.model';
+import {
+  AuditLogAttributes,
+  AuditAction,
+  AuditEntityType,
+  AuditPerformerType,
+} from './audit-logs.attributes';
+import { User } from './user.domain';
+import { Workspace } from '../workspaces/domains/workspaces.domain';
+
+@Table({
+  underscored: true,
+  timestamps: false,
+  tableName: 'audit_logs',
+})
+export class AuditLogModel extends Model implements AuditLogAttributes {
+  @PrimaryKey
+  @Column({ type: DataType.UUID, defaultValue: DataType.UUIDV4 })
+  id: string;
+
+  @Column({
+    type: DataType.ENUM(...Object.values(AuditEntityType)),
+    allowNull: false,
+  })
+  entityType: AuditEntityType;
+
+  @Column({ type: DataType.UUID, allowNull: false })
+  entityId: string;
+
+  @Column({
+    type: DataType.ENUM(...Object.values(AuditAction)),
+    allowNull: false,
+  })
+  action: AuditAction;
+
+  @Column({
+    type: DataType.ENUM(...Object.values(AuditPerformerType)),
+    allowNull: false,
+  })
+  performerType: AuditPerformerType;
+
+  @Column({ type: DataType.UUID, allowNull: true })
+  performerId?: string;
+
+  @Column({ type: DataType.JSONB, allowNull: true })
+  metadata?: Record<string, any>;
+
+  @Column({
+    type: DataType.DATE,
+    allowNull: false,
+    defaultValue: DataType.NOW,
+  })
+  createdAt: Date;
+
+  @BelongsTo(() => UserModel, {
+    foreignKey: 'entityId',
+    targetKey: 'uuid',
+    as: 'user',
+    constraints: false,
+  })
+  user?: UserModel;
+
+  @BelongsTo(() => WorkspaceModel, {
+    foreignKey: 'entityId',
+    targetKey: 'id',
+    as: 'workspace',
+    constraints: false,
+  })
+  workspace?: WorkspaceModel;
+
+  @BelongsTo(() => UserModel, {
+    foreignKey: 'performerId',
+    targetKey: 'uuid',
+    as: 'performer',
+    constraints: false,
+  })
+  performer?: UserModel;
+}

--- a/src/modules/user/audit-logs.repository.spec.ts
+++ b/src/modules/user/audit-logs.repository.spec.ts
@@ -1,0 +1,58 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { createMock } from '@golevelup/ts-jest';
+import { getModelToken } from '@nestjs/sequelize';
+import { SequelizeAuditLogRepository } from './audit-logs.repository';
+import { AuditLogModel } from './audit-logs.model';
+import {
+  AuditAction,
+  AuditEntityType,
+  AuditPerformerType,
+} from './audit-logs.attributes';
+import { newAuditLog, newUser } from '../../../test/fixtures';
+
+describe('SequelizeAuditLogRepository', () => {
+  let repository: SequelizeAuditLogRepository;
+  let auditLogModel: typeof AuditLogModel;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [SequelizeAuditLogRepository],
+    })
+      .useMocker(() => createMock())
+      .compile();
+
+    repository = module.get<SequelizeAuditLogRepository>(
+      SequelizeAuditLogRepository,
+    );
+    auditLogModel = module.get<typeof AuditLogModel>(
+      getModelToken(AuditLogModel),
+    );
+  });
+
+  describe('create', () => {
+    it('When valid audit log data is provided, then it should create and return an audit log', async () => {
+      const user = newUser();
+      const auditLogData = newAuditLog({
+        entityType: AuditEntityType.User,
+        entityId: user.uuid,
+        action: AuditAction.PasswordChanged,
+        performerType: AuditPerformerType.User,
+        performerId: user.uuid,
+      });
+
+      jest.spyOn(auditLogModel, 'create').mockResolvedValueOnce({
+        toJSON: jest.fn().mockReturnValue({ ...auditLogData.toJSON() }),
+      } as any);
+
+      const result = await repository.create(auditLogData);
+
+      expect(auditLogModel.create).toHaveBeenCalledWith({
+        ...auditLogData,
+        createdAt: expect.any(Date),
+      });
+      expect(result.entityId).toBe(user.uuid);
+      expect(result.action).toBe(AuditAction.PasswordChanged);
+      expect(result.performerId).toBe(user.uuid);
+    });
+  });
+});

--- a/src/modules/user/audit-logs.repository.ts
+++ b/src/modules/user/audit-logs.repository.ts
@@ -1,0 +1,47 @@
+import { Injectable } from '@nestjs/common';
+import { InjectModel } from '@nestjs/sequelize';
+import { AuditLogModel } from './audit-logs.model';
+import { AuditLog } from './audit-logs.domain';
+import {
+  AuditLogAttributes,
+  AuditAction,
+  AuditEntityType,
+  AuditPerformerType,
+} from './audit-logs.attributes';
+
+export interface AuditLogFilters {
+  entityType?: AuditEntityType;
+  entityId?: string;
+  performerType?: AuditPerformerType;
+  performerId?: string;
+  actions?: AuditAction[];
+  dateFrom?: Date;
+  dateTo?: Date;
+}
+
+@Injectable()
+export class SequelizeAuditLogRepository {
+  constructor(
+    @InjectModel(AuditLogModel)
+    private readonly auditLogModel: typeof AuditLogModel,
+  ) {}
+
+  async create(
+    auditLogData: Omit<AuditLogAttributes, 'id' | 'createdAt'>,
+  ): Promise<AuditLog> {
+    const auditLog = await this.auditLogModel.create({
+      ...auditLogData,
+      createdAt: new Date(),
+    });
+
+    return this.auditLogToDomain(auditLog);
+  }
+
+  private auditLogToDomain(auditLogModel: AuditLogModel): AuditLog {
+    return AuditLog.build({
+      ...auditLogModel.toJSON(),
+      user: auditLogModel.user || undefined,
+      workspace: auditLogModel.workspace || undefined,
+    });
+  }
+}

--- a/src/modules/user/user.module.ts
+++ b/src/modules/user/user.module.ts
@@ -48,6 +48,7 @@ import { UserNotificationTokensModel } from './user-notification-tokens.model';
 import { BackupModule } from '../backups/backup.module';
 import { CacheManagerModule } from '../cache-manager/cache-manager.module';
 import { AsymmetricEncryptionModule } from '../../externals/asymmetric-encryption/asymmetric-encryption.module';
+import { NotificationModule } from '../../externals/notifications/notifications.module';
 
 @Module({
   imports: [
@@ -78,6 +79,7 @@ import { AsymmetricEncryptionModule } from '../../externals/asymmetric-encryptio
     forwardRef(() => BackupModule),
     CacheManagerModule,
     AsymmetricEncryptionModule,
+    NotificationModule,
   ],
   controllers: [UserController],
   providers: [

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -42,6 +42,13 @@ import {
 } from '../src/modules/keyserver/key-server.domain';
 import { DeviceAttributes } from '../src/modules/backups/models/device.attributes';
 import { Device, DevicePlatform } from '../src/modules/backups/device.domain';
+import { AuditLog } from '../src/modules/user/audit-logs.domain';
+import {
+  AuditAction,
+  AuditEntityType,
+  AuditLogAttributes,
+  AuditPerformerType,
+} from '../src/modules/user/audit-logs.attributes';
 
 export const constants = {
   BUCKET_ID_LENGTH: 24,
@@ -615,4 +622,18 @@ export const newDevice = (options?: Partial<DeviceAttributes>): Device => {
   };
 
   return new Device(mergedAttributes);
+};
+
+export const newAuditLog = (params?: Partial<AuditLogAttributes>): AuditLog => {
+  return AuditLog.build({
+    id: v4(),
+    entityType: AuditEntityType.User,
+    entityId: v4(),
+    action: AuditAction.PasswordChanged,
+    performerType: AuditPerformerType.User,
+    performerId: v4(),
+    createdAt: new Date(),
+    metadata: params?.metadata || {},
+    ...params,
+  });
 };


### PR DESCRIPTION
Added database-backed audit logging to track sensitive user operations with extended retention, addressing the limitation of 30-day Graylog retention for critical actions.

- Database: New audit_logs table with migration for user/workspace events
Service: AuditLogService with methods for common actions (password changes, email changes, 2FA, account recovery, storage updates)
- Events: AuditActionEvent and AuditLogListener for async event processing
Integration: Auto-logging in user controller and gateway operations
#### Tracked Actions
- User: password-changed, email-changed, 2fa-enabled/disabled, account-reset/recovery, storage-changed
- Workspace: workspace-created/deleted, workspace-storage-changed
