### PR TITLE
[_] chore: add readiness and liveness checks

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -48,6 +48,8 @@ WORKSPACES_GUEST_USER_INVITATION_EMAIL_ID=sendgrid_template_id
 SHARE_DOMAINS=http://localhost:3000
 PCREATED_USERS_PASSWORD=example
 
+HEALTH_CHECK_TOKEN=secret-token
+
 # SENTRY_DSN=dsn
 STORAGE_API_URL=http://network-api:6382
 STORJ_BRIDGE=http://network-api:6382

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -32,6 +32,7 @@ import { getClientIdFromHeaders } from './common/decorators/client.decorator';
 import { AuthGuard } from './modules/auth/auth.guard';
 import { CacheManagerModule } from './modules/cache-manager/cache-manager.module';
 import { ReferralModule } from './modules/referral/referral.module';
+import { HealthModule } from './infrastructure/health/health.module';
 
 const isCronjobInstance = process.env.EXECUTE_JOBS === 'true';
 const appName = isCronjobInstance ? 'drive-server-cronjob' : 'drive-server';
@@ -150,6 +151,7 @@ const appName = isCronjobInstance ? 'drive-server-cronjob' : 'drive-server';
     GatewayModule,
     CacheManagerModule,
     ReferralModule,
+    HealthModule,
   ],
   controllers: [],
   providers: [

--- a/src/config/configuration.ts
+++ b/src/config/configuration.ts
@@ -182,4 +182,5 @@ export default () => ({
     productSecret: process.env.CELLO_PRODUCT_SECRET,
   },
   executeCronjobs: process.env.EXECUTE_JOBS === 'true',
+  healthCheckToken: process.env.HEALTH_CHECK_TOKEN,
 });

--- a/src/infrastructure/health/health.controller.ts
+++ b/src/infrastructure/health/health.controller.ts
@@ -1,0 +1,35 @@
+import {
+  Controller,
+  Get,
+  HttpCode,
+  HttpStatus,
+  UseGuards,
+} from '@nestjs/common';
+import { ApiOperation, ApiTags } from '@nestjs/swagger';
+import { HealthTokenGuard } from './health.guard';
+import { HealthService } from './health.service';
+import { DisableGlobalAuth } from '../../modules/auth/decorators/disable-global-auth.decorator';
+
+@ApiTags('Health')
+@Controller('health')
+@DisableGlobalAuth()
+@UseGuards(HealthTokenGuard)
+export class HealthController {
+  constructor(private readonly healthService: HealthService) {}
+
+  @Get('live')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Liveness probe' })
+  live() {
+    return { status: 'ok' };
+  }
+
+  @Get('ready')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: 'Readiness probe — checks services',
+  })
+  async ready() {
+    return this.healthService.check();
+  }
+}

