### PR TITLE
chore: create new index for sync and fixed some intermitent tests

### DIFF
--- a/migrations/20260410094351-create-files-user-updated-at-status-index.js
+++ b/migrations/20260410094351-create-files-user-updated-at-status-index.js
@@ -1,0 +1,17 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.sequelize.query(`
+      CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_user_updated_at_status
+      ON public.files USING btree (user_id, updated_at, status);
+    `);
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.sequelize.query(`
+      DROP INDEX CONCURRENTLY IF EXISTS idx_user_updated_at_status;
+    `);
+  },
+};

--- a/migrations/20260410101101-drop-idx-user-status-updated-at-uuid.js
+++ b/migrations/20260410101101-drop-idx-user-status-updated-at-uuid.js
@@ -4,13 +4,13 @@
 module.exports = {
   async up(queryInterface, Sequelize) {
     await queryInterface.sequelize.query(`
-      DROP INDEX CONCURRENTLY IF EXISTS idx_user_status_updated_at_uuid;
+      DROP INDEX CONCURRENTLY IF EXISTS idx_user_status_updated_uuid;
     `);
   },
 
   async down(queryInterface, Sequelize) {
     await queryInterface.sequelize.query(`
-      CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_user_status_updated_at_uuid
+      CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_user_status_updated_uuid
       ON public.files USING btree (user_id, status, updated_at, uuid);
     `);
   },

--- a/migrations/20260410101101-drop-idx-user-status-updated-at-uuid.js
+++ b/migrations/20260410101101-drop-idx-user-status-updated-at-uuid.js
@@ -1,0 +1,17 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.sequelize.query(`
+      DROP INDEX CONCURRENTLY IF EXISTS idx_user_status_updated_at_uuid;
+    `);
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.sequelize.query(`
+      CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_user_status_updated_at_uuid
+      ON public.files USING btree (user_id, status, updated_at, uuid);
+    `);
+  },
+};

