### PR TITLE
[_] fix(usage): add unique constraint to usage table

### DIFF
--- a/migrations/20250825221935-create-user_id-period-type-partial-constraint.js
+++ b/migrations/20250825221935-create-user_id-period-type-partial-constraint.js
@@ -1,0 +1,18 @@
+'use strict';
+
+const indexName = 'usage_unique_user_period_type_monthly_yearly';
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.sequelize.query(
+      `CREATE UNIQUE INDEX CONCURRENTLY ${indexName} ON public.usages (user_id, period, type) 
+        WHERE type = 'monthly' OR type = 'yearly';`,
+    );
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.sequelize.query(
+      `DROP INDEX CONCURRENTLY ${indexName}`,
+    );
+  },
+};


### PR DESCRIPTION
This adds an unique constraint using INDEX as postgresql does not allow partial constraints by default. When two calls to `/usage` are made at the same time, a race condition is created, therefore, two records are created in the table with the same value.

⚠️ We need to clean the usages table before running the index creation !! 