### PR TITLE
[PB-4731]: implement caching for user avatars in cache manager

### DIFF
--- a/src/modules/cache-manager/cache-manager.service.ts
+++ b/src/modules/cache-manager/cache-manager.service.ts
@@ -7,7 +7,9 @@ export class CacheManagerService {
   private readonly USAGE_KEY_PREFIX = 'usage:';
   private readonly LIMIT_KEY_PREFIX = 'limit:';
   private readonly JWT_KEY_PREFIX = 'jwt:';
+  private readonly AVATAR_KEY_PREFIX = 'avatar:';
   private readonly TTL_10_MINUTES = 10000 * 60;
+  private readonly TTL_24_HOURS = 24 * 60 * 60 * 1000;
 
   constructor(@Inject(CACHE_MANAGER) private readonly cacheManager: Cache) {}
 
@@ -74,5 +76,24 @@ export class CacheManagerService {
       `${this.JWT_KEY_PREFIX}${jti}`,
     );
     return !!cacheJwt;
+  }
+
+  async getUserAvatar(userUuid: string) {
+    const cachedAvatar = await this.cacheManager.get<string>(
+      `${this.AVATAR_KEY_PREFIX}${userUuid}`,
+    );
+    return cachedAvatar ?? null;
+  }
+
+  async setUserAvatar(userUuid: string, url: string, ttlMs?: number) {
+    return this.cacheManager.set(
+      `${this.AVATAR_KEY_PREFIX}${userUuid}`,
+      url,
+      ttlMs ?? this.TTL_24_HOURS,
+    );
+  }
+
+  async deleteUserAvatar(userUuid: string) {
+    return this.cacheManager.del(`${this.AVATAR_KEY_PREFIX}${userUuid}`);
   }
 }

--- a/src/modules/user/user.controller.ts
+++ b/src/modules/user/user.controller.ts
@@ -547,10 +547,7 @@ export class UserController {
   async refreshAvatarUser(
     @UserDecorator() user: User,
   ): Promise<RefreshUserAvatarDto> {
-    const avatar = user.avatar
-      ? await this.userUseCases.getAvatarUrl(user.avatar)
-      : null;
-
+    const avatar = await this.userUseCases.getCachedAvatar(user);
     return { avatar };
   }
 


### PR DESCRIPTION
- Added methods to CacheManagerService for getting, setting, and deleting user avatars.
- Updated UserController to use cached avatar retrieval.
- Refactored user use cases to include getCachedAvatar logic, handling cache hits and misses.
- Enhanced unit tests to cover new avatar caching functionality and edge cases.