### PR TITLE
[_]: feat/add index to improve performance

### DIFF
--- a/migrations/20260225092001-create-index-files-status-trash.js
+++ b/migrations/20260225092001-create-index-files-status-trash.js
@@ -1,0 +1,17 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  useTransaction: false,
+  async up(queryInterface, Sequelize) {
+    await queryInterface.sequelize.query(
+      `CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_files_status_trash ON files (user_id) WHERE status = 'TRASHED';`,
+    );
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.sequelize.query(
+      `DROP INDEX CONCURRENTLY IF EXISTS idx_files_status_trash;`,
+    );
+  },
+};


### PR DESCRIPTION
Queries fetching files with status = 'TRASHED' for a specific user were slow because the DB had to scan the entire files table, including `EXISTS` and `DELETED` files.
To solve this, we created a partial index on `user_id` filtered by `status = 'TRASHED'`.

## EXPLAIN ANALYZE
### QUERY
```
explain analyze select * from files
where status = 'TRASHED'
and user_id = 1
limit 50 ;
```

### BEFORE
```
Limit  (cost=0.00..6.35 rows=50 width=183) (actual time=0.079..0.105 rows=50 loops=1)
  ->  Seq Scan on files  (cost=0.00..6353.00 rows=50000 width=183) (actual time=0.066..0.088 rows=50 loops=1)
        Filter: ((status = 'TRASHED'::enum_files_status) AND (user_id = 1))
Planning Time: 1.881 ms
Execution Time: 0.259 ms
```

### AFTER
```
Limit  (cost=0.29..2.71 rows=50 width=183) (actual time=0.043..0.090 rows=50 loops=1)
  ->  Index Scan using idx_files_status_trash on files  (cost=0.29..2422.29 rows=50000 width=183) (actual time=0.042..0.085 rows=50 loops=1)
        Index Cond: (user_id = 1)
Planning Time: 1.963 ms
Execution Time: 0.232 ms>
```