### PR TITLE
[PB-2394] feat(usage): added initial module structure and base domain

### DIFF
--- a/src/modules/usage/usage.domain.spec.ts
+++ b/src/modules/usage/usage.domain.spec.ts
@@ -1,0 +1,79 @@
+import { v4 } from 'uuid';
+import { Usage, UsageType } from './usage.domain';
+
+describe('Usage Domain', () => {
+  const usageAttributes = {
+    id: v4(),
+    userId: v4(),
+    delta: 100,
+    period: new Date(),
+    type: UsageType.Daily,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  };
+
+  it('When Usage type is Yearly, then isYearly should return true', () => {
+    const usage = Usage.build({ ...usageAttributes, type: UsageType.Yearly });
+
+    expect(usage.isYearly()).toBe(true);
+  });
+  it('When Usage type is not yearly, then isYearly should return false', () => {
+    const usage = Usage.build({ ...usageAttributes, type: UsageType.Monthly });
+
+    expect(usage.isYearly()).toBe(false);
+  });
+
+  it('When instance is created, then period should be parsed to date', () => {
+    const usage = Usage.build(usageAttributes);
+
+    expect(usage.period).toBeInstanceOf(Date);
+  });
+
+  it('When usage is daily, then getNextPeriodStartDate should return next day', () => {
+    const usage = Usage.build({
+      ...usageAttributes,
+      type: UsageType.Daily,
+      period: new Date('2024-01-15T00:00:00.000Z'),
+    });
+
+    const nextPeriod = usage.getNextPeriodStartDate();
+
+    expect(nextPeriod).toEqual(new Date('2024-01-16T00:00:00.000Z'));
+  });
+
+  it('When usage is yearly, then getNextPeriodStartDate should return next year', () => {
+    const usage = Usage.build({
+      ...usageAttributes,
+      type: UsageType.Yearly,
+      period: new Date('2024-01-15T00:00:00.000Z'),
+    });
+
+    const nextPeriod = usage.getNextPeriodStartDate();
+
+    expect(nextPeriod).toEqual(new Date('2025-01-15T00:00:00.000Z'));
+  });
+
+  it('When usage is previous day to target, then isPreviousDayTo should return true', () => {
+    const usage = Usage.build({
+      ...usageAttributes,
+      type: UsageType.Daily,
+      period: new Date('2024-01-15T00:00:00.000Z'),
+    });
+
+    const result = usage.isPreviousDayTo(new Date('2024-01-16T00:00:00.000Z'));
+
+    expect(result).toBe(true);
+  });
+
+  it('When usage is yearly, then isPreviousDayTo should return false', () => {
+    const usage = Usage.build({
+      ...usageAttributes,
+      type: UsageType.Yearly,
+      period: new Date('2024-01-15T00:00:00.000Z'),
+    });
+
+    const result = usage.isPreviousDayTo(new Date('2025-01-15T00:00:00.000Z'));
+
+    expect(result).toBe(false);
+  });
+});