--- a/src/modules/file/dto/get-files.dto.spec.ts
+++ b/src/modules/file/dto/get-files.dto.spec.ts
@@ -24,7 +24,6 @@ describe('GetFilesDto', () => {
     dto.sort = 'updatedAt';
     dto.order = SortOrder.DESC;
     dto.updatedAt = '2024-01-01T00:00:00.000Z';
-    dto.lastId = v4();
 
     const errors = await validate(dto);
     expect(errors.length).toBe(0);
@@ -213,28 +212,6 @@ describe('GetFilesDto', () => {
     dto.limit = 10;
     dto.offset = -1;
     dto.status = FileStatus.EXISTS;
-
-    const errors = await validate(dto);
-    expect(errors.length).toBeGreaterThan(0);
-  });
-
-  it('When lastId is valid, then it should pass', async () => {
-    const dto = new GetFilesDto();
-    dto.limit = 10;
-    dto.offset = 0;
-    dto.status = FileStatus.EXISTS;
-    dto.lastId = v4();
-
-    const errors = await validate(dto);
-    expect(errors.length).toBe(0);
-  });
-
-  it('When lastId is invalid, then it should fail', async () => {
-    const dto = new GetFilesDto();
-    dto.limit = 10;
-    dto.offset = 0;
-    dto.status = FileStatus.EXISTS;
-    dto.lastId = 'INVALID';
 
     const errors = await validate(dto);
     expect(errors.length).toBeGreaterThan(0);

--- a/src/modules/file/dto/get-files.dto.spec.ts
+++ b/src/modules/file/dto/get-files.dto.spec.ts
@@ -81,17 +81,6 @@ describe('GetFilesDto', () => {
     expect(errors.length).toBe(0);
   });
 
-  it('When sort is plainName, then it should pass', async () => {
-    const dto = new GetFilesDto();
-    dto.limit = 10;
-    dto.offset = 0;
-    dto.status = FileStatus.EXISTS;
-    dto.sort = 'plainName';
-
-    const errors = await validate(dto);
-    expect(errors.length).toBe(0);
-  });
-
   it('When sort is invalid, then it should fail', async () => {
     const dto = new GetFilesDto();
     dto.limit = 10;

--- a/src/modules/file/dto/get-files.dto.ts
+++ b/src/modules/file/dto/get-files.dto.ts
@@ -19,21 +19,24 @@ export class GetFilesDto extends RequiredLargePaginationDto {
   @IsEnum(allowedStatuses)
   status: FileStatus | 'ALL';
 
+  // TODO: this should not be a valid option.
   @ApiProperty({
     description: 'Bucket ID filter',
     required: false,
+    deprecated: true,
   })
   @IsOptional()
   @IsString()
   bucket?: string;
 
+  // TODO: uuid should not be a valid option here, but one client is using it so we need to keep it.
   @ApiProperty({
     description: 'Field to sort by',
-    enum: ['updatedAt', 'size', 'id', 'plainName', 'uuid'],
+    enum: ['updatedAt', 'uuid'],
     required: false,
   })
   @IsOptional()
-  @IsEnum(['updatedAt', 'size', 'id', 'plainName', 'uuid'])
+  @IsEnum(['updatedAt', 'uuid'])
   sort?: SortableFileAttributes;
 
   @ApiProperty({
@@ -52,12 +55,4 @@ export class GetFilesDto extends RequiredLargePaginationDto {
   @IsOptional()
   @IsString()
   updatedAt?: string;
-
-  @ApiProperty({
-    description: 'The last file uuid of the provided list in the previous call',
-    required: false,
-  })
-  @IsOptional()
-  @IsUUID('4')
-  lastId?: FileAttributes['uuid'];
 }

--- a/src/modules/file/file.controller.spec.ts
+++ b/src/modules/file/file.controller.spec.ts
@@ -639,7 +639,6 @@ describe('FileController', () => {
   describe('getFiles', () => {
     const validLimit = 50;
     const validOffset = 0;
-    const lastId = v4();
 
     it('When getFiles is called with valid parameters, then it should return files', async () => {
       const mockFiles = [
@@ -658,7 +657,6 @@ describe('FileController', () => {
         sort: 'plainName',
         order: SortOrder.ASC,
         updatedAt: '2023-01-01T00:00:00.000Z',
-        lastId,
       };
 
       const result = await fileController.getFiles(userMocked, queryParams);
@@ -682,7 +680,6 @@ describe('FileController', () => {
           limit: validLimit,
           offset: validOffset,
           sort: [['plainName', 'ASC']],
-          lastId,
         }),
         'test-bucket',
       );

--- a/src/modules/file/file.controller.ts
+++ b/src/modules/file/file.controller.ts
@@ -363,7 +363,7 @@ export class FileController {
     @UserDecorator() user: User,
     @Query() queryParams: GetFilesDto,
   ): Promise<FileDto[]> {
-    const { limit, offset, status, bucket, sort, order, updatedAt, lastId } =
+    const { limit, offset, status, bucket, sort, order, updatedAt } =
       queryParams;
 
     const fns: Record<string, (...args) => Promise<File[]>> = {
@@ -376,7 +376,7 @@ export class FileController {
     const files: File[] = await fns[status].bind(this.fileUseCases)(
       user.id,
       new Date(updatedAt || 1),
-      { limit, offset, sort: sort && order && [[sort, order]], lastId },
+      { limit, offset, sort: sort && order && [[sort, order]] },
       bucket,
     );
 

--- a/src/modules/user/user.usecase.spec.ts
+++ b/src/modules/user/user.usecase.spec.ts
@@ -4370,6 +4370,16 @@ describe('User use cases', () => {
   describe('checkAndNotifyStorageThreshold', () => {
     const mockUser = newUser({ attributes: { email: 'test@internxt.com' } });
     const MAX_EMAILS_PER_MONTH = 2;
+    const FIXED_NOW = new Date('2025-06-15T12:00:00.000Z');
+
+    beforeEach(() => {
+      jest.useFakeTimers();
+      jest.setSystemTime(FIXED_NOW);
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
 
     it('When usage is below threshold, then should not send email', async () => {
       const limit = 100 * 1024 * 1024 * 1024;

--- a/src/modules/workspaces/workspaces.usecase.spec.ts
+++ b/src/modules/workspaces/workspaces.usecase.spec.ts
@@ -3866,6 +3866,16 @@ describe('WorkspacesUsecases', () => {
     const workspaceId = v4();
     const limit = 50;
     const offset = 0;
+    const FIXED_NOW = new Date('2026-04-10T12:00:00Z');
+
+    beforeAll(() => {
+      jest.useFakeTimers();
+      jest.setSystemTime(FIXED_NOW);
+    });
+
+    afterAll(() => {
+      jest.useRealTimers();
+    });
 
     it('When files are retrieved and no retention limit is found, it should return files with expiresAt null', async () => {
       const trashedFiles = [newFile()];


### PR DESCRIPTION
We created one index for cursor navigation, however, we will be changing the navigation schema.

After a lot of tests, we noticed the `idx_user_status_updated_at_uuid` index tries to cover all the queries that filter by updated_at, but it is not efficient unless a status is passed. Most of our sync queries do not use `status = 'EXISTS'`, as they are only part of the Windows recovery process.

We're talking about:

- 350K calls without status vs 40K calls with status
- All desktop clients calling `GET /files` without status filtering constantly, vs just one client calling it with status = 'EXISTS' just for its recovery process.

This does not intend to improve performance when a large `OFFSET` is required, but rather to address query timeouts and allow normal users to use the platform smoothly, so we still expect some slowness in those cases.

I also dropped support for lastSeenId (no client is using it yet) and some unused sorting fields to prevent clients from using them in the future.

## Benchmark
I ran some benchmarks with the potentially slowest query by nature, so we are essentially looking at the 2nd worst scenario (the 1st worst being a large `OFFSET`).

The conditions for this benchmark are:
- Test user:
    - 12,976 files after 2026-03-01
    - 111,233 existing files in total
    - 693,359 files across all statuses
- Table total rows: 22,779,318
- Total size: 11 GB

### Status = 'ALL' (most called query)
```sql
select
	*
from
	"files" as "FileModel"
where
"FileModel"."user_id" = 10001
	and "FileModel"."updated_at" > '2026-03-01 00:00:00.001 +00:00'
order by
	"FileModel"."updated_at" asc
limit 1000 offset 0;
```
New index:

```sql
Limit  (cost=0.56..2951.75 rows=1000 width=224) (actual time=4.748..504.505 rows=1000 loops=1)
  Buffers: shared hit=23 read=985
  ->  Index Scan using idx_user_updated_at_status on files "FileModel"  (cost=0.56..170363.98 rows=57727 width=224) (actual time=4.737..504.298 rows=1000 loops=1)
        Index Cond: ((user_id = 10001) AND (updated_at > '2026-03-01 00:00:00.001+00'::timestamp with time zone))
        Buffers: shared hit=23 read=985
Planning:
  Buffers: shared hit=21 read=12 dirtied=4
Planning Time: 74.665 ms
Execution Time: 508.432 ms
```
Old index
```sql
Limit  (cost=179366.39..179368.89 rows=1000 width=224) (actual time=1074.438..1074.593 rows=1000 loops=1)
  Buffers: shared read=34708 written=4
  ->  Sort  (cost=179366.39..179510.71 rows=57727 width=224) (actual time=1053.334..1053.410 rows=1000 loops=1)
        Sort Key: updated_at
        Sort Method: top-N heapsort  Memory: 486kB
        Buffers: shared read=34708 written=4
        ->  Bitmap Heap Scan on files "FileModel"  (cost=10994.32..176201.28 rows=57727 width=224) (actual time=280.994..946.090 rows=496832 loops=1)
              Recheck Cond: ((user_id = 10001) AND (updated_at > '2026-03-01 00:00:00.001+00'::timestamp with time zone))
              Heap Blocks: exact=30527
              Buffers: shared read=34708 written=4
              ->  Bitmap Index Scan on idx_user_status_updated_at_uuid  (cost=0.00..10979.89 rows=57727 width=0) (actual time=277.413..277.413 rows=496832 loops=1)
                    Index Cond: ((user_id = 10001) AND (updated_at > '2026-03-01 00:00:00.001+00'::timestamp with time zone))
                    Buffers: shared read=4181
Planning:
  Buffers: shared hit=2
Planning Time: 3.520 ms
JIT:
  Functions: 6
  Options: Inlining false, Optimization false, Expressions true, Deforming true
  Timing: Generation 5.303 ms (Deform 3.485 ms), Inlining 0.000 ms, Optimization 2.197 ms, Emission 18.929 ms, Total 26.428 ms
Execution Time: 1080.468 ms
```
### Filtering by status (worst scenario)
```sql
select
	*
from
	"files" as "FileModel"
where
	"FileModel"."status" = 'EXISTS'
	and "FileModel"."user_id" = 1
	and "FileModel"."updated_at" > '2026-03-01 00:00:00.001 +00:00'
order by
	  "FileModel"."uuid" asc
limit 1000 offset 0;
```
New index:

```sql
Limit (cost=91101.84..91104.34 rows=1000 width=224) (actual time=5697.801..5697.965 rows=1000 loops=1)
Buffers: shared hit=13205
-> Sort (cost=91101.84..91174.91 rows=29228 width=224) (actual time=5697.788..5697.859 rows=1000 loops=1)
Sort Key: uuid
Sort Method: top-N heapsort Memory: 485kB
Buffers: shared hit=13205
-> Index Scan using idx_user_updated_at_status on files "FileModel" (cost=0.56..89499.30 rows=29228 width=224) (actual time=26.299..5553.993 rows=12976 loops=1)
Index Cond: ((user_id = 10001) AND (updated_at > '2026-03-01 00:00:00.001+00'::timestamp with time zone) AND (status = 'EXISTS'::enum_files_status))
Buffers: shared hit=13205
Planning:
Buffers: shared hit=4
Planning Time: 161.388 ms
Execution Time: 5710.953 ms
```
Old index:

```sql
Limit (cost=86505.65..86508.15 rows=1000 width=224) (actual time=16801.929..16802.817 rows=1000 loops=1)
Buffers: shared hit=13059
-> Sort (cost=86505.65..86575.48 rows=27934 width=224) (actual time=16800.544..16800.806 rows=1000 loops=1)
Sort Key: uuid
Sort Method: top-N heapsort Memory: 485kB
Buffers: shared hit=13059
-> Index Scan using idx_user_status_updated_at_uuid on files "FileModel" (cost=0.56..84974.05 rows=27934 width=224) (actual time=21.433..16331.582 rows=12976 loops=1)
Index Cond: ((user_id = 10001) AND (status = 'EXISTS'::enum_files_status) AND (updated_at > '2026-03-01 00:00:00.001+00'::timestamp with time zone))
Buffers: shared hit=13059
Planning:
Buffers: shared hit=4
Planning Time: 171.139 ms
Execution Time: 16811.403 ms
```