### PR TITLE
[_] chore: added deploy cronjob step to deploy action

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -80,4 +80,4 @@ jobs:
         uses: steebchen/kubectl@v2.0.0
         with:
           config: ${{ secrets.KUBE_CONFIG_DATA }}
-          command: set image --record deployment/drive-server-wip-cron drive-server-wip-cron=${{ secrets.DOCKERHUB_USERNAME }}/drive-server-wip-cron:${{ github.sha }} -n drive
+          command: set image --record deployment/drive-server-wip-cron drive-server-wip-cron=${{ secrets.DOCKERHUB_USERNAME }}/drive-server-wip:${{ github.sha }} -n drive


### PR DESCRIPTION
This PR intends to automate the cronjob deployment so the team doesn't need to deploy fixes manually by pulling master every time we want to roll out a fix/change to any cronjob.