### PR TITLE
 [PB-4693] feat: add updated at index for removed folders

### DIFF
--- a/migrations/20250730231958-create-updated-at-folders-index.js
+++ b/migrations/20250730231958-create-updated-at-folders-index.js
@@ -1,0 +1,20 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.sequelize.query(
+      `
+        CREATE INDEX CONCURRENTLY deleted_folders_updated_at_index
+        ON folders USING btree (updated_at) 
+        WHERE (removed = true);
+      `,
+    );
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.sequelize.query(
+      `DROP INDEX IF EXISTS deleted_folders_updated_at_index`,
+    );
+  },
+};


### PR DESCRIPTION
This index is required for the deleted items cleanup cronjob. 

We will be looking for removed folders updated between a specific range of time instead of scanning the entire database looking for any undeleted folder.

Related: https://github.com/internxt/drive-server-wip/pull/638