### PR TITLE
[PB-4737]: fix/match user UUID in backupfile with UUID in token

### DIFF
--- a/src/modules/user/dto/recover-account.dto.ts
+++ b/src/modules/user/dto/recover-account.dto.ts
@@ -25,8 +25,8 @@ export class RecoverAccountDto {
     example: '123e4567-e89b-12d3-a456-426614174000',
     description: 'User uuid',
   })
-  @IsNotEmpty()
-  uuid: string;
+  @IsOptional()
+  uuid?: string;
 
   @ApiProperty({
     example: 'some_salt',

--- a/src/modules/user/user.controller.spec.ts
+++ b/src/modules/user/user.controller.spec.ts
@@ -1339,7 +1339,7 @@ describe('User Controller', () => {
       );
     });
 
-    it('When reset is false but private keys are provided but the uuid does not match, then it throws BadRequestException', async () => {
+    it('When reset is false, private keys are provided but the uuid does not match, then it throws BadRequestException', async () => {
       await expect(
         userController.recoverAccountV2(
           { token: validToken, reset: 'false' },
@@ -1349,6 +1349,27 @@ describe('User Controller', () => {
           },
         ),
       ).rejects.toThrow(BadRequestException);
+    });
+
+    it('When reset is false, private keys are provided and the uuid is not provided, then it updates credentials with private keys', async () => {
+      await userController.recoverAccountV2(
+        { token: validToken, reset: 'false' },
+        {
+          ...mockRecoverAccountDto,
+          uuid: undefined,
+        },
+      );
+
+      expect(userUseCases.updateCredentials).toHaveBeenCalledWith(
+        mockUser.uuid,
+        {
+          mnemonic: mockRecoverAccountDto.mnemonic,
+          password: mockRecoverAccountDto.password,
+          salt: mockRecoverAccountDto.salt,
+          privateKeys: mockRecoverAccountDto.privateKeys,
+        },
+        false,
+      );
     });
   });
 

--- a/src/modules/user/user.controller.ts
+++ b/src/modules/user/user.controller.ts
@@ -819,7 +819,7 @@ export class UserController {
     }
 
     const uuidsMatch = decodedContent.payload.uuid === body.uuid;
-    if (!uuidsMatch) {
+    if (body.uuid && !uuidsMatch) {
       throw new BadRequestException(
         'Backup file does not match the users uuid',
       );


### PR DESCRIPTION
When recovering an account match the user's uuid in the recovery token with the uuid optionally provided in the body. This is matched if and only if the uuid was provided, this is assuming the new backup recovery format will go into production as is, (without specifying user uuid) and the pr that introduces this field to the file will be merged later on