### PR TITLE
[PB-5048] feat: allow 1000 items per endpoint

### DIFF
--- a/src/common/dto/basic-pagination.dto.ts
+++ b/src/common/dto/basic-pagination.dto.ts
@@ -2,30 +2,36 @@ import { ApiProperty } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
 import { IsNumber, IsOptional, Max, Min } from 'class-validator';
 
-export class BasicPaginationDto {
-  @ApiProperty({
-    description: 'Items per page',
-    example: 3,
-    required: false,
-    minimum: 0,
-    maximum: 50,
-  })
-  @IsOptional()
-  @IsNumber()
-  @Type(() => Number)
-  @Min(0)
-  @Max(50)
-  limit?: number;
+export function createPaginationDto(maxLimit: number) {
+  class PaginationDto {
+    @ApiProperty({
+      description: 'Items per page',
+      example: Math.min(50, maxLimit),
+      required: false,
+      minimum: 0,
+      maximum: maxLimit,
+    })
+    @IsOptional()
+    @IsNumber()
+    @Type(() => Number)
+    @Min(0)
+    @Max(maxLimit)
+    limit?: number;
 
-  @ApiProperty({
-    description: 'Offset for pagination',
-    example: 0,
-    required: false,
-    minimum: 0,
-  })
-  @IsOptional()
-  @IsNumber()
-  @Type(() => Number)
-  @Min(0)
-  offset?: number;
+    @ApiProperty({
+      description: 'Offset for pagination',
+      example: 0,
+      required: false,
+      minimum: 0,
+    })
+    @IsOptional()
+    @IsNumber()
+    @Type(() => Number)
+    @Min(0)
+    offset?: number;
+  }
+  return PaginationDto;
 }
+
+export class BasicPaginationDto extends createPaginationDto(50) {}
+export class LargePaginationDto extends createPaginationDto(1000) {}

--- a/src/modules/workspaces/dto/get-workspace-files.dto.ts
+++ b/src/modules/workspaces/dto/get-workspace-files.dto.ts
@@ -6,14 +6,17 @@ import {
   ValidationArguments,
 } from 'class-validator';
 import { FileStatus, SortableFileAttributes } from '../../file/file.domain';
-import { BasicPaginationDto } from '../../../common/dto/basic-pagination.dto';
+import { LargePaginationDto } from '../../../common/dto/basic-pagination.dto';
 import { ApiProperty } from '@nestjs/swagger';
 
 const allowedStatuses = [...Object.values(FileStatus), 'ALL'];
 
-export class GetWorkspaceFilesQueryDto extends BasicPaginationDto {
+export class GetWorkspaceFilesQueryDto extends LargePaginationDto {
   @IsOptional()
-  @ApiProperty()
+  @ApiProperty({
+    required: false,
+    enum: allowedStatuses,
+  })
   @IsEnum(allowedStatuses, {
     message: (args: ValidationArguments) =>
       `Invalid status provided: ${

--- a/src/modules/workspaces/dto/get-workspace-folders.dto.ts
+++ b/src/modules/workspaces/dto/get-workspace-folders.dto.ts
@@ -5,7 +5,8 @@ import {
   IsDateString,
   ValidationArguments,
 } from 'class-validator';
-import { BasicPaginationDto } from '../../../common/dto/basic-pagination.dto';
+import { ApiProperty } from '@nestjs/swagger';
+import { LargePaginationDto } from '../../../common/dto/basic-pagination.dto';
 import {
   FolderStatus,
   SortableFolderAttributes,
@@ -13,8 +14,12 @@ import {
 
 const allowedStatuses = [...Object.values(FolderStatus), 'ALL'];
 
-export class GetWorkspaceFoldersQueryDto extends BasicPaginationDto {
+export class GetWorkspaceFoldersQueryDto extends LargePaginationDto {
   @IsOptional()
+  @ApiProperty({
+    required: false,
+    enum: allowedStatuses,
+  })
   @IsEnum(allowedStatuses, {
     message: (args: ValidationArguments) =>
       `Invalid status provided: ${


### PR DESCRIPTION
### Changes
- Increased workspace `GET workspaces/:workspaceId/files-folders` endpoint max allowed items.

Performance impact

There's a Seq scan in `workspace_items_users` but it is not related to this PR. Let's add the index in another ticket.

```
Limit  (cost=15874.69..15874.70 rows=1 width=462) (actual time=30.022..32.978 rows=195 loops=1)
  ->  Sort  (cost=15874.69..15874.70 rows=1 width=462) (actual time=30.021..32.965 rows=195 loops=1)
        Sort Key: "FileModel".updated_at
        Sort Method: quicksort  Memory: 145kB
        ->  Nested Loop  (cost=1000.58..15874.68 rows=1 width=462) (actual time=1.533..32.718 rows=195 loops=1)
              ->  Gather  (cost=1000.00..15872.08 rows=1 width=112) (actual time=1.510..31.124 rows=195 loops=1)
                    Workers Planned: 2
                    Workers Launched: 2
                    ->  Parallel Seq Scan on workspace_items_users "workspaceUser"  (cost=0.00..14871.98 rows=1 width=112) (actual time=15.333..24.172 rows=65 loops=3)
                          Filter: (((created_by)::text = 'fcab1cb8-bd97-42f5-bae4-27a1d5ebbfd2'::text) AND (workspace_id = '500b706b-584a-4947-a6f6-9999f960a827'::uuid) AND ((item_type)::text = 'file'::text))
                          Rows Removed by Filter: 185614
              ->  Index Scan using files_uuid_key on files "FileModel"  (cost=0.57..2.60 rows=1 width=350) (actual time=0.008..0.008 rows=1 loops=195)
                    Index Cond: (uuid = "workspaceUser".item_id)
                    Filter: ((updated_at > '1970-01-01 00:00:00.001'::timestamp without time zone) AND (status = 'EXISTS'::enum_files_status))
Planning Time: 0.455 ms
Execution Time: 33.059 ms
```