### PR TITLE
[_] fix: add parent_uuid support to folder sync queries

### DIFF
--- a/migrations/20260416141407-modify-idx-folders-user-parent-updated-index.js
+++ b/migrations/20260416141407-modify-idx-folders-user-parent-updated-index.js
@@ -1,0 +1,28 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.sequelize.query(`
+      CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_folders_user_id_updated_at_parent_uuid_not_null
+      ON folders (user_id, updated_at)
+      WHERE parent_uuid IS NOT NULL;
+    `);
+
+    await queryInterface.sequelize.query(`
+      DROP INDEX CONCURRENTLY IF EXISTS idx_folders_user_parent_updated;
+    `);
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.sequelize.query(`
+      CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_folders_user_parent_updated
+      ON folders (user_id, updated_at)
+      WHERE parent_id IS NOT NULL;
+    `);
+
+    await queryInterface.sequelize.query(`
+      DROP INDEX CONCURRENTLY IF EXISTS idx_folders_user_id_updated_at_parent_uuid_not_null;
+    `);
+  },
+};

--- a/src/modules/folder/folder.repository.spec.ts
+++ b/src/modules/folder/folder.repository.spec.ts
@@ -186,7 +186,7 @@ describe('SequelizeFolderRepository', () => {
         where: {
           ...whereClause,
           updatedAt: { [Op.gt]: updatedAfter },
-          parentId: { [Op.not]: null },
+          parentUuid: { [Op.not]: null },
         },
         include: [
           {

--- a/src/modules/folder/folder.repository.ts
+++ b/src/modules/folder/folder.repository.ts
@@ -849,7 +849,7 @@ export class SequelizeFolderRepository implements FolderRepository {
         updatedAt: {
           [Op.gt]: updatedAfter,
         },
-        parentId: {
+        parentUuid: {
           [Op.not]: null,
         },
       },


### PR DESCRIPTION
## What

We fixed the folder sync a few weeks ago by adding a new index, but the query changed to `parentUuid`, so folder sync is slower again.

Let's standardize the indexes and queries to use `parentUuid`.

## Changes
- Changed index name and predicate
- Changed workspace's folder listing / sync query to `WHERE parent_uuid: NULL`.

## Benchmark

Before (index with parent_id IS NOT NULL)
```sql
Limit  (cost=18.21..18.22 rows=1 width=137) (actual time=0.190..0.192 rows=0 loops=1)
  Buffers: shared hit=6
  ->  Sort  (cost=18.21..18.22 rows=1 width=137) (actual time=0.189..0.190 rows=0 loops=1)
        Sort Key: updated_at
        Sort Method: quicksort  Memory: 25kB
        Buffers: shared hit=6
        ->  Bitmap Heap Scan on folders "FolderModel"  (cost=14.19..18.20 rows=1 width=137) (actual time=0.154..0.155 rows=0 loops=1)
              Recheck Cond: ((user_id = 10001) AND (parent_uuid IS NOT NULL))
              Filter: (updated_at > '2026-04-16 12:26:00+00'::timestamp with time zone)
              Buffers: shared hit=6
              ->  BitmapAnd  (cost=14.19..14.19 rows=1 width=0) (actual time=0.146..0.147 rows=0 loops=1)
                    Buffers: shared hit=6
                    ->  Bitmap Index Scan on user_id_folders_index  (cost=0.00..4.46 rows=4 width=0) (actual time=0.080..0.080 rows=11 loops=1)
                          Index Cond: (user_id = 10001)
                          Buffers: shared hit=3
                    ->  Bitmap Index Scan on folders_parent_uuid_index  (cost=0.00..9.48 rows=140 width=0) (actual time=0.063..0.063 rows=35 loops=1)
                          Index Cond: (parent_uuid IS NOT NULL)
                          Buffers: shared hit=3
Planning:
  Buffers: shared hit=19 read=1
Planning Time: 1.796 ms
Execution Time: 0.347 ms
```

After index:

```sql
Limit  (cost=0.14..8.16 rows=1 width=137) (actual time=0.079..0.080 rows=0 loops=1)
  Buffers: shared hit=1
  ->  Index Scan using idx_folders_user_parent_updated on folders "FolderModel"  (cost=0.14..8.16 rows=1 width=137) (actual time=0.070..0.070 rows=0 loops=1)
        Index Cond: ((user_id = 10001) AND (updated_at > '2026-04-16 12:26:00+00'::timestamp with time zone))
        Buffers: shared hit=1
Planning Time: 0.507 ms
Execution Time: 0.116 ms
```
