### PR TITLE
feat(gateway): set tier on workspace creation

### DIFF
--- a/src/modules/gateway/dto/initialize-workspace.dto.ts
+++ b/src/modules/gateway/dto/initialize-workspace.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsNotEmpty, IsNumber, IsOptional } from 'class-validator';
+import { IsNotEmpty, IsNumber, IsOptional, IsUUID } from 'class-validator';
 
 export class InitializeWorkspaceDto {
   @ApiProperty({
@@ -8,6 +8,15 @@ export class InitializeWorkspaceDto {
   })
   @IsNotEmpty()
   ownerId: string;
+
+  @ApiProperty({
+    example: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
+    description: 'Tier ID for the workspace',
+    required: false,
+  })
+  @IsOptional()
+  @IsUUID()
+  tierId?: string;
 
   @ApiProperty({
     example: 'Address from billing',

--- a/src/modules/gateway/gateway.usecase.ts
+++ b/src/modules/gateway/gateway.usecase.ts
@@ -28,8 +28,21 @@ export class GatewayUseCases {
     Logger.log(
       `Initializing workspace with owner id: ${initializeWorkspaceDto.ownerId}`,
     );
-    const { ownerId, maxSpaceBytes, address, numberOfSeats, phoneNumber } =
-      initializeWorkspaceDto;
+    const {
+      ownerId,
+      maxSpaceBytes,
+      address,
+      numberOfSeats,
+      phoneNumber,
+      tierId,
+    } = initializeWorkspaceDto;
+
+    if (tierId) {
+      const tier = await this.featureLimitService.getTier(tierId);
+      if (!tier) {
+        throw new BadRequestException(`Tier with ID ${tierId} not found`);
+      }
+    }
 
     try {
       return await this.workspaceUseCases.initiateWorkspace(
@@ -39,6 +52,7 @@ export class GatewayUseCases {
           address,
           numberOfSeats,
           phoneNumber,
+          tierId,
         },
       );
     } catch (error) {

--- a/src/modules/workspaces/workspaces.usecase.ts
+++ b/src/modules/workspaces/workspaces.usecase.ts
@@ -107,6 +107,7 @@ export class WorkspacesUsecases {
       address?: string;
       numberOfSeats: number;
       phoneNumber?: string;
+      tierId?: string;
     },
   ) {
     const owner = await this.userRepository.findByUuid(ownerId);
@@ -135,6 +136,13 @@ export class WorkspacesUsecases {
       bridgeUser: workspaceEmail,
       mnemonic: owner.mnemonic,
     });
+
+    if (workspaceData.tierId) {
+      await this.userRepository.updateBy(
+        { uuid: workspaceUser.uuid },
+        { tierId: workspaceData.tierId },
+      );
+    }
 
     const workspaceId = v4();
 
@@ -3054,6 +3062,7 @@ export class WorkspacesUsecases {
         numberOfSeats: workspace.numberOfSeats,
         phoneNumber: workspace.phoneNumber,
         address: workspace.address,
+        tierId: workspaceNetworkUser.tierId,
       }),
     ]);
   }


### PR DESCRIPTION
Adds optional tierId parameter to workspace initialization to set the tier during workspace creation.

###   Changes

  - Added tierId field to InitializeWorkspaceDto with UUID validation
  - Updated GatewayUseCases.initializeWorkspace() to validate tier exists before creation
  - Modified WorkspacesUsecases.initiateWorkspace() to set tier on workspace user during initialization