### PR TITLE
[_] fix: empty trash timeout fixed when there are too many items

### DIFF
--- a/src/modules/file/file.repository.ts
+++ b/src/modules/file/file.repository.ts
@@ -798,7 +798,7 @@ export class SequelizeFileRepository implements FileRepository {
         type: QueryTypes.UPDATE,
       },
     );
-    return result[1] as number;
+    return result[1];
   }
 
   async markFilesInFolderAsRemoved(

--- a/src/modules/file/file.repository.ts
+++ b/src/modules/file/file.repository.ts
@@ -779,7 +779,7 @@ export class SequelizeFileRepository implements FileRepository {
     const result = await this.fileModel.sequelize.query(
       `
       UPDATE files 
-      SET status = :deletedStatus, removed_at = NOW(), removed = true, updated_at = NOW()
+      SET status = :deletedStatus, updated_at = NOW()
       WHERE uuid IN (
         SELECT uuid 
         FROM files 

--- a/src/modules/file/file.repository.ts
+++ b/src/modules/file/file.repository.ts
@@ -120,6 +120,7 @@ export interface FileRepository {
     fileUuids: string[],
     order?: [keyof FileModel, 'ASC' | 'DESC'][],
   ): Promise<File[]>;
+  deleteUserTrashedFilesBatch(userId: number, limit: number): Promise<number>;
 }
 
 @Injectable()

--- a/src/modules/file/file.usecase.ts
+++ b/src/modules/file/file.usecase.ts
@@ -638,6 +638,13 @@ export class FileUseCases {
     };
   }
 
+  async deleteUserTrashedFilesBatch(
+    user: User,
+    limit: number,
+  ): Promise<number> {
+    return this.fileRepository.deleteUserTrashedFilesBatch(user.id, limit);
+  }
+
   async moveFile(
     user: User,
     fileUuid: File['fileId'],

--- a/src/modules/folder/folder.repository.ts
+++ b/src/modules/folder/folder.repository.ts
@@ -780,7 +780,7 @@ export class SequelizeFolderRepository implements FolderRepository {
         type: QueryTypes.UPDATE,
       },
     );
-    return result[1] as number;
+    return result[1];
   }
 
   async findAllCursorWhereUpdatedAfter(

--- a/src/modules/folder/folder.usecase.ts
+++ b/src/modules/folder/folder.usecase.ts
@@ -17,6 +17,7 @@ import { SequelizeUserRepository } from '../user/user.repository';
 import {
   Folder,
   FolderOptions,
+  FolderStatus,
   SortableFolderAttributes,
 } from './folder.domain';
 import { FolderAttributes } from './folder.attributes';
@@ -660,6 +661,13 @@ export class FolderUseCases {
     return foldersWithMaybePlainName.map((folder) =>
       folder.plainName ? folder : this.decryptFolderName(folder),
     );
+  }
+
+  async deleteUserTrashedFoldersBatch(
+    user: User,
+    limit: number,
+  ): Promise<number> {
+    return this.folderRepository.deleteTrashedFoldersBatch(user.id, limit);
   }
 
   async getFoldersWithParent(

--- a/src/modules/folder/folder.usecase.ts
+++ b/src/modules/folder/folder.usecase.ts
@@ -17,7 +17,6 @@ import { SequelizeUserRepository } from '../user/user.repository';
 import {
   Folder,
   FolderOptions,
-  FolderStatus,
   SortableFolderAttributes,
 } from './folder.domain';
 import { FolderAttributes } from './folder.attributes';


### PR DESCRIPTION
A refactor of @larry-internxt's https://github.com/internxt/drive-server-wip/pull/615. 

It was easier to create another branch instead of working from the original PR. 

This PR uses a raw query to delete folders and files in batches instead of making SELECT and UPDATE queries sequentially. We tend to encourage the use of Sequelize ORM for all of our queries; however, this endpoint's performance could be significantly benefited by using a raw query that combines updating and selecting.