### PR TITLE
[_] feat: added more logs to deleted items cleanup job

### DIFF
--- a/src/modules/jobs/tasks/deleted-items-cleanup.task.spec.ts
+++ b/src/modules/jobs/tasks/deleted-items-cleanup.task.spec.ts
@@ -124,7 +124,7 @@ describe('DeletedItemsCleanupTask', () => {
         yield ['folder-1'];
       })();
 
-      const mockProcessor = jest.fn().mockResolvedValue(undefined);
+      const mockProcessor = jest.fn().mockResolvedValue({ updatedCount: 4 });
 
       await expect(
         task['processPhase'](
@@ -147,7 +147,7 @@ describe('DeletedItemsCleanupTask', () => {
         yield [];
       })();
 
-      const mockProcessor = jest.fn().mockResolvedValue(undefined);
+      const mockProcessor = jest.fn().mockResolvedValue({ updatedCount: 4 });
 
       const result = await task['processPhase'](
         'job-123',

--- a/src/modules/jobs/tasks/deleted-items-cleanup.task.ts
+++ b/src/modules/jobs/tasks/deleted-items-cleanup.task.ts
@@ -144,7 +144,14 @@ export class DeletedItemsCleanupTask {
         );
       }
 
-      await processor(folderUuids);
+      this.logger.log(
+        `[${jobId}] Deleted folders found with existent children, ${JSON.stringify({ folderUuids })}`,
+      );
+
+      const result = await processor(folderUuids);
+
+      this.logger.log(`[${jobId}] ${result.updatedCount} children updated`);
+
       processedItems += folderUuids.length;
     }
     return processedItems;

--- a/src/modules/jobs/tasks/deleted-items-cleanup.task.ts
+++ b/src/modules/jobs/tasks/deleted-items-cleanup.task.ts
@@ -117,7 +117,7 @@ export class DeletedItemsCleanupTask {
     jobId: string | number,
     phaseName: string,
     generator: AsyncGenerator<string[], void, unknown>,
-    processor: (folderUuids: string[]) => Promise<any>,
+    processor: (folderUuids: string[]) => Promise<{ updatedCount: number }>,
   ) {
     let firstFolderUuid: string | null = null;
     let sameFolderRepeatedTimes = 0;


### PR DESCRIPTION
This PR intends to add more logs to the deleted items cleanup job. We want to be able to check how the job is behaving before closing this task.