### PR TITLE
[PB-4416] chore(sharings): add sharings with and type index

### DIFF
--- a/migrations/20250816053443-add-shared-with-type-and-shared-with-index.js
+++ b/migrations/20250816053443-add-shared-with-type-and-shared-with-index.js
@@ -1,0 +1,17 @@
+'use strict';
+
+const indexName = 'sharing_with_and_type_index';
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.sequelize.query(
+      `CREATE INDEX CONCURRENTLY ${indexName} ON sharings (shared_with, shared_with_type)`,
+    );
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.sequelize.query(
+      `DROP INDEX CONCURRENTLY ${indexName}`,
+    );
+  },
+};


### PR DESCRIPTION
We frequently make queries using `shared_with` and `shared_with_type` fields. 

Our current queries are performant due to the use of the `item_id` index created in `sharings`. However, these fields should be indexed too to make any query not relying on files performant.

Required for:
https://github.com/internxt/drive-server-wip/pull/658