### PR TITLE
[_] fix: do not list removed devices

### DIFF
--- a/src/modules/backups/backup.usecase.ts
+++ b/src/modules/backups/backup.usecase.ts
@@ -142,6 +142,8 @@ export class BackupUseCase {
 
     const folders = await this.folderUsecases.getFoldersByUserId(user.id, {
       bucket: user.backupsBucket,
+      removed: false,
+      deleted: false,
     });
 
     return Promise.all(


### PR DESCRIPTION
## What
I got a report by the macOS team claiming this endpoint was too slow. 

We weren't filtering out removed devices, causing empty checks to run against deleted devices. This is not a common situation, but users with many deleted backups could be affected.

We still have a 1 + N issue, but given how infrequent this operation is, let's monitor it for now.