### PR TITLE
[PB-2394] chore: create extended statistics for user_id, updated_at

### DIFF
--- a/migrations/20250916110659-create-files-user-updated-statistics.js
+++ b/migrations/20250916110659-create-files-user-updated-statistics.js
@@ -1,0 +1,37 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.sequelize.query(
+      'ALTER TABLE files ALTER COLUMN user_id SET STATISTICS 500;',
+    );
+    await queryInterface.sequelize.query(
+      'ALTER TABLE files ALTER COLUMN updated_at SET STATISTICS 500;',
+    );
+
+    await queryInterface.sequelize.query(
+      `
+        CREATE STATISTICS files_user_updated_stats
+        ON user_id, updated_at FROM files;
+      `,
+    );
+
+    // Run ANALYZE to populate the statistics
+    await queryInterface.sequelize.query('ANALYZE files;');
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.sequelize.query(
+      `DROP STATISTICS IF EXISTS files_user_updated_stats`,
+    );
+
+    // Reset statistics target to default (use default_statistics_target)
+    await queryInterface.sequelize.query(
+      'ALTER TABLE files ALTER COLUMN user_id SET STATISTICS -1;',
+    );
+    await queryInterface.sequelize.query(
+      'ALTER TABLE files ALTER COLUMN updated_at SET STATISTICS -1;',
+    );
+  },
+};


### PR DESCRIPTION
Queries using `(user_id, updated_at)` conditions were using inefficient single column indexes instead of the composite index, causing slow performance on delta calculations.

### **Solution** 
Add extended statistics to capture correlation between `user_id` and `updated_at` columns, enabling the query planner to make better index selection decisions.

### Why Increase Statistics Target?
Extended statistics accuracy depends on the underlying single-column statistics quality. For a table with 668M rows:

- **Default (100):** Captures 100 most common values and ~100 histogram buckets
- **Increased (500):** Captures 500 most common values and ~500 histogram buckets
- **Result:** More granular data distribution understanding, leading to better correlation detection between `user_id` and `updated_at`


The table is really big, so we actually can increase the target to 1000 but let's go with a conservative approach, we do not know if we really need more granular data.

These common values are fetched by fetching 300 * target_statistic_number rows, so for a table of 668M rows with statistics_target = 500, PostgreSQL would sample approximately 150,000 rows (300 × 500) to build the most common values list and histogram.

**Some points to take into account:**
- Statistics are only consulted during query planning, not execution
- If unhelpful, they're simply ignored with no performance penalty
- This is not an index, it's pure metadata for the planner
- Only affects queries using both `user_id` and `updated_at` columns

Reference:
- https://www.postgresql.org/docs/current/sql-createstatistics.html
- https://www.postgresql.org/docs/current/planner-stats.html