--- a/src/modules/usage/usage.domain.ts
+++ b/src/modules/usage/usage.domain.ts
@@ -1,0 +1,75 @@
+export enum UsageType {
+  Daily = 'daily',
+  Monthly = 'monthly',
+  Yearly = 'yearly',
+}
+export interface UsageAttributes {
+  id: string;
+  userId: string;
+  delta: number;
+  period: Date;
+  type: UsageType;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export class Usage implements UsageAttributes {
+  id: string;
+  userId: string;
+  delta: number;
+  period: Date;
+  type: UsageType;
+  createdAt: Date;
+  updatedAt: Date;
+
+  constructor({
+    id,
+    userId,
+    delta,
+    period,
+    type,
+    createdAt,
+    updatedAt,
+  }: UsageAttributes) {
+    this.id = id;
+    this.userId = userId;
+    this.delta = delta;
+    this.period = new Date(period);
+    this.type = type;
+    this.createdAt = createdAt;
+    this.updatedAt = updatedAt;
+  }
+
+  static build(usage: UsageAttributes): Usage {
+    return new Usage(usage);
+  }
+
+  isYearly(): boolean {
+    return this.type === UsageType.Yearly;
+  }
+
+  isPreviousDayTo(targetDate: Date): boolean {
+    if (this.isYearly()) {
+      return false;
+    }
+
+    const nextPeriodStart = this.getNextPeriodStartDate();
+    const normalizedTarget = new Date(targetDate);
+    normalizedTarget.setUTCHours(0, 0, 0, 0);
+
+    return nextPeriodStart.getTime() === normalizedTarget.getTime();
+  }
+
+  getNextPeriodStartDate(): Date {
+    const nextPeriod = new Date(this.period);
+
+    if (this.isYearly()) {
+      nextPeriod.setUTCFullYear(nextPeriod.getUTCFullYear() + 1);
+    } else {
+      nextPeriod.setUTCDate(nextPeriod.getUTCDate() + 1);
+      nextPeriod.setUTCHours(0, 0, 0, 0);
+    }
+
+    return nextPeriod;
+  }
+}

--- a/src/modules/usage/usage.model.ts
+++ b/src/modules/usage/usage.model.ts
@@ -1,0 +1,54 @@
+import {
+  Column,
+  Model,
+  Table,
+  PrimaryKey,
+  DataType,
+  Default,
+  AllowNull,
+  ForeignKey,
+  BelongsTo,
+} from 'sequelize-typescript';
+import { UserModel } from '../user/user.model';
+
+@Table({
+  underscored: true,
+  timestamps: true,
+  tableName: 'usages',
+})
+export class UsageModel extends Model {
+  @PrimaryKey
+  @Column(DataType.UUID)
+  id: string;
+
+  @ForeignKey(() => UserModel)
+  @AllowNull(false)
+  @Column(DataType.UUID)
+  userId: string;
+
+  @Default(0)
+  @AllowNull(false)
+  @Column(DataType.BIGINT)
+  delta: number;
+
+  @AllowNull(false)
+  @Column(DataType.DATEONLY)
+  period: Date;
+
+  @AllowNull(false)
+  @Column(DataType.STRING)
+  type: string;
+
+  @AllowNull(false)
+  @Default(DataType.NOW)
+  @Column(DataType.DATE)
+  createdAt: Date;
+
+  @AllowNull(false)
+  @Default(DataType.NOW)
+  @Column(DataType.DATE)
+  updatedAt: Date;
+
+  @BelongsTo(() => UserModel)
+  user: UserModel;
+}

--- a/src/modules/usage/usage.module.ts
+++ b/src/modules/usage/usage.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { SequelizeModule } from '@nestjs/sequelize';
+import { UsageModel } from './usage.model';
+import { UsageService } from './usage.service';
+import { SequelizeUsageRepository } from './usage.repository';
+
+@Module({
+  imports: [SequelizeModule.forFeature([UsageModel])],
+  providers: [SequelizeUsageRepository, UsageService],
+  exports: [UsageService],
+})
+export class UsageModule {}

--- a/src/modules/usage/usage.repository.ts
+++ b/src/modules/usage/usage.repository.ts
@@ -1,0 +1,18 @@
+import { InjectModel } from '@nestjs/sequelize';
+import { Injectable } from '@nestjs/common';
+import { UsageModel } from './usage.model';
+import { Usage } from './usage.domain';
+
+@Injectable()
+export class SequelizeUsageRepository {
+  constructor(
+    @InjectModel(UsageModel)
+    private readonly usageModel: typeof UsageModel,
+  ) {}
+
+  toDomain(model: UsageModel): Usage {
+    return Usage.build({
+      ...model.toJSON(),
+    });
+  }
+}

--- a/src/modules/usage/usage.service.ts
+++ b/src/modules/usage/usage.service.ts
@@ -1,0 +1,7 @@
+import { Injectable } from '@nestjs/common';
+import { SequelizeUsageRepository } from './usage.repository';
+
+@Injectable()
+export class UsageService {
+  constructor(private readonly usageRepository: SequelizeUsageRepository) {}
+}

--- a/test/fixtures.spec.ts
+++ b/test/fixtures.spec.ts
@@ -11,6 +11,8 @@ import {
 import * as fixtures from './fixtures';
 import { SharingActionName } from '../src/modules/sharing/sharing.domain';
 import { UserKeysEncryptVersions } from '../src/modules/keyserver/key-server.domain';
+import { newUsage } from './fixtures';
+import { UsageType } from '../src/modules/usage/usage.domain';
 
 describe('Testing fixtures tests', () => {
   describe("User's fixture", () => {
@@ -630,6 +632,60 @@ describe('Testing fixtures tests', () => {
       const keyServer = fixtures.newKeyServer();
 
       expect(keyServer.encryptVersion).toBe(UserKeysEncryptVersions.Ecc);
+    });
+  });
+
+  describe('Usage Fixture', () => {
+    it('When it generates a usage, then it should be random', () => {
+      const usage = newUsage();
+      const otherUsage = newUsage();
+
+      expect(usage.id).toBeTruthy();
+      expect(usage.id).not.toBe(otherUsage.id);
+      expect(usage.userId).not.toBe(otherUsage.userId);
+    });
+
+    it('When it generates a usage, then the delta should be within the range', () => {
+      const usage = newUsage();
+
+      expect(usage.delta).toBeGreaterThanOrEqual(0);
+      expect(usage.delta).toBeLessThanOrEqual(1000);
+    });
+
+    it('When it generates a usage and a type is provided, then that type should be set', () => {
+      const usage = newUsage({ attributes: { type: UsageType.Monthly } });
+
+      expect(usage.type).toBe(UsageType.Monthly);
+    });
+
+    it('When it generates a usage, then the period should be populated', () => {
+      const usage = newUsage();
+
+      expect(usage.period).toBeInstanceOf(Date);
+      expect(usage.period).toBeTruthy();
+    });
+
+    it('When it generates a usage and custom attributes are provided, then those attributes should be set correctly', () => {
+      const customAttributes = {
+        delta: 500,
+        type: UsageType.Yearly,
+        period: new Date('2023-01-01T00:00:00Z'),
+      };
+
+      const usage = newUsage({ attributes: customAttributes });
+
+      expect(usage.delta).toBe(customAttributes.delta);
+      expect(usage.type).toBe(customAttributes.type);
+      expect(usage.period).toEqual(customAttributes.period);
+    });
+
+    it('When it generates multiple usages, then all their identifiers should be unique', () => {
+      const usages = Array.from({ length: 10 }, () => newUsage());
+
+      const ids = usages.map((usage) => usage.id);
+      const uniqueIds = new Set(ids);
+
+      expect(uniqueIds.size).toBe(usages.length);
     });
   });
 });

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -42,6 +42,7 @@ import {
 } from '../src/modules/keyserver/key-server.domain';
 import { DeviceAttributes } from '../src/modules/backups/models/device.attributes';
 import { Device, DevicePlatform } from '../src/modules/backups/device.domain';
+import { Usage, UsageType } from '../src/modules/usage/usage.domain';
 
 export const constants = {
   BUCKET_ID_LENGTH: 24,
@@ -615,4 +616,30 @@ export const newDevice = (options?: Partial<DeviceAttributes>): Device => {
   };
 
   return new Device(mergedAttributes);
+};
+
+export const newUsage = (params?: { attributes?: Partial<Usage> }): Usage => {
+  const randomCreatedAt = randomDataGenerator.date();
+  const randomPeriod = randomDataGenerator.date();
+
+  const usage = Usage.build({
+    id: v4(),
+    userId: v4(),
+    delta: randomDataGenerator.integer({ min: 0, max: 1000 }),
+    period: randomPeriod,
+    type: UsageType.Daily,
+    createdAt: randomCreatedAt,
+    updatedAt: new Date(
+      randomDataGenerator.date({
+        min: randomCreatedAt,
+      }),
+    ),
+  });
+
+  params?.attributes &&
+    Object.keys(params.attributes).forEach((key) => {
+      usage[key] = params.attributes[key];
+    });
+
+  return usage;
 };


### PR DESCRIPTION
This module adds the initial structure for the usage module.

Domain functions:
- `getNextPeriodStartDate`: This function provides the next date delta is expected to be calculated. If the type is yearly, then we expect delta to be calculated from the next year, otherwise, we expect delta to be calculated the next day.
- `isPreviousDayTo`: This function just tell us if the usage was calculated for the previous day. Eg: usage is from August 18 and today is August 19, then it should return True.

Related
https://github.com/internxt/drive-server-wip/pull/668