### PR TITLE
[PB-5032] Add events module with initial payment processing support

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -25,6 +25,7 @@ import { AppSumoModule } from './modules/app-sumo/app-sumo.module';
 import { PlanModule } from './modules/plan/plan.module';
 import { WorkspacesModule } from './modules/workspaces/workspaces.module';
 import { GatewayModule } from './modules/gateway/gateway.module';
+import { EventsModule } from './modules/events/events.module';
 import { APP_FILTER } from '@nestjs/core';
 import { HttpGlobalExceptionFilter } from './common/http-global-exception-filter.exception';
 import { JobsModule } from './modules/jobs/jobs.module';
@@ -155,6 +156,7 @@ import { getClientIdFromHeaders } from './common/decorators/client.decorator';
     PlanModule,
     WorkspacesModule,
     GatewayModule,
+    EventsModule,
   ],
   controllers: [],
   providers: [

--- a/src/config/configuration.ts
+++ b/src/config/configuration.ts
@@ -116,6 +116,8 @@ export default () => ({
         process.env.WORKSPACES_USER_INVITATION_EMAIL_ID || '',
       invitationToWorkspaceGuestUser:
         process.env.WORKSPACES_GUEST_USER_INVITATION_EMAIL_ID || '',
+      incompleteCheckout:
+        process.env.SENDGRID_TEMPLATE_DRIVE_INCOMPLETE_CHECKOUT || '',
     },
   },
   newsletter: {

--- a/src/externals/mailer/mailer.service.ts
+++ b/src/externals/mailer/mailer.service.ts
@@ -252,4 +252,19 @@ export class MailerService {
       context,
     );
   }
+
+  async sendIncompleteCheckoutEmail(
+    email: string,
+    completeCheckoutUrl: string,
+  ): Promise<void> {
+    const context = {
+      complete_checkout_url: completeCheckoutUrl,
+    };
+
+    await this.send(
+      email,
+      this.configService.get('mailer.templates.incompleteCheckout'),
+      context,
+    );
+  }
 }

--- a/src/modules/events/dto/incomplete-checkout.dto.spec.ts
+++ b/src/modules/events/dto/incomplete-checkout.dto.spec.ts
@@ -1,0 +1,76 @@
+import { validate } from 'class-validator';
+import { plainToInstance } from 'class-transformer';
+import { IncompleteCheckoutDto } from './incomplete-checkout.dto';
+
+describe('IncompleteCheckoutDto', () => {
+  describe('validate complete_checkout_url', () => {
+    it('When valid HTTPS drive URL is passed, then no errors should be returned', async () => {
+      const checkoutData = {
+        complete_checkout_url: 'https://drive.internxt.com/checkout/complete',
+      };
+      const dto = plainToInstance(IncompleteCheckoutDto, checkoutData);
+
+      const errors = await validate(dto);
+
+      expect(errors.length).toBe(0);
+    });
+
+    it('When valid HTTPS URL with different domain is passed, then no errors should be returned', async () => {
+      const checkoutData = {
+        complete_checkout_url: 'https://checkout.example.com/complete?id=12345',
+      };
+      const dto = plainToInstance(IncompleteCheckoutDto, checkoutData);
+
+      const errors = await validate(dto);
+
+      expect(errors.length).toBe(0);
+    });
+
+    it('When valid HTTPS URL is passed, then no errors should be returned', async () => {
+      const checkoutData = {
+        complete_checkout_url: 'https://example.com/checkout/complete',
+      };
+      const dto = plainToInstance(IncompleteCheckoutDto, checkoutData);
+
+      const errors = await validate(dto);
+
+      expect(errors.length).toBe(0);
+    });
+
+    it('When invalid URL without protocol is passed, then validation error should be returned', async () => {
+      const checkoutData = {
+        complete_checkout_url: 'invalid-url',
+      };
+      const dto = plainToInstance(IncompleteCheckoutDto, checkoutData);
+
+      const errors = await validate(dto);
+
+      expect(errors.length).toBeGreaterThan(0);
+      expect(errors[0].property).toBe('complete_checkout_url');
+    });
+
+    it('When malformed URL is passed, then validation error should be returned', async () => {
+      const checkoutData = {
+        complete_checkout_url: 'not-a-valid-url',
+      };
+      const dto = plainToInstance(IncompleteCheckoutDto, checkoutData);
+
+      const errors = await validate(dto);
+
+      expect(errors.length).toBeGreaterThan(0);
+      expect(errors[0].property).toBe('complete_checkout_url');
+    });
+
+    it('When empty string is passed, then validation error should be returned', async () => {
+      const checkoutData = {
+        complete_checkout_url: '',
+      };
+      const dto = plainToInstance(IncompleteCheckoutDto, checkoutData);
+
+      const errors = await validate(dto);
+
+      expect(errors.length).toBeGreaterThan(0);
+      expect(errors[0].property).toBe('complete_checkout_url');
+    });
+  });
+});

