### PR TITLE
[_] fix: add limit 1 to backup queries

### DIFF
--- a/src/modules/backups/backup.usecase.spec.ts
+++ b/src/modules/backups/backup.usecase.spec.ts
@@ -6,7 +6,6 @@ import { SequelizeBackupRepository } from './backup.repository';
 import { BridgeService } from '../../externals/bridge/bridge.service';
 import { CryptoService } from '../../externals/crypto/crypto.service';
 import { FolderUseCases } from '../folder/folder.usecase';
-import { FileUseCases } from '../file/file.usecase';
 import {
   NotFoundException,
   ConflictException,
@@ -15,16 +14,17 @@ import {
 import { type Folder } from '../folder/folder.domain';
 import { DevicePlatform } from './device.domain';
 import { SequelizeFolderRepository } from '../folder/folder.repository';
+import { SequelizeFileRepository } from '../file/file.repository';
 
 describe('BackupUseCase', () => {
   let backupUseCase: BackupUseCase;
   let backupRepository: SequelizeBackupRepository;
   let folderRepository: SequelizeFolderRepository;
+  let fileRepository: SequelizeFileRepository;
 
   let bridgeService: BridgeService;
   let cryptoService: CryptoService;
   let folderUseCases: FolderUseCases;
-  let fileUseCases: FileUseCases;
 
   const userMocked = newUser({
     attributes: {
@@ -55,9 +55,11 @@ describe('BackupUseCase', () => {
     bridgeService = module.get<BridgeService>(BridgeService);
     cryptoService = module.get<CryptoService>(CryptoService);
     folderUseCases = module.get<FolderUseCases>(FolderUseCases);
-    fileUseCases = module.get<FileUseCases>(FileUseCases);
     folderRepository = module.get<SequelizeFolderRepository>(
       SequelizeFolderRepository,
+    );
+    fileRepository = module.get<SequelizeFileRepository>(
+      SequelizeFileRepository,
     );
   });
 
@@ -81,9 +83,8 @@ describe('BackupUseCase', () => {
 
   describe('createDeviceAsFolder', () => {
     it('When a folder with the same name exists, then it should throw a ConflictException', async () => {
-      jest
-        .spyOn(folderUseCases, 'getFolders')
-        .mockResolvedValue([{ id: 1, name: 'Device Folder' }] as any);
+      const existentFolder = newFolder();
+      jest.spyOn(folderRepository, 'findOne').mockResolvedValue(existentFolder);
 
       await expect(
         backupUseCase.createDeviceAsFolder(userMocked, 'Device Folder'),
@@ -92,10 +93,11 @@ describe('BackupUseCase', () => {
 
     it('When no folder with the same name exists, then it should create the folder', async () => {
       const mockFolder = newFolder();
-      jest.spyOn(folderUseCases, 'getFolders').mockResolvedValue([]);
+      jest.spyOn(folderRepository, 'findOne').mockResolvedValue(null);
       jest
-        .spyOn(folderUseCases, 'createFolderDevice')
+        .spyOn(folderRepository, 'createFolder')
         .mockResolvedValue(mockFolder);
+      jest.spyOn(backupUseCase, 'isFolderEmpty').mockResolvedValue(true);
 
       const result = await backupUseCase.createDeviceAsFolder(
         userMocked,
@@ -123,6 +125,7 @@ describe('BackupUseCase', () => {
       jest
         .spyOn(folderUseCases, 'getFoldersByUserId')
         .mockResolvedValue([mockFolder]);
+      jest.spyOn(backupUseCase, 'isFolderEmpty').mockResolvedValue(true);
 
       const result = await backupUseCase.getDevicesAsFolder(userMocked);
 
@@ -189,10 +192,9 @@ describe('BackupUseCase', () => {
   describe('isFolderEmpty', () => {
     it('When the folder has no subfolders or files, then it should return true', async () => {
       const parentFolder = newFolder();
-      jest
-        .spyOn(folderUseCases, 'getFoldersByParentUuid')
-        .mockResolvedValue([]);
-      jest.spyOn(fileUseCases, 'getByFolderAndUser').mockResolvedValue([]);
+
+      jest.spyOn(folderRepository, 'findOne').mockResolvedValue(null);
+      jest.spyOn(fileRepository, 'findOneBy').mockResolvedValue(null);
 
       const result = await backupUseCase.isFolderEmpty(
         userMocked,
@@ -203,12 +205,9 @@ describe('BackupUseCase', () => {
 
     it('When the folder has subfolders or files, then it should return false', async () => {
       const parentFolder = newFolder();
-      const mockFolder = newFolder();
-
-      jest
-        .spyOn(folderUseCases, 'getFoldersByParentUuid')
-        .mockResolvedValue([mockFolder]);
-      jest.spyOn(fileUseCases, 'getByFolderAndUser').mockResolvedValue([]);
+      const folderInBackup = newFolder();
+      jest.spyOn(folderRepository, 'findOne').mockResolvedValue(folderInBackup);
+      jest.spyOn(fileRepository, 'findOneBy').mockResolvedValue(null);
 
       const result = await backupUseCase.isFolderEmpty(
         userMocked,
@@ -354,6 +353,7 @@ describe('BackupUseCase', () => {
       jest
         .spyOn(folderUseCases, 'updateByFolderIdAndForceUpdatedAt')
         .mockResolvedValue(updatedFolder);
+      jest.spyOn(backupUseCase, 'isFolderEmpty').mockResolvedValue(true);
 
       const result = await backupUseCase.updateDeviceAsFolder(
         userMocked,
@@ -570,6 +570,7 @@ describe('BackupUseCase', () => {
       jest
         .spyOn(folderRepository, 'findByUuids')
         .mockResolvedValue([mockFolder]);
+      jest.spyOn(backupUseCase, 'isFolderEmpty').mockResolvedValue(true);
 
       const result = await backupUseCase.getUserDevices(userMocked, {}, 10, 0);
 
@@ -837,6 +838,7 @@ describe('BackupUseCase', () => {
       jest
         .spyOn(backupRepository, 'createDevice')
         .mockResolvedValue(mockDevice);
+      jest.spyOn(backupUseCase, 'isFolderEmpty').mockResolvedValue(true);
 
       const result = await backupUseCase.createDeviceForExistingFolder(
         userMocked,
@@ -1078,6 +1080,7 @@ describe('BackupUseCase', () => {
       jest
         .spyOn(folderRepository, 'updateOneAndReturn')
         .mockResolvedValue(mockFolder);
+      jest.spyOn(backupUseCase, 'isFolderEmpty').mockResolvedValue(true);
 
       jest
         .spyOn(backupRepository, 'updateDeviceName')

--- a/src/modules/backups/backup.usecase.ts
+++ b/src/modules/backups/backup.usecase.ts
@@ -11,7 +11,6 @@ import { type User } from '../user/user.domain';
 import { BridgeService } from './../../externals/bridge/bridge.service';
 import { CryptoService } from './../../externals/crypto/crypto.service';
 import { FolderUseCases } from '../folder/folder.usecase';
-import { FileUseCases } from '../file/file.usecase';
 import { Folder, type FolderAttributes } from '../folder/folder.domain';
 import { SequelizeUserRepository } from '../user/user.repository';
 import { type BackupModel } from './models/backup.model';
@@ -21,6 +20,8 @@ import { type CreateDeviceAndAttachFolderDto } from './dto/create-device-and-att
 import { type DevicePlatform } from './device.domain';
 import { type UpdateDeviceAndFolderDto } from './dto/update-device-and-folder.dto';
 import { SequelizeFolderRepository } from '../folder/folder.repository';
+import { SequelizeFileRepository } from '../file/file.repository';
+import { FileStatus } from '../file/file.domain';
 
 @Injectable()
 export class BackupUseCase {
@@ -32,8 +33,7 @@ export class BackupUseCase {
     @Inject(forwardRef(() => FolderUseCases))
     private readonly folderUsecases: FolderUseCases,
     private readonly folderRepository: SequelizeFolderRepository,
-    @Inject(forwardRef(() => FileUseCases))
-    private readonly fileUsecases: FileUseCases,
+    private readonly fileRepository: SequelizeFileRepository,
   ) {}
 
   async deleteUserBackups(userId: number) {
@@ -49,6 +49,7 @@ export class BackupUseCase {
     return this.backupRepository.findAllLegacyDevices(user);
   }
 
+  // @deprecated
   async deleteDevice(user: User, deviceId: number) {
     const device = await this.backupRepository.findDeviceByUserAndId(
       user,
@@ -97,18 +98,20 @@ export class BackupUseCase {
       bucket = backupsBucket;
     }
 
-    const folders = await this.folderUsecases.getFolders(user.id, {
+    // We do not have an index to cover this query, but it is not a frequent operation
+    const folder = await this.folderRepository.findOne({
       bucket,
       plainName: deviceName,
       deleted: false,
       removed: false,
+      userId: user.id,
     });
 
-    if (folders.length > 0) {
+    if (folder) {
       throw new ConflictException('Folder with the same name already exists');
     }
 
-    const createdFolder = await this.folderUsecases.createFolderDevice(user, {
+    const createdFolder = await this.folderRepository.createFolder(user.id, {
       plainName: deviceName,
       bucket,
     });
@@ -483,16 +486,19 @@ export class BackupUseCase {
   }
 
   async isFolderEmpty(user: User, folder: Folder) {
-    const folders = await this.folderUsecases.getFoldersByParentUuid(
-      folder.uuid,
-      user.id,
-    );
-    const files = await this.fileUsecases.getByFolderAndUser(
-      folder.id,
-      user.id,
-      { deleted: false },
-    );
-    return folders.length === 0 && files.length === 0;
+    const folderInFolder = await this.folderRepository.findOne({
+      parentUuid: folder.uuid,
+      userId: user.id,
+      removed: false,
+      deleted: false,
+    });
+    const fileInFolder = await this.fileRepository.findOneBy({
+      folderUuid: folder.uuid,
+      userId: user.id,
+      status: FileStatus.EXISTS,
+    });
+
+    return !folderInFolder && !fileInFolder;
   }
 
   async sumExistentBackupSizes(userId: number) {

--- a/src/modules/file/file.usecase.spec.ts
+++ b/src/modules/file/file.usecase.spec.ts
@@ -3313,25 +3313,6 @@ describe('FileUseCases', () => {
     });
   });
 
-  describe('getFilesByFolderUuid', () => {
-    it('When called with folder uuid and status, then it should return files', async () => {
-      const folderUuid = v4();
-      const status = FileStatus.EXISTS;
-      const mockFiles = [newFile()];
-      jest
-        .spyOn(fileRepository, 'getFilesByFolderUuid')
-        .mockResolvedValue(mockFiles);
-
-      const result = await service.getFilesByFolderUuid(folderUuid, status);
-
-      expect(result).toEqual(mockFiles);
-      expect(fileRepository.getFilesByFolderUuid).toHaveBeenCalledWith(
-        folderUuid,
-        status,
-      );
-    });
-  });
-
   describe('hasUploadedFiles', () => {
     it('When user has uploaded files, then it should return true', async () => {
       const mockFile = newFile();

--- a/src/modules/file/file.usecase.ts
+++ b/src/modules/file/file.usecase.ts
@@ -490,13 +490,6 @@ export class FileUseCases {
     };
   }
 
-  async getFilesByFolderUuid(
-    folderUuid: FileAttributes['folderUuid'],
-    status: FileStatus,
-  ) {
-    return this.fileRepository.getFilesByFolderUuid(folderUuid, status);
-  }
-
   getFilesByIds(user: User, fileIds: File['id'][]): Promise<File[]> {
     return this.fileRepository.findByIds(user.id, fileIds);
   }

--- a/src/modules/folder/folder.usecase.spec.ts
+++ b/src/modules/folder/folder.usecase.spec.ts
@@ -27,9 +27,8 @@ import {
 import { CalculateFolderSizeTimeoutException } from './exception/calculate-folder-size-timeout.exception';
 import { SharingService } from '../sharing/sharing.service';
 import { type UpdateFolderMetaDto } from './dto/update-folder-meta.dto';
-import { FileUseCases } from '../file/file.usecase';
 import { FileStatus } from '../file/file.domain';
-import { FeatureLimitService } from '../feature-limit/feature-limit.service';
+import { SequelizeFileRepository } from '../file/file.repository';
 
 const folderId = 4;
 const user = newUser();
@@ -39,8 +38,7 @@ describe('FolderUseCases', () => {
   let folderRepository: SequelizeFolderRepository;
   let cryptoService: CryptoService;
   let sharingService: SharingService;
-  let fileUsecases: FileUseCases;
-  let featureLimitService: FeatureLimitService;
+  let fileRepository: SequelizeFileRepository;
 
   const userMocked = User.build({
     id: 1,
@@ -86,8 +84,9 @@ describe('FolderUseCases', () => {
     );
     cryptoService = module.get<CryptoService>(CryptoService);
     sharingService = module.get<SharingService>(SharingService);
-    fileUsecases = module.get<FileUseCases>(FileUseCases);
-    featureLimitService = module.get<FeatureLimitService>(FeatureLimitService);
+    fileRepository = module.get<SequelizeFileRepository>(
+      SequelizeFileRepository,
+    );
   });
 
   it('should be defined', () => {
@@ -1466,13 +1465,13 @@ describe('FolderUseCases', () => {
         .spyOn(folderRepository, 'findByUuid')
         .mockResolvedValueOnce(rootFolder);
       jest
-        .spyOn(fileUsecases, 'getFilesByFolderUuid')
+        .spyOn(fileRepository, 'getFilesByFolderUuid')
         .mockResolvedValueOnce([fileInRootFolder]);
       jest
         .spyOn(folderRepository, 'findAllByParentUuid')
         .mockResolvedValueOnce([childrenFolder]);
       jest
-        .spyOn(fileUsecases, 'getFilesByFolderUuid')
+        .spyOn(fileRepository, 'getFilesByFolderUuid')
         .mockResolvedValueOnce([]);
 
       // Second iteration mocks for children folder
@@ -1480,7 +1479,7 @@ describe('FolderUseCases', () => {
         .spyOn(folderRepository, 'findByUuid')
         .mockResolvedValueOnce(childrenFolder);
       jest
-        .spyOn(fileUsecases, 'getFilesByFolderUuid')
+        .spyOn(fileRepository, 'getFilesByFolderUuid')
         .mockResolvedValueOnce([]);
       jest
         .spyOn(folderRepository, 'findAllByParentUuid')
@@ -1511,7 +1510,7 @@ describe('FolderUseCases', () => {
         .spyOn(folderRepository, 'findByUuid')
         .mockResolvedValueOnce(rootFolder);
       jest
-        .spyOn(fileUsecases, 'getFilesByFolderUuid')
+        .spyOn(fileRepository, 'getFilesByFolderUuid')
         .mockResolvedValueOnce([fileInRootFolder]);
       jest
         .spyOn(folderRepository, 'findAllByParentUuid')
@@ -1531,7 +1530,7 @@ describe('FolderUseCases', () => {
         .spyOn(folderRepository, 'findByUuid')
         .mockResolvedValueOnce(rootFolder);
       jest
-        .spyOn(fileUsecases, 'getFilesByFolderUuid')
+        .spyOn(fileRepository, 'getFilesByFolderUuid')
         .mockResolvedValueOnce([fileInRootFolder]);
       jest
         .spyOn(folderRepository, 'findAllByParentUuid')
@@ -1539,7 +1538,7 @@ describe('FolderUseCases', () => {
 
       await service.getFolderTree(user, rootFolder.uuid, true);
 
-      expect(fileUsecases.getFilesByFolderUuid).toHaveBeenCalledWith(
+      expect(fileRepository.getFilesByFolderUuid).toHaveBeenCalledWith(
         rootFolder.uuid,
         FileStatus.TRASHED,
       );
@@ -1561,7 +1560,7 @@ describe('FolderUseCases', () => {
         .spyOn(folderRepository, 'findByUuid')
         .mockResolvedValueOnce(rootFolder);
       jest
-        .spyOn(fileUsecases, 'getFilesByFolderUuid')
+        .spyOn(fileRepository, 'getFilesByFolderUuid')
         .mockResolvedValueOnce([fileInRootFolder]);
       jest
         .spyOn(folderRepository, 'findAllByParentUuid')
@@ -1572,7 +1571,7 @@ describe('FolderUseCases', () => {
         .spyOn(folderRepository, 'findByUuid')
         .mockResolvedValueOnce(childrenFolder); // Children folder is fetch again from queue
       jest
-        .spyOn(fileUsecases, 'getFilesByFolderUuid')
+        .spyOn(fileRepository, 'getFilesByFolderUuid')
         .mockResolvedValueOnce([]);
       jest
         .spyOn(folderRepository, 'findAllByParentUuid')
@@ -2293,46 +2292,6 @@ describe('FolderUseCases', () => {
         uuidSort,
       );
       expect(result).toEqual(folders);
-    });
-  });
-  describe('createFolderDevice', () => {
-    it('When plain name is not given, then it should throw an error', async () => {
-      const mockFolderData: Partial<FolderAttributes> = {
-        bucket: 'mock bucket',
-      };
-      await expect(
-        service.createFolderDevice(userMocked, mockFolderData),
-      ).rejects.toThrow(BadRequestException);
-      expect(folderRepository.createFolder).not.toHaveBeenCalled();
-    });
-
-    it('When bucket is not given, then it should throw an error', async () => {
-      const mockFolderData: Partial<FolderAttributes> = {
-        plainName: 'mock plain name',
-      };
-
-      await expect(
-        service.createFolderDevice(userMocked, mockFolderData),
-      ).rejects.toThrow(BadRequestException);
-      expect(folderRepository.createFolder).not.toHaveBeenCalled();
-    });
-
-    it('When both plain name and bucket are given, then it should create a folder', async () => {
-      const mockFolder = newFolder();
-      const mockFolderData: Partial<FolderAttributes> = {
-        plainName: 'mock plain name',
-        bucket: 'mock bucket',
-      };
-      jest
-        .spyOn(folderRepository, 'createFolder')
-        .mockResolvedValue(mockFolder);
-      const result = await service.createFolderDevice(
-        userMocked,
-        mockFolderData,
-      );
-
-      expect(result).toBe(mockFolder);
-      expect(folderRepository.createFolder).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/src/modules/folder/folder.usecase.ts
+++ b/src/modules/folder/folder.usecase.ts
@@ -29,12 +29,11 @@ import { v4 } from 'uuid';
 import { type UpdateFolderMetaDto } from './dto/update-folder-meta.dto';
 import { type FolderStatsDto } from './dto/responses/folder-stats.dto';
 import { type WorkspaceAttributes } from '../workspaces/attributes/workspace.attributes';
-import { FileUseCases } from '../file/file.usecase';
 import { type File, FileStatus } from '../file/file.domain';
 import { type CreateFolderDto } from './dto/create-folder.dto';
 import { type FolderModel } from './folder.model';
 import { type MoveFolderDto } from './dto/move-folder.dto';
-import { FeatureLimitService } from '../feature-limit/feature-limit.service';
+import { SequelizeFileRepository } from '../file/file.repository';
 
 const invalidName = /[\\/]|^\s*$/;
 
@@ -49,10 +48,8 @@ export class FolderUseCases {
     private readonly userRepository: SequelizeUserRepository,
     @Inject(forwardRef(() => SharingService))
     private readonly sharingUsecases: SharingService,
-    @Inject(forwardRef(() => FileUseCases))
-    private readonly fileUsecases: FileUseCases,
+    private readonly fileRepository: SequelizeFileRepository,
     private readonly cryptoService: CryptoService,
-    private readonly featureLimitService: FeatureLimitService,
   ) {}
 
   getFoldersByIds(user: User, folderIds: FolderAttributes['id'][]) {
@@ -143,7 +140,7 @@ export class FolderUseCases {
         throw new ForbiddenException('Folder does not belong to you!');
       }
 
-      folder.files = await this.fileUsecases.getFilesByFolderUuid(
+      folder.files = await this.fileRepository.getFilesByFolderUuid(
         folder.uuid,
         deleted ? FileStatus.TRASHED : FileStatus.EXISTS,
       );
@@ -288,13 +285,6 @@ export class FolderUseCases {
         };
       }),
     );
-  }
-
-  async createFolderDevice(user: User, folderData: Partial<FolderAttributes>) {
-    if (!folderData.plainName || !folderData.bucket) {
-      throw new BadRequestException('Folder name and bucket are required');
-    }
-    return this.folderRepository.createFolder(user.id, folderData);
   }
 
   async updateFolderMetaData(


### PR DESCRIPTION
## What
Some queries were missing a LIMIT 1, causing us to fetch all folders/files inside a backup just for a simple "isEmpty" check.
## Changes

- Removed circular dependency between folderUsecases and fileUsecases.
- Fetch only 1 folder when checking the availability of a backup name.
- Fetch only 1 folder and 1 file when checking whether the device has any backups.