### PR TITLE
[_] fix/remove-duplicate-free-tier-from-database

### DIFF
--- a/migrations/20250925185947-reassign-free-tier-label.js
+++ b/migrations/20250925185947-reassign-free-tier-label.js
@@ -1,0 +1,74 @@
+'use strict';
+
+const INCORRECT_FREE_TIER_ID = '3a8f239e-9c4d-494a-9255-de65ab909483';
+
+module.exports = {
+  async up(queryInterface) {
+    const [results] = await queryInterface.sequelize.query(
+      `SELECT id FROM tiers WHERE label = '10gb_individual' LIMIT 1`,
+    );
+
+    if (results.length === 0) {
+      throw new Error('Tier with label 10gb_individual not found');
+    }
+
+    const newTierId = results[0].id;
+
+    // Update tier-limit relationships to point to the correct tier
+    await queryInterface.sequelize.query(
+      `UPDATE tiers_limits
+       SET tier_id = '${newTierId}',
+           updated_at = NOW()
+       WHERE tier_id = '${INCORRECT_FREE_TIER_ID}'`,
+    );
+
+    await queryInterface.sequelize.query(
+      `DELETE FROM tiers WHERE id = '${INCORRECT_FREE_TIER_ID}'`,
+    );
+
+    // Change the already set by default free tier (10gb_individual) to free_individual
+    await queryInterface.sequelize.query(
+      `UPDATE tiers
+       SET label = 'free_individual',
+           context = 'Free - 1GB',
+           updated_at = NOW()
+       WHERE label = '10gb_individual'`,
+    );
+  },
+
+  async down(queryInterface) {
+    await queryInterface.sequelize.query(
+      `INSERT INTO tiers (id, label, context, created_at, updated_at)
+       VALUES (
+         '${INCORRECT_FREE_TIER_ID}',
+         'free_individual',
+         'Free - 1GB',
+         NOW(),
+         NOW()
+       )`,
+    );
+
+    const [results] = await queryInterface.sequelize.query(
+      `SELECT id FROM tiers WHERE label = 'free_individual' AND id != '${INCORRECT_FREE_TIER_ID}' LIMIT 1`,
+    );
+
+    if (results.length > 0) {
+      const currentTierId = results[0].id;
+
+      await queryInterface.sequelize.query(
+        `UPDATE tiers_limits
+         SET tier_id = '${INCORRECT_FREE_TIER_ID}',
+             updated_at = NOW()
+         WHERE tier_id = '${currentTierId}'`,
+      );
+    }
+
+    await queryInterface.sequelize.query(
+      `UPDATE tiers
+       SET label = '10gb_individual',
+           context = 'Plan 10GB',
+           updated_at = NOW()
+       WHERE label = 'free_individual' AND id != '${INCORRECT_FREE_TIER_ID}'`,
+    );
+  },
+};


### PR DESCRIPTION
We currently have a duplicate free tier in production. Users are being assigned to the original free tier (10gb_individual label) by default, but there's also a duplicate tier with UUID `3a8f239e-9c4d-494a-9255-de65ab909483` that was incorrectly created some days ago.

This PR removes the duplicated tier and assign the correct label to the 10gb_individual tier. We already assign that tier to the free users on account creation, so it does not make sense to have a duplicate.

### Changes

  1. Removing the duplicate tier: Deletes the incorrectly created free tier (3a8f239e-9c4d-494a-9255-de65ab909483)
  2. Reassigning tier relationships: Moves any tier-limit relationships from the duplicate to the original tier
  3. Updating the original tier: Changes the existing 10gb_individual tier to use the correct free_individual label and "Free - 1GB" context

Required for -> https://github.com/internxt/drive-server-wip/pull/721