### PR TITLE
[PB-4689] feat/audit logs decorator and service

### DIFF
--- a/src/common/audit-logs/audit-log.service.spec.ts
+++ b/src/common/audit-logs/audit-log.service.spec.ts
@@ -1,0 +1,91 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { createMock, DeepMocked } from '@golevelup/ts-jest';
+import { Logger } from '@nestjs/common';
+import { AuditLogService } from './audit-log.service';
+import { AuditLogsRepository } from './audit-logs.repository';
+import {
+  AuditAction,
+  AuditEntityType,
+  AuditPerformerType,
+} from './audit-logs.attributes';
+import { v4 } from 'uuid';
+
+describe('AuditLogService', () => {
+  let service: AuditLogService;
+  let repository: DeepMocked<AuditLogsRepository>;
+  let logger: DeepMocked<Logger>;
+
+  beforeEach(async () => {
+    logger = createMock<Logger>();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [AuditLogService],
+    })
+      .setLogger(logger)
+      .useMocker(() => createMock())
+      .compile();
+
+    service = module.get<AuditLogService>(AuditLogService);
+    repository = module.get(AuditLogsRepository);
+  });
+
+  it('When the service is instantiated, then it should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('log', () => {
+    it('When valid audit log data is provided, then it should create an audit log', async () => {
+      const auditLogDto = {
+        entityType: AuditEntityType.User,
+        entityId: v4(),
+        action: AuditAction.PasswordChanged,
+        performerType: AuditPerformerType.User,
+        performerId: v4(),
+        metadata: { folderUuid: v4() },
+      };
+
+      repository.create.mockResolvedValueOnce({} as any);
+
+      await service.log(auditLogDto);
+
+      expect(repository.create).toHaveBeenCalledWith(auditLogDto);
+    });
+
+    it('When valid audit log data without metadata is provided, then it should create an audit log', async () => {
+      const auditLogDto = {
+        entityType: AuditEntityType.User,
+        entityId: v4(),
+        action: AuditAction.TfaEnabled,
+        performerType: AuditPerformerType.User,
+        performerId: v4(),
+      };
+
+      repository.create.mockResolvedValueOnce({} as any);
+
+      await service.log(auditLogDto);
+
+      expect(repository.create).toHaveBeenCalledWith(auditLogDto);
+    });
+
+    it('When repository throws an error, then it should log a warning and not throw', async () => {
+      const auditLogDto = {
+        entityType: AuditEntityType.User,
+        entityId: v4(),
+        action: AuditAction.EmailChanged,
+        performerType: AuditPerformerType.User,
+        performerId: v4(),
+        metadata: { newEmail: 'new@example.com' },
+      };
+
+      const error = new Error('Database connection failed');
+      repository.create.mockRejectedValueOnce(error);
+
+      const loggerWarnSpy = jest.spyOn(logger, 'warn').mockImplementation();
+
+      await service.log(auditLogDto);
+
+      expect(repository.create).toHaveBeenCalledWith(auditLogDto);
+      expect(loggerWarnSpy).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/common/audit-logs/audit-log.service.ts
+++ b/src/common/audit-logs/audit-log.service.ts
@@ -1,0 +1,43 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { AuditLogsRepository } from './audit-logs.repository';
+import {
+  AuditAction,
+  AuditEntityType,
+  AuditPerformerType,
+} from './audit-logs.attributes';
+
+export interface CreateAuditLogDto {
+  entityType: AuditEntityType;
+  entityId: string;
+  action: AuditAction;
+  performerType: AuditPerformerType;
+  performerId?: string;
+  metadata?: Record<string, any>;
+}
+
+@Injectable()
+export class AuditLogService {
+  private readonly logger = new Logger(AuditLogService.name);
+
+  constructor(private readonly auditLogsRepository: AuditLogsRepository) {}
+
+  /**
+   * Creates an audit log entry without throwing errors
+   * @param dto Audit log data
+   */
+  async log(dto: CreateAuditLogDto): Promise<void> {
+    try {
+      await this.auditLogsRepository.create(dto);
+    } catch (error) {
+      this.logger.warn(
+        {
+          action: dto.action,
+          entityType: dto.entityType,
+          entityId: dto.entityId,
+          error: (error as Error).message,
+        },
+        'Failed to create audit log',
+      );
+    }
+  }
+}

--- a/src/common/audit-logs/audit-logs.module.ts
+++ b/src/common/audit-logs/audit-logs.module.ts
@@ -5,6 +5,8 @@ import {
   AuditLogsRepository,
   SequelizeAuditLogRepository,
 } from './audit-logs.repository';
+import { AuditLogService } from './audit-log.service';
+import { AuditLogInterceptor } from './interceptors/audit-log.interceptor';
 
 @Module({
   imports: [SequelizeModule.forFeature([AuditLogModel])],
@@ -14,7 +16,9 @@ import {
       provide: AuditLogsRepository,
       useClass: SequelizeAuditLogRepository,
     },
+    AuditLogService,
+    AuditLogInterceptor,
   ],
-  exports: [],
+  exports: [AuditLogService, AuditLogInterceptor, AuditLogsRepository],
 })
 export class AuditLogsModule {}

--- a/src/common/audit-logs/decorators/audit-log.decorator.ts
+++ b/src/common/audit-logs/decorators/audit-log.decorator.ts
@@ -1,0 +1,81 @@
+import { applyDecorators, SetMetadata, UseInterceptors } from '@nestjs/common';
+import {
+  AuditAction,
+  AuditEntityType,
+  AuditPerformerType,
+} from '../audit-logs.attributes';
+import { AuditLogInterceptor } from '../interceptors/audit-log.interceptor';
+
+export type ValueExtractor<T = any> =
+  | string
+  | ((req: any, res: any) => T | undefined);
+
+export interface AuditLogConfig {
+  action: AuditAction;
+
+  /**
+   * The type of entity being audited (defaults to User)
+   */
+  entityType?: AuditEntityType;
+
+  /**
+   * Path or callback to extract the entity ID
+   * Examples:
+   * - 'user.uuid' - extracts from req.user.uuid
+   * - 'params.userId' - extracts from req.params.userId
+   * - (req, res) => res.workspace.id - custom extraction
+   *
+   * Defaults to 'user.uuid' if not specified
+   */
+  entityId?: ValueExtractor<string>;
+
+  /**
+   * Path or callback to extract the performer ID
+   * Defaults to 'user.uuid' if not specified
+   */
+  performerId?: ValueExtractor<string>;
+
+  performerType?: AuditPerformerType;
+
+  metadata?:
+    | string[]
+    | ((req: any, res: any) => Record<string, any> | undefined);
+}
+
+export const AUDIT_LOG_METADATA_KEY = 'audit-log';
+
+/**
+ * Decorator to mark controller methods for automatic audit logging
+ *
+ * @param config Configuration for audit logging
+ *
+ * @example
+ * // Minimal usage - auto-detects entityId from user.uuid
+ * @AuditLog({ action: AuditAction.TfaEnabled })
+ *
+ * @example
+ * // With string paths for data extraction
+ * @AuditLog({
+ *   action: AuditAction.EmailChanged,
+ *   entityId: 'user.uuid',
+ *   metadata: ['body.newEmail', 'body.oldEmail']
+ * })
+ *
+ * @example
+ * // With callback functions for complex extraction
+ * @AuditLog({
+ *   action: AuditAction.WorkspaceCreated,
+ *   entityType: AuditEntityType.Workspace,
+ *   entityId: (req, res) => res.workspace.id,
+ *   performerId: 'user.uuid',
+ *   metadata: (req, res) => ({
+ *     workspaceName: res.workspace.name,
+ *     ownerId: res.workspace.ownerId
+ *   })
+ * })
+ */
+export const AuditLog = (config: AuditLogConfig) =>
+  applyDecorators(
+    SetMetadata(AUDIT_LOG_METADATA_KEY, config),
+    UseInterceptors(AuditLogInterceptor),
+  );

--- a/src/common/audit-logs/interceptors/audit-log.interceptor.spec.ts
+++ b/src/common/audit-logs/interceptors/audit-log.interceptor.spec.ts
@@ -1,0 +1,144 @@
+import { createMock, DeepMocked } from '@golevelup/ts-jest';
+import { CallHandler, ExecutionContext } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { of, lastValueFrom } from 'rxjs';
+import { AuditLogInterceptor } from './audit-log.interceptor';
+import { AuditLogService } from '../audit-log.service';
+import { AuditLogConfig } from '../decorators/audit-log.decorator';
+import {
+  AuditAction,
+  AuditEntityType,
+  AuditPerformerType,
+} from '../audit-logs.attributes';
+import { newUser } from '../../../../test/fixtures';
+
+describe('AuditLogInterceptor', () => {
+  let interceptor: AuditLogInterceptor;
+  let reflector: DeepMocked<Reflector>;
+  let auditLogService: DeepMocked<AuditLogService>;
+
+  const mockHandler = jest.fn();
+
+  const createContext = (request: any) =>
+    createMock<ExecutionContext>({
+      getHandler: () => mockHandler,
+      switchToHttp: () => ({ getRequest: () => request }),
+    });
+
+  const createCallHandler = (response: any): CallHandler => ({
+    handle: jest.fn().mockReturnValue(of(response)),
+  });
+
+  beforeEach(() => {
+    reflector = createMock<Reflector>();
+    auditLogService = createMock<AuditLogService>();
+    interceptor = new AuditLogInterceptor(reflector, auditLogService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('When the interceptor is instantiated, then it should be defined', () => {
+    expect(interceptor).toBeDefined();
+  });
+
+  describe('intercept', () => {
+    it('When no audit log metadata is found, then it should pass through without logging', async () => {
+      const context = createContext({});
+      const next = createCallHandler({ data: 'test' });
+      reflector.get.mockReturnValue(undefined);
+
+      const result = await lastValueFrom(interceptor.intercept(context, next));
+
+      expect(result).toEqual({ data: 'test' });
+      expect(auditLogService.log).not.toHaveBeenCalled();
+    });
+
+    it('When audit log metadata is found with minimal config, then it should create audit log with defaults', async () => {
+      const metadata: AuditLogConfig = { action: AuditAction.TfaEnabled };
+      const request = { user: newUser() };
+      const context = createContext(request);
+      const next = createCallHandler({ success: true });
+
+      reflector.get.mockReturnValue(metadata);
+      auditLogService.log.mockResolvedValue(undefined);
+
+      await lastValueFrom(interceptor.intercept(context, next));
+
+      expect(auditLogService.log).toHaveBeenCalledWith({
+        action: AuditAction.TfaEnabled,
+        entityType: AuditEntityType.User,
+        entityId: request.user.uuid,
+        performerType: AuditPerformerType.User,
+        performerId: request.user.uuid,
+        metadata: undefined,
+      });
+    });
+
+    it('When using custom extractors, then it should extract values from paths and callbacks', async () => {
+      const metadata: AuditLogConfig = {
+        action: AuditAction.WorkspaceCreated,
+        entityType: AuditEntityType.Workspace,
+        entityId: (_req, res) => res.workspace.id,
+        performerId: 'body.creatorId',
+        performerType: AuditPerformerType.System,
+        metadata: ['body.name'],
+      };
+      const request = {
+        user: { uuid: newUser() },
+        body: { creatorId: 'creator-789', name: 'My Workspace' },
+      };
+      const response = { workspace: { id: 'workspace-456' } };
+      const context = createContext(request);
+      const next = createCallHandler(response);
+
+      reflector.get.mockReturnValue(metadata);
+      auditLogService.log.mockResolvedValue(undefined);
+
+      await lastValueFrom(interceptor.intercept(context, next));
+
+      expect(auditLogService.log).toHaveBeenCalledWith({
+        action: AuditAction.WorkspaceCreated,
+        entityType: AuditEntityType.Workspace,
+        entityId: 'workspace-456',
+        performerId: 'creator-789',
+        performerType: AuditPerformerType.System,
+        metadata: { name: 'My Workspace' },
+      });
+    });
+
+    it('When entityId cannot be extracted, then it should not create audit log', async () => {
+      const metadata: AuditLogConfig = {
+        action: AuditAction.EmailChanged,
+        entityId: 'user.id',
+      };
+      const request = { user: {} };
+      const context = createContext(request);
+      const next = createCallHandler({});
+
+      reflector.get.mockReturnValue(metadata);
+
+      await lastValueFrom(interceptor.intercept(context, next));
+
+      expect(auditLogService.log).not.toHaveBeenCalled();
+    });
+
+    it('When audit log creation fails, then it should not throw', async () => {
+      const metadata: AuditLogConfig = {
+        action: AuditAction.PasswordChanged,
+      };
+      const request = { user: newUser() };
+      const context = createContext(request);
+      const next = createCallHandler({});
+      const error = new Error('Audit log creation failed');
+
+      reflector.get.mockReturnValue(metadata);
+      auditLogService.log.mockRejectedValue(error);
+
+      const result = await lastValueFrom(interceptor.intercept(context, next));
+
+      expect(result).toEqual({});
+    });
+  });
+});

--- a/src/common/audit-logs/interceptors/audit-log.interceptor.ts
+++ b/src/common/audit-logs/interceptors/audit-log.interceptor.ts
@@ -1,0 +1,141 @@
+import {
+  Injectable,
+  NestInterceptor,
+  ExecutionContext,
+  CallHandler,
+  Logger,
+} from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { Observable } from 'rxjs';
+import { tap } from 'rxjs/operators';
+import {
+  AuditLogConfig,
+  AUDIT_LOG_METADATA_KEY,
+  ValueExtractor,
+} from '../decorators/audit-log.decorator';
+import { AuditLogService } from '../audit-log.service';
+import { AuditEntityType, AuditPerformerType } from '../audit-logs.attributes';
+import { extractByPath, extractMultiple } from '../utils/path-extractor.util';
+
+@Injectable()
+export class AuditLogInterceptor implements NestInterceptor {
+  private readonly logger = new Logger(AuditLogInterceptor.name);
+
+  constructor(
+    private readonly reflector: Reflector,
+    private readonly auditLogService: AuditLogService,
+  ) {}
+
+  intercept(context: ExecutionContext, next: CallHandler): Observable<any> {
+    const handler = context.getHandler();
+    const auditConfig = this.reflector.get<AuditLogConfig>(
+      AUDIT_LOG_METADATA_KEY,
+      handler,
+    );
+
+    if (!auditConfig) {
+      this.logger.debug('No audit log config found on handler');
+      return next.handle();
+    }
+
+    const request = context.switchToHttp().getRequest();
+
+    return next.handle().pipe(
+      tap((response) => {
+        this.createAuditLog(auditConfig, request, response).catch((error) => {
+          this.logger.error(
+            {
+              action: auditConfig.action,
+              error: (error as Error).message,
+            },
+            'Failed to create audit log',
+          );
+        });
+      }),
+    );
+  }
+
+  private async createAuditLog(
+    config: AuditLogConfig,
+    request: any,
+    response: any,
+  ): Promise<void> {
+    const entityId = this.extractValue(
+      request,
+      response,
+      config.entityId || 'user.uuid',
+    );
+    const performerId = this.extractValue(
+      request,
+      response,
+      config.performerId || 'user.uuid',
+    );
+
+    if (!entityId) {
+      this.logger.warn(
+        {
+          action: config.action,
+          entityIdExtractor: config.entityId || 'user.uuid',
+        },
+        'Could not extract entityId for audit log',
+      );
+      return;
+    }
+
+    const extractedMetadata = this.extractMetadata(
+      request,
+      response,
+      config.metadata,
+    );
+
+    const auditLogDto = {
+      action: config.action,
+      entityType: config.entityType || AuditEntityType.User,
+      entityId,
+      performerType: config.performerType || AuditPerformerType.User,
+      performerId,
+      metadata: extractedMetadata,
+    };
+
+    await this.auditLogService.log(auditLogDto);
+  }
+
+  /**
+   * Extracts a value using either a string path or callback function
+   */
+  private extractValue(
+    request: any,
+    response: any,
+    extractor: ValueExtractor<string>,
+  ): string | undefined {
+    if (typeof extractor === 'function') {
+      return extractor(request, response);
+    }
+
+    return extractByPath(request, extractor);
+  }
+
+  private extractMetadata(
+    request: any,
+    response: any,
+    metadataConfig:
+      | string[]
+      | ((req: any, res: any) => Record<string, any> | undefined)
+      | undefined,
+  ): Record<string, any> | undefined {
+    if (!metadataConfig) {
+      return undefined;
+    }
+
+    if (typeof metadataConfig === 'function') {
+      return metadataConfig(request, response);
+    }
+
+    if (Array.isArray(metadataConfig)) {
+      const extracted = extractMultiple(request, metadataConfig);
+      return Object.keys(extracted).length > 0 ? extracted : undefined;
+    }
+
+    return undefined;
+  }
+}

--- a/src/common/audit-logs/utils/path-extractor.util.ts
+++ b/src/common/audit-logs/utils/path-extractor.util.ts
@@ -1,0 +1,31 @@
+/**
+ * Extracts a value from an object using a dot-notation path
+ */
+export function extractByPath(obj: any, path: string): any {
+  let result = obj;
+  for (const key of path.split('.')) {
+    result = result?.[key];
+  }
+  return result;
+}
+
+/**
+ * Extracts multiple values from an object using dot-notation paths
+ * and returns them as a record
+ */
+export function extractMultiple(
+  obj: any,
+  paths: string[],
+): Record<string, any> {
+  const result: Record<string, any> = {};
+
+  for (const path of paths) {
+    const value = extractByPath(obj, path);
+    if (value !== undefined) {
+      const key = path.split('.').pop() || path;
+      result[key] = value;
+    }
+  }
+
+  return result;
+}


### PR DESCRIPTION
Dependency: https://github.com/internxt/drive-server-wip/pull/728

This PR adds a decorator that would let us to audit any endpoint by just setting it up correctly.

We'll decorate the controllers in another PR.