--- a/src/infrastructure/health/health.guard.ts
+++ b/src/infrastructure/health/health.guard.ts
@@ -1,0 +1,24 @@
+import {
+  type CanActivate,
+  type ExecutionContext,
+  Injectable,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+
+@Injectable()
+export class HealthTokenGuard implements CanActivate {
+  constructor(private readonly configService: ConfigService) {}
+
+  canActivate(context: ExecutionContext): boolean {
+    const request = context.switchToHttp().getRequest();
+    const token = request.headers['x-health-token'];
+    const expectedToken = this.configService.get<string>('healthCheckToken');
+
+    if (!expectedToken || token !== expectedToken) {
+      throw new UnauthorizedException();
+    }
+
+    return true;
+  }
+}

--- a/src/infrastructure/health/health.module.ts
+++ b/src/infrastructure/health/health.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { HealthController } from './health.controller';
+import { HealthTokenGuard } from './health.guard';
+import { HealthService } from './health.service';
+import { CacheManagerModule } from '../../modules/cache-manager/cache-manager.module';
+
+@Module({
+  imports: [CacheManagerModule],
+  controllers: [HealthController],
+  providers: [HealthTokenGuard, HealthService],
+})
+export class HealthModule {}

--- a/src/infrastructure/health/health.service.spec.ts
+++ b/src/infrastructure/health/health.service.spec.ts
@@ -1,0 +1,86 @@
+import { ServiceUnavailableException, type Logger } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import { createMock, type DeepMocked } from '@golevelup/ts-jest';
+import { Sequelize } from 'sequelize-typescript';
+import { HealthService, HealthStatus, CheckStatus } from './health.service';
+import { CacheManagerService } from '../../modules/cache-manager/cache-manager.service';
+
+describe('HealthService', () => {
+  let service: HealthService;
+  let sequelize: DeepMocked<Sequelize>;
+  let cacheManagerService: DeepMocked<CacheManagerService>;
+
+  beforeEach(async () => {
+    const moduleRef = await Test.createTestingModule({
+      providers: [HealthService],
+    })
+      .setLogger(createMock<Logger>())
+      .useMocker(() => createMock())
+      .compile();
+
+    service = moduleRef.get(HealthService);
+    sequelize = moduleRef.get(Sequelize);
+    cacheManagerService = moduleRef.get(CacheManagerService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('check', () => {
+    it('When all services are healthy, then it should return status ok', async () => {
+      sequelize.authenticate.mockResolvedValue();
+      cacheManagerService.checkHealth.mockResolvedValue();
+
+      const result = await service.check();
+
+      expect(result.status).toBe(HealthStatus.Ok);
+      expect(result.checks.db.status).toBe(CheckStatus.Ok);
+      expect(result.checks.redis.status).toBe(CheckStatus.Ok);
+      expect(result.failedChecks).toHaveLength(0);
+    });
+
+    it('When DB is healthy, then it should include ping in db check', async () => {
+      sequelize.authenticate.mockResolvedValue();
+      cacheManagerService.checkHealth.mockResolvedValue();
+
+      const result = await service.check();
+
+      expect(result.checks.db.ping).toBeGreaterThanOrEqual(0);
+    });
+
+    it('When Redis fails, then it should return status degraded with redis in failedChecks', async () => {
+      sequelize.authenticate.mockResolvedValue();
+      cacheManagerService.checkHealth.mockRejectedValue(
+        new Error('Connection refused'),
+      );
+
+      const result = await service.check();
+
+      expect(result.status).toBe(HealthStatus.Degraded);
+      expect(result.checks.redis.status).toBe(CheckStatus.Error);
+      expect(result.failedChecks).toContain('redis');
+    });
+
+    it('When DB fails, then it should throw', async () => {
+      sequelize.authenticate.mockRejectedValue(new Error('DB unreachable'));
+      cacheManagerService.checkHealth.mockResolvedValue();
+
+      await expect(service.check()).rejects.toThrow(
+        ServiceUnavailableException,
+      );
+    });
+
+    it('When DB fails, then the exception payload should contain db in failedChecks', async () => {
+      sequelize.authenticate.mockRejectedValue(new Error('DB unreachable'));
+      cacheManagerService.checkHealth.mockResolvedValue();
+
+      try {
+        await service.check();
+      } catch (err) {
+        expect(err.response.failedChecks).toContain('db');
+        expect(err.response.checks.db.status).toBe(CheckStatus.Error);
+      }
+    });
+  });
+});

--- a/src/infrastructure/health/health.service.ts
+++ b/src/infrastructure/health/health.service.ts
@@ -1,0 +1,116 @@
+import {
+  Inject,
+  Injectable,
+  Logger,
+  ServiceUnavailableException,
+} from '@nestjs/common';
+import { InjectConnection } from '@nestjs/sequelize';
+import { Sequelize } from 'sequelize-typescript';
+import { CacheManagerService } from '../../modules/cache-manager/cache-manager.service';
+
+export enum HealthStatus {
+  Ok = 'ok',
+  Degraded = 'degraded',
+  Failed = 'failed',
+}
+
+export enum CheckStatus {
+  Ok = 'ok',
+  Error = 'error',
+}
+
+type CheckResult = { status: CheckStatus; ping?: number; error?: string };
+type HealthPayload = {
+  status: HealthStatus;
+  uptime: number;
+  timestamp: string;
+  checks: Record<string, CheckResult>;
+  failedChecks: string[];
+};
+type ServiceDefinition = {
+  required: boolean;
+  check: () => Promise<CheckResult>;
+};
+
+@Injectable()
+export class HealthService {
+  private readonly logger = new Logger(HealthService.name);
+
+  constructor(
+    @InjectConnection() private readonly sequelize: Sequelize,
+    @Inject() private readonly cacheManager: CacheManagerService,
+  ) {}
+
+  private get services(): Record<string, ServiceDefinition> {
+    return {
+      db: {
+        required: true,
+        check: async () => {
+          const start = Date.now();
+          await this.sequelize.authenticate();
+          return { status: CheckStatus.Ok, ping: Date.now() - start };
+        },
+      },
+      redis: {
+        required: false,
+        check: async () => {
+          const start = Date.now();
+          await this.cacheManager.checkHealth();
+          return { status: CheckStatus.Ok, ping: Date.now() - start };
+        },
+      },
+    };
+  }
+
+  async check(): Promise<HealthPayload> {
+    const services = this.services;
+
+    const checks: Record<string, CheckResult> = Object.fromEntries(
+      await Promise.all(
+        Object.entries(services).map(async ([name, { check }]) => {
+          const start = Date.now();
+          try {
+            return [name, await check()];
+          } catch (err) {
+            return [
+              name,
+              {
+                status: CheckStatus.Error,
+                ping: Date.now() - start,
+                error: String(err),
+              },
+            ];
+          }
+        }),
+      ),
+    );
+
+    const failedChecks = Object.entries(checks)
+      .filter(([, r]) => r.status !== CheckStatus.Ok)
+      .map(([name]) => name);
+
+    const hasRequiredFailure = failedChecks.some(
+      (name) => services[name].required,
+    );
+
+    const payload: HealthPayload = {
+      status: hasRequiredFailure
+        ? HealthStatus.Failed
+        : failedChecks.length > 0
+          ? HealthStatus.Degraded
+          : HealthStatus.Ok,
+      uptime: process.uptime(),
+      timestamp: new Date().toISOString(),
+      checks,
+      failedChecks,
+    };
+
+    this.logger.debug(`Health check: ${JSON.stringify(payload)}`);
+
+    if (hasRequiredFailure) {
+      throw new ServiceUnavailableException(payload);
+    }
+
+    return payload;
+  }
+}

--- a/src/modules/cache-manager/cache-manager.service.ts
+++ b/src/modules/cache-manager/cache-manager.service.ts
@@ -100,4 +100,14 @@ export class CacheManagerService {
   async deleteUserAvatar(userUuid: string) {
     return this.cacheManager.del(`${this.AVATAR_KEY_PREFIX}${userUuid}`);
   }
+
+  async checkHealth(): Promise<void> {
+    const key = 'health_check';
+    const value = Date.now().toString();
+    await this.cacheManager.set(key, value, 5000);
+    const result = await this.cacheManager.get(key);
+    if (result !== value) {
+      throw new Error('Redis health check failed: value mismatch');
+    }
+  }
 }


### PR DESCRIPTION
Example:

Services healthy
```json
{
    "status": "ok",
    "uptime": 15.455946799,
    "timestamp": "2026-04-13T14:22:00.831Z",
    "checks": {
        "db": {
            "status": "ok",
            "ping": 2
        },
        "redis": {
            "status": "ok",
            "ping": 3
        }
    },
    "failedChecks": []
}
```

Optional service not healthy
```json
{
    "status": "degraded",
    "uptime": 161.267781658,
    "timestamp": "2026-04-13T13:59:10.510Z",
    "checks": {
        "db": {
            "status": "ok",
            "ping": 2
        },
        "redis": {
            "status": "error",
            "ping": 2,
            "error": "Error: Redis health check failed: value mismatch"
        }
    },
    "failedChecks": [
        "redis"
    ]
}
```