### PR TITLE
[_] fix: do not log exception in exception filter

### DIFF
--- a/src/common/http-global-exception-filter.exception.ts
+++ b/src/common/http-global-exception-filter.exception.ts
@@ -56,7 +56,6 @@ export class HttpGlobalExceptionFilter extends BaseExceptionFilter {
         error: {
           message: exception.message,
           stack: exception.stack,
-          exception,
         },
       };
 


### PR DESCRIPTION
Logging the exception when there's a high number of errors could lead to high memory usage too, it is better to just log in the stack and the message.