--- a/src/modules/events/dto/incomplete-checkout.dto.spec.ts
+++ b/src/modules/events/dto/incomplete-checkout.dto.spec.ts
@@ -6,7 +6,7 @@ describe('IncompleteCheckoutDto', () => {
   describe('validate complete_checkout_url', () => {
     it('When valid HTTPS drive URL is passed, then no errors should be returned', async () => {
       const checkoutData = {
-        complete_checkout_url: 'https://drive.internxt.com/checkout/complete',
+        completeCheckoutUrl: 'https://drive.internxt.com/checkout/complete',
       };
       const dto = plainToInstance(IncompleteCheckoutDto, checkoutData);
 
@@ -17,7 +17,7 @@ describe('IncompleteCheckoutDto', () => {
 
     it('When valid HTTPS URL with different domain is passed, then no errors should be returned', async () => {
       const checkoutData = {
-        complete_checkout_url: 'https://checkout.example.com/complete?id=12345',
+        completeCheckoutUrl: 'https://checkout.example.com/complete?id=12345',
       };
       const dto = plainToInstance(IncompleteCheckoutDto, checkoutData);
 
@@ -28,7 +28,7 @@ describe('IncompleteCheckoutDto', () => {
 
     it('When valid HTTPS URL is passed, then no errors should be returned', async () => {
       const checkoutData = {
-        complete_checkout_url: 'https://example.com/checkout/complete',
+        completeCheckoutUrl: 'https://example.com/checkout/complete',
       };
       const dto = plainToInstance(IncompleteCheckoutDto, checkoutData);
 
@@ -39,38 +39,38 @@ describe('IncompleteCheckoutDto', () => {
 
     it('When invalid URL without protocol is passed, then validation error should be returned', async () => {
       const checkoutData = {
-        complete_checkout_url: 'invalid-url',
+        completeCheckoutUrl: 'invalid-url',
       };
       const dto = plainToInstance(IncompleteCheckoutDto, checkoutData);
 
       const errors = await validate(dto);
 
       expect(errors.length).toBeGreaterThan(0);
-      expect(errors[0].property).toBe('complete_checkout_url');
+      expect(errors[0].property).toBe('completeCheckoutUrl');
     });
 
     it('When malformed URL is passed, then validation error should be returned', async () => {
       const checkoutData = {
-        complete_checkout_url: 'not-a-valid-url',
+        completeCheckoutUrl: 'not-a-valid-url',
       };
       const dto = plainToInstance(IncompleteCheckoutDto, checkoutData);
 
       const errors = await validate(dto);
 
       expect(errors.length).toBeGreaterThan(0);
-      expect(errors[0].property).toBe('complete_checkout_url');
+      expect(errors[0].property).toBe('completeCheckoutUrl');
     });
 
     it('When empty string is passed, then validation error should be returned', async () => {
       const checkoutData = {
-        complete_checkout_url: '',
+        completeCheckoutUrl: '',
       };
       const dto = plainToInstance(IncompleteCheckoutDto, checkoutData);
 
       const errors = await validate(dto);
 
       expect(errors.length).toBeGreaterThan(0);
-      expect(errors[0].property).toBe('complete_checkout_url');
+      expect(errors[0].property).toBe('completeCheckoutUrl');
     });
   });
 });

--- a/src/modules/events/dto/incomplete-checkout.dto.ts
+++ b/src/modules/events/dto/incomplete-checkout.dto.ts
@@ -1,0 +1,11 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsUrl } from 'class-validator';
+
+export class IncompleteCheckoutDto {
+  @ApiProperty({
+    description: 'URL to complete the checkout process',
+    example: 'https://drive.internxt.com/checkout/complete',
+  })
+  @IsUrl()
+  complete_checkout_url: string;
+}

--- a/src/modules/events/dto/incomplete-checkout.dto.ts
+++ b/src/modules/events/dto/incomplete-checkout.dto.ts
@@ -7,5 +7,5 @@ export class IncompleteCheckoutDto {
     example: 'https://drive.internxt.com/checkout/complete',
   })
   @IsUrl()
-  complete_checkout_url: string;
+  completeCheckoutUrl: string;
 }

--- a/src/modules/events/events.controller.spec.ts
+++ b/src/modules/events/events.controller.spec.ts
@@ -14,7 +14,7 @@ describe('EventsController', () => {
   const mockUser = newUser({ attributes: { email: 'test@internxt.com' } });
 
   const mockIncompleteCheckoutDto: IncompleteCheckoutDto = {
-    complete_checkout_url: 'https://drive.internxt.com/checkout/complete',
+    completeCheckoutUrl: 'https://drive.internxt.com/checkout/complete',
   };
 
   beforeEach(async () => {

--- a/src/modules/events/events.controller.spec.ts
+++ b/src/modules/events/events.controller.spec.ts
@@ -1,0 +1,89 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { Logger } from '@nestjs/common';
+import { createMock, DeepMocked } from '@golevelup/ts-jest';
+import { EventsController } from './events.controller';
+import { EventsUseCases } from './events.usecase';
+import { IncompleteCheckoutDto } from './dto/incomplete-checkout.dto';
+import { User } from '../user/user.domain';
+import { newUser } from '../../../test/fixtures';
+
+describe('EventsController', () => {
+  let controller: EventsController;
+  let eventsUseCases: DeepMocked<EventsUseCases>;
+
+  const mockUser = newUser({ attributes: { email: 'test@internxt.com' } });
+
+  const mockIncompleteCheckoutDto: IncompleteCheckoutDto = {
+    complete_checkout_url: 'https://drive.internxt.com/checkout/complete',
+  };
+
+  beforeEach(async () => {
+    const moduleRef: TestingModule = await Test.createTestingModule({
+      controllers: [EventsController],
+    })
+      .setLogger(createMock<Logger>())
+      .useMocker(() => createMock())
+      .compile();
+
+    controller = moduleRef.get<EventsController>(EventsController);
+    eventsUseCases = moduleRef.get(EventsUseCases);
+  });
+
+  it('When tests are started, then it should be defined', () => {
+    expect(controller).toBeDefined();
+    expect(eventsUseCases).toBeDefined();
+  });
+
+  describe('handle incomplete checkout', () => {
+    it('When valid user and dto are provided, then should call usecase with correct parameters', async () => {
+      const expectedResult = { success: true };
+      eventsUseCases.handleIncompleteCheckoutEvent.mockResolvedValue(
+        expectedResult,
+      );
+
+      const result = await controller.handleIncompleteCheckout(
+        mockUser,
+        mockIncompleteCheckoutDto,
+      );
+
+      expect(result).toEqual(expectedResult);
+      expect(eventsUseCases.handleIncompleteCheckoutEvent).toHaveBeenCalledWith(
+        mockUser,
+        mockIncompleteCheckoutDto,
+      );
+    });
+
+    it('When different user is provided, then should pass correct user to usecase', async () => {
+      const differentUser = newUser({
+        attributes: { email: 'different@internxt.com' },
+      });
+      const expectedResult = { success: true };
+      eventsUseCases.handleIncompleteCheckoutEvent.mockResolvedValue(
+        expectedResult,
+      );
+
+      const result = await controller.handleIncompleteCheckout(
+        differentUser,
+        mockIncompleteCheckoutDto,
+      );
+
+      expect(result).toEqual(expectedResult);
+      expect(eventsUseCases.handleIncompleteCheckoutEvent).toHaveBeenCalledWith(
+        differentUser,
+        mockIncompleteCheckoutDto,
+      );
+    });
+
+    it('When usecase throws error, then should propagate error', async () => {
+      const mockError = new Error('SendGrid service unavailable');
+      eventsUseCases.handleIncompleteCheckoutEvent.mockRejectedValue(mockError);
+
+      await expect(
+        controller.handleIncompleteCheckout(
+          mockUser,
+          mockIncompleteCheckoutDto,
+        ),
+      ).rejects.toThrow('SendGrid service unavailable');
+    });
+  });
+});

--- a/src/modules/events/events.controller.ts
+++ b/src/modules/events/events.controller.ts
@@ -1,0 +1,35 @@
+import { Body, Controller, Post } from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiOperation,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
+import { EventsUseCases } from './events.usecase';
+import { IncompleteCheckoutDto } from './dto/incomplete-checkout.dto';
+import { User as UserDecorator } from '../auth/decorators/user.decorator';
+import { User } from '../user/user.domain';
+
+@ApiTags('Events')
+@Controller('events')
+@ApiBearerAuth()
+export class EventsController {
+  constructor(private readonly eventsUseCases: EventsUseCases) {}
+
+  @Post('/payments/incomplete-checkout')
+  @ApiBearerAuth()
+  @ApiOperation({
+    summary: 'Handle incomplete checkout event',
+    description: 'Sends notification email when user abandons checkout process',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Incomplete checkout email sent successfully',
+  })
+  async handleIncompleteCheckout(
+    @UserDecorator() user: User,
+    @Body() dto: IncompleteCheckoutDto,
+  ) {
+    return this.eventsUseCases.handleIncompleteCheckoutEvent(user, dto);
+  }
+}

--- a/src/modules/events/events.module.ts
+++ b/src/modules/events/events.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
+import { MailerService } from '../../externals/mailer/mailer.service';
+import { EventsController } from './events.controller';
+import { EventsUseCases } from './events.usecase';
+
+@Module({
+  imports: [ConfigModule],
+  controllers: [EventsController],
+  providers: [MailerService, EventsUseCases],
+  exports: [EventsUseCases],
+})
+export class EventsModule {}

--- a/src/modules/events/events.usecase.spec.ts
+++ b/src/modules/events/events.usecase.spec.ts
@@ -14,7 +14,7 @@ describe('EventsUseCases', () => {
 
   const mockUser = newUser({ attributes: { email: 'test@internxt.com' } });
   const mockIncompleteCheckoutDto: IncompleteCheckoutDto = {
-    complete_checkout_url: 'https://drive.internxt.com/checkout/complete',
+    completeCheckoutUrl: 'https://drive.internxt.com/checkout/complete',
   };
 
   beforeEach(async () => {
@@ -49,7 +49,7 @@ describe('EventsUseCases', () => {
       expect(result).toEqual({ success: true });
       expect(mockSendIncompleteCheckoutEmail).toHaveBeenCalledWith(
         mockUser.email,
-        mockIncompleteCheckoutDto.complete_checkout_url,
+        mockIncompleteCheckoutDto.completeCheckoutUrl,
       );
     });
 

--- a/src/modules/events/events.usecase.spec.ts
+++ b/src/modules/events/events.usecase.spec.ts
@@ -1,0 +1,70 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+import { createMock } from '@golevelup/ts-jest';
+import { EventsUseCases } from './events.usecase';
+import { MailerService } from '../../externals/mailer/mailer.service';
+import { IncompleteCheckoutDto } from './dto/incomplete-checkout.dto';
+import { User } from '../user/user.domain';
+import { newUser } from '../../../test/fixtures';
+
+describe('EventsUseCases', () => {
+  let usecases: EventsUseCases;
+  let mailerService: MailerService;
+  let configService: ConfigService;
+
+  const mockUser = newUser({ attributes: { email: 'test@internxt.com' } });
+  const mockIncompleteCheckoutDto: IncompleteCheckoutDto = {
+    complete_checkout_url: 'https://drive.internxt.com/checkout/complete',
+  };
+
+  beforeEach(async () => {
+    const moduleRef: TestingModule = await Test.createTestingModule({
+      providers: [EventsUseCases],
+    })
+      .useMocker(createMock)
+      .compile();
+
+    usecases = moduleRef.get<EventsUseCases>(EventsUseCases);
+    mailerService = moduleRef.get<MailerService>(MailerService);
+    configService = moduleRef.get<ConfigService>(ConfigService);
+  });
+
+  it('When tests are started, then it should be defined', () => {
+    expect(usecases).toBeDefined();
+    expect(mailerService).toBeDefined();
+    expect(configService).toBeDefined();
+  });
+
+  describe('handle incomplete checkout event', () => {
+    it('When valid user and dto are provided, then should send email successfully', async () => {
+      const mockSendIncompleteCheckoutEmail = jest
+        .spyOn(mailerService, 'sendIncompleteCheckoutEmail')
+        .mockResolvedValue(undefined);
+
+      const result = await usecases.handleIncompleteCheckoutEvent(
+        mockUser,
+        mockIncompleteCheckoutDto,
+      );
+
+      expect(result).toEqual({ success: true });
+      expect(mockSendIncompleteCheckoutEmail).toHaveBeenCalledWith(
+        mockUser.email,
+        mockIncompleteCheckoutDto.complete_checkout_url,
+      );
+    });
+
+    it('When mailer service throws error, then should propagate the error', async () => {
+      const mockError = new Error('SendGrid service unavailable');
+      jest
+        .spyOn(mailerService, 'sendIncompleteCheckoutEmail')
+        .mockRejectedValue(mockError);
+
+      await expect(
+        usecases.handleIncompleteCheckoutEvent(
+          mockUser,
+          mockIncompleteCheckoutDto,
+        ),
+      ).rejects.toThrow('SendGrid service unavailable');
+    });
+  });
+});

--- a/src/modules/events/events.usecase.ts
+++ b/src/modules/events/events.usecase.ts
@@ -1,0 +1,32 @@
+import { Injectable, Logger, Inject } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { MailerService } from '../../externals/mailer/mailer.service';
+import { IncompleteCheckoutDto } from './dto/incomplete-checkout.dto';
+import { User } from '../user/user.domain';
+
+@Injectable()
+export class EventsUseCases {
+  constructor(
+    private readonly mailerService: MailerService,
+    @Inject(ConfigService)
+    private readonly configService: ConfigService,
+  ) {}
+
+  async handleIncompleteCheckoutEvent(
+    user: User,
+    dto: IncompleteCheckoutDto,
+  ): Promise<{ success: boolean }> {
+    try {
+      await this.mailerService.sendIncompleteCheckoutEmail(
+        user.email,
+        dto.complete_checkout_url,
+      );
+      return { success: true };
+    } catch (error) {
+      new Logger('[EVENTS/INCOMPLETE_CHECKOUT]').error(
+        `Failed to send incomplete checkout email to ${user.email}: ${error.message}`,
+      );
+      throw error;
+    }
+  }
+}

--- a/src/modules/events/events.usecase.ts
+++ b/src/modules/events/events.usecase.ts
@@ -19,7 +19,7 @@ export class EventsUseCases {
     try {
       await this.mailerService.sendIncompleteCheckoutEmail(
         user.email,
-        dto.complete_checkout_url,
+        dto.completeCheckoutUrl,
       );
       return { success: true };
     } catch (error) {


### PR DESCRIPTION
This adds a events module to process specific controlled events from the frontend, for example payment processing.

- The endpoint **/events/payments/incomplete-checkout** is exposed for handling incomplete checkout events
- Receives the needed param *completeCheckoutUrl* for the template to send the email.
- Add a new method in mailer service async **sendIncompleteCheckoutEmail** and respective templateId env var.