### PR TITLE
[_] fix/reduce stats limit

### DIFF
--- a/src/modules/folder/folder.repository.spec.ts
+++ b/src/modules/folder/folder.repository.spec.ts
@@ -1152,7 +1152,7 @@ describe('SequelizeFolderRepository', () => {
       const mockResult = {
         file_count: '0',
         total_size: '0',
-        total_files_found: '0',
+        max_depth: null,
       };
 
       jest
@@ -1171,7 +1171,7 @@ describe('SequelizeFolderRepository', () => {
       const mockResult = {
         file_count: '500',
         total_size: '5000000',
-        total_files_found: '500',
+        max_depth: '5',
       };
 
       jest
@@ -1188,9 +1188,9 @@ describe('SequelizeFolderRepository', () => {
 
     it('When folder reaches maximum file count, then it should return exact count at boundary', async () => {
       const mockResult = {
-        file_count: '1000',
+        file_count: '10000',
         total_size: '10000000',
-        total_files_found: '1000',
+        max_depth: '5',
       };
 
       jest
@@ -1199,15 +1199,15 @@ describe('SequelizeFolderRepository', () => {
 
       const result = await repository.calculateFolderStats(folder.uuid);
 
-      expect(result.fileCount).toBe(1000);
+      expect(result.fileCount).toBe(10000);
       expect(result.isFileCountExact).toBe(true);
     });
 
     it('When folder exceeds maximum file count, then it should cap count and mark as approximate', async () => {
       const mockResult = {
-        file_count: '1500',
+        file_count: '10001',
         total_size: '15000000',
-        total_files_found: '1500',
+        max_depth: '5',
       };
 
       jest
@@ -1216,15 +1216,15 @@ describe('SequelizeFolderRepository', () => {
 
       const result = await repository.calculateFolderStats(folder.uuid);
 
-      expect(result.fileCount).toBe(1000);
+      expect(result.fileCount).toBe(10000);
       expect(result.isFileCountExact).toBe(false);
     });
 
     it('When folder exceeds maximum total items, then it should mark size as approximate', async () => {
       const mockResult = {
-        file_count: '12000',
+        file_count: '10001',
         total_size: '50000000',
-        total_files_found: '12000',
+        max_depth: '5',
       };
 
       jest
@@ -1241,7 +1241,7 @@ describe('SequelizeFolderRepository', () => {
       const mockResult = {
         file_count: '9973',
         total_size: '27634171904',
-        total_files_found: '9973',
+        max_depth: '10',
       };
 
       jest
@@ -1250,29 +1250,17 @@ describe('SequelizeFolderRepository', () => {
 
       const result = await repository.calculateFolderStats(folder.uuid);
 
-      expect(result.fileCount).toBe(1000);
+      expect(result.fileCount).toBe(9973);
       expect(result.totalSize).toBe(27634171904);
-      expect(result.isFileCountExact).toBe(false);
+      expect(result.isFileCountExact).toBe(true);
       expect(result.isTotalSizeExact).toBe(true);
-    });
-
-    it('When stats calculation times out, then it should throw timeout exception', async () => {
-      jest.spyOn(FolderModel.sequelize, 'query').mockRejectedValueOnce({
-        original: {
-          code: TIMEOUT_ERROR_CODE,
-        },
-      });
-
-      await expect(
-        repository.calculateFolderStats(folder.uuid),
-      ).rejects.toThrow(CalculateFolderSizeTimeoutException);
     });
 
     it('When folder stats are requested, then only existent files are counted', async () => {
       const mockResult = {
         file_count: '100',
         total_size: '1000000',
-        total_files_found: '100',
+        max_depth: '5',
       };
 
       jest
@@ -1286,7 +1274,9 @@ describe('SequelizeFolderRepository', () => {
         {
           replacements: {
             folderUuid: folder.uuid,
-            fileStatusCondition: [FileStatus.EXISTS],
+            maxDepth: 50,
+            fileStatus: FileStatus.EXISTS,
+            maxFiles: 10001,
           },
         },
       );

--- a/src/modules/folder/folder.repository.spec.ts
+++ b/src/modules/folder/folder.repository.spec.ts
@@ -1188,7 +1188,7 @@ describe('SequelizeFolderRepository', () => {
 
     it('When folder reaches maximum file count, then it should return exact count at boundary', async () => {
       const mockResult = {
-        file_count: '10000',
+        file_count: '1000',
         total_size: '10000000',
         max_depth: '5',
       };
@@ -1199,13 +1199,13 @@ describe('SequelizeFolderRepository', () => {
 
       const result = await repository.calculateFolderStats(folder.uuid);
 
-      expect(result.fileCount).toBe(10000);
+      expect(result.fileCount).toBe(1000);
       expect(result.isFileCountExact).toBe(true);
     });
 
     it('When folder exceeds maximum file count, then it should cap count and mark as approximate', async () => {
       const mockResult = {
-        file_count: '10001',
+        file_count: '1001',
         total_size: '15000000',
         max_depth: '5',
       };
@@ -1216,13 +1216,13 @@ describe('SequelizeFolderRepository', () => {
 
       const result = await repository.calculateFolderStats(folder.uuid);
 
-      expect(result.fileCount).toBe(10000);
+      expect(result.fileCount).toBe(1000);
       expect(result.isFileCountExact).toBe(false);
     });
 
     it('When folder exceeds maximum total items, then it should mark size as approximate', async () => {
       const mockResult = {
-        file_count: '10001',
+        file_count: '1001',
         total_size: '50000000',
         max_depth: '5',
       };
@@ -1239,7 +1239,7 @@ describe('SequelizeFolderRepository', () => {
 
     it('When folder has deep hierarchy, then it should include files from all nested levels', async () => {
       const mockResult = {
-        file_count: '9973',
+        file_count: '973',
         total_size: '27634171904',
         max_depth: '10',
       };
@@ -1250,7 +1250,7 @@ describe('SequelizeFolderRepository', () => {
 
       const result = await repository.calculateFolderStats(folder.uuid);
 
-      expect(result.fileCount).toBe(9973);
+      expect(result.fileCount).toBe(973);
       expect(result.totalSize).toBe(27634171904);
       expect(result.isFileCountExact).toBe(true);
       expect(result.isTotalSizeExact).toBe(true);
@@ -1276,7 +1276,7 @@ describe('SequelizeFolderRepository', () => {
             folderUuid: folder.uuid,
             maxDepth: 50,
             fileStatus: FileStatus.EXISTS,
-            maxFiles: 10001,
+            maxFiles: 1001,
           },
         },
       );

--- a/src/modules/folder/folder.repository.ts
+++ b/src/modules/folder/folder.repository.ts
@@ -939,7 +939,7 @@ export class SequelizeFolderRepository implements FolderRepository {
     totalSize: number;
     isTotalSizeExact: boolean;
   }> {
-    const MAX_FILES = 10000;
+    const MAX_FILES = 1000;
     const MAX_DEPTH = 50;
 
     const calculateStatsQuery = `
@@ -994,13 +994,13 @@ export class SequelizeFolderRepository implements FolderRepository {
       },
     );
 
-    const fileCount = Number.parseInt(result.file_count);
-    const hitFileLimit = fileCount > MAX_FILES;
+    const rawFileCount = Number.parseInt(result.file_count);
+    const hitFileLimit = rawFileCount > MAX_FILES;
     const hitDepthLimit = Number.parseInt(result.max_depth) >= MAX_DEPTH;
     const isExact = !hitFileLimit && !hitDepthLimit;
 
     return {
-      fileCount: Math.min(fileCount, MAX_FILES),
+      fileCount: hitFileLimit ? MAX_FILES : rawFileCount,
       totalSize: Number.parseInt(result.total_size),
       isFileCountExact: isExact,
       isTotalSizeExact: isExact,

--- a/src/modules/folder/folder.repository.ts
+++ b/src/modules/folder/folder.repository.ts
@@ -939,16 +939,16 @@ export class SequelizeFolderRepository implements FolderRepository {
     totalSize: number;
     isTotalSizeExact: boolean;
   }> {
-    try {
-      const fileStatusCondition = [FileStatus.EXISTS];
+    const MAX_FILES = 10000;
+    const MAX_DEPTH = 50;
 
-      const calculateStatsQuery = `
+    const calculateStatsQuery = `
       WITH RECURSIVE folder_recursive AS (
         SELECT
           fl1.uuid,
           fl1.parent_uuid,
-          1 as depth,
-          fl1.user_id as owner_id
+          1 AS depth,
+          fl1.user_id AS owner_id
         FROM folders fl1
         WHERE fl1.uuid = :folderUuid
           AND fl1.removed = FALSE
@@ -962,57 +962,49 @@ export class SequelizeFolderRepository implements FolderRepository {
           fr.depth + 1,
           fr.owner_id
         FROM folders fl2
-        INNER JOIN folder_recursive fr
-          ON fr.uuid = fl2.parent_uuid
-        WHERE fr.depth < 100000
+        INNER JOIN folder_recursive fr ON fr.uuid = fl2.parent_uuid
+        WHERE fr.depth < :maxDepth
           AND fl2.user_id = fr.owner_id
           AND fl2.removed = FALSE
           AND fl2.deleted = FALSE
       ),
-      ranked_files AS (
-        SELECT
-          f.uuid,
-          f.size,
-          ROW_NUMBER() OVER (ORDER BY f.creation_time) as rn
+      limited_files AS (
+        SELECT f.uuid, f.size, fr.depth
         FROM folder_recursive fr
-        INNER JOIN files f
-          ON f.folder_uuid = fr.uuid
-          AND f.status IN (:fileStatusCondition)
+        INNER JOIN files f ON f.folder_uuid = fr.uuid
+        WHERE f.status = :fileStatus
+        LIMIT :maxFiles
       )
       SELECT
-        COUNT(uuid) as file_count,
-        COALESCE(SUM(size), 0) as total_size,
-        MAX(rn) as total_files_found
-      FROM ranked_files
-      WHERE rn <= 10000;
+        COUNT(*) AS file_count,
+        COALESCE(SUM(size), 0) AS total_size,
+        MAX(depth) AS max_depth
+      FROM limited_files
       `;
 
-      const [[result]]: any = await FolderModel.sequelize.query(
-        calculateStatsQuery,
-        {
-          replacements: {
-            folderUuid,
-            fileStatusCondition,
-          },
+    const [[result]]: any = await FolderModel.sequelize.query(
+      calculateStatsQuery,
+      {
+        replacements: {
+          folderUuid,
+          maxDepth: MAX_DEPTH,
+          fileStatus: FileStatus.EXISTS,
+          maxFiles: MAX_FILES + 1,
         },
-      );
+      },
+    );
 
-      const fileCount = Number.parseInt(result.file_count);
-      const totalFilesFound = Number.parseInt(result.total_files_found || 0);
+    const fileCount = Number.parseInt(result.file_count);
+    const hitFileLimit = fileCount > MAX_FILES;
+    const hitDepthLimit = Number.parseInt(result.max_depth) >= MAX_DEPTH;
+    const isExact = !hitFileLimit && !hitDepthLimit;
 
-      return {
-        fileCount: Math.min(fileCount, 1000),
-        isFileCountExact: totalFilesFound <= 1000,
-        totalSize: Number.parseInt(result.total_size),
-        isTotalSizeExact: totalFilesFound < 10000,
-      };
-    } catch (error) {
-      if (error.original?.code === '57014') {
-        throw new CalculateFolderSizeTimeoutException();
-      }
-
-      throw error;
-    }
+    return {
+      fileCount: Math.min(fileCount, MAX_FILES),
+      totalSize: Number.parseInt(result.total_size),
+      isFileCountExact: isExact,
+      isTotalSizeExact: isExact,
+    };
   }
 
   async getDeletedFoldersWithNotDeletedChildren(options: {


### PR DESCRIPTION
## What

This query is not the most performant, but we still have an ORDER BY creation_time which is not an indexed field.

Also, we we're looking for 10K files while just returning 1K, so there's no point on the extra load on the DB.

## Changes

1. Removed order by creation_time as it adds no value here.
2. Reduced files limit to 1K as discussed. (looks for 1001)
3. Reduce depth to 50.


## Benchmark

New:
```sql
Aggregate  (cost=1131.27..1131.28 rows=1 width=44) (actual time=13.068..13.072 rows=1 loops=1)
  Buffers: shared hit=727
  CTE folder_recursive
    ->  Recursive Union  (cost=0.57..82.90 rows=11 width=40) (actual time=0.019..0.103 rows=21 loops=1)
          Buffers: shared hit=52
          ->  Index Scan using uuid_index on folders fl1  (cost=0.57..2.59 rows=1 width=40) (actual time=0.017..0.018 rows=1 loops=1)
                Index Cond: (uuid = '451a7bfe-ed44-43d6-a25b-41670a1d6ecd'::uuid)
                Filter: ((NOT removed) AND (NOT deleted))
                Buffers: shared hit=5
          ->  Nested Loop  (cost=0.57..8.02 rows=1 width=40) (actual time=0.022..0.037 rows=10 loops=2)
                Buffers: shared hit=47
                ->  WorkTable Scan on folder_recursive fr_1  (cost=0.00..0.22 rows=3 width=24) (actual time=0.001..0.001 rows=4 loops=2)
                      Filter: (depth < 50)
                ->  Index Scan using idx_folders_user_parentuuid_plainname_not_deleted_removed on folders fl2  (cost=0.57..2.59 rows=1 width=36) (actual time=0.005..0.009 rows=3 loops=7)
                      Index Cond: ((user_id = fr_1.owner_id) AND (parent_uuid = fr_1.uuid))
                      Buffers: shared hit=47
  ->  Limit  (cost=0.57..1030.86 rows=1001 width=28) (actual time=0.046..12.967 rows=1001 loops=1)
        Buffers: shared hit=727
        ->  Nested Loop  (cost=0.57..12832.27 rows=12467 width=28) (actual time=0.045..12.853 rows=1001 loops=1)
              Buffers: shared hit=727
              ->  CTE Scan on folder_recursive fr  (cost=0.00..0.22 rows=11 width=20) (actual time=0.021..0.114 rows=21 loops=1)
                    Buffers: shared hit=52
              ->  Index Scan using idx_files_folder_user_exists on files f  (cost=0.57..1155.22 rows=1133 width=24) (actual time=0.010..0.601 rows=48 loops=21)
                    Index Cond: (folder_uuid = fr.uuid)
                    Buffers: shared hit=675
Planning:
  Buffers: shared hit=10
Planning Time: 0.963 ms
Execution Time: 17.968 ms
```

Old
```sql
Aggregate  (cost=14199.63..14199.64 rows=1 width=48) (actual time=14.332..14.335 rows=1 loops=1)
  Buffers: shared hit=1535
  CTE folder_recursive
    ->  Recursive Union  (cost=0.57..82.90 rows=11 width=40) (actual time=0.015..0.273 rows=53 loops=1)
          Buffers: shared hit=265
          ->  Index Scan using uuid_index on folders fl1  (cost=0.57..2.59 rows=1 width=40) (actual time=0.014..0.015 rows=1 loops=1)
                Index Cond: (uuid = '451a7bfe-ed44-43d6-a25b-41670a1d6ecd'::uuid)
                Filter: ((NOT removed) AND (NOT deleted))
                Buffers: shared hit=5
          ->  Nested Loop  (cost=0.57..8.02 rows=1 width=40) (actual time=0.017..0.048 rows=10 loops=5)
                Buffers: shared hit=260
                ->  WorkTable Scan on folder_recursive fr_1  (cost=0.00..0.22 rows=3 width=24) (actual time=0.000..0.002 rows=11 loops=5)
                      Filter: (depth < 20)
                ->  Index Scan using idx_folders_user_parentuuid_plainname_not_deleted_removed on folders fl2  (cost=0.57..2.59 rows=1 width=36) (actual time=0.003..0.004 rows=1 loops=53)
                      Index Cond: ((user_id = fr_1.owner_id) AND (parent_uuid = fr_1.uuid))
                      Buffers: shared hit=260
  ->  WindowAgg  (cost=13680.41..13898.56 rows=12467 width=40) (actual time=10.886..14.188 rows=1662 loops=1)
        Run Condition: (row_number() OVER (?) <= 10000)
        Buffers: shared hit=1535
        ->  Sort  (cost=13680.39..13711.56 rows=12467 width=32) (actual time=10.880..10.970 rows=1662 loops=1)
              Sort Key: f.creation_time
              Sort Method: quicksort  Memory: 126kB
              Buffers: shared hit=1535
              ->  Nested Loop  (cost=0.57..12832.27 rows=12467 width=32) (actual time=0.030..2.365 rows=1662 loops=1)
                    Buffers: shared hit=1535
                    ->  CTE Scan on folder_recursive fr  (cost=0.00..0.22 rows=11 width=16) (actual time=0.017..0.299 rows=53 loops=1)
                          Buffers: shared hit=265
                    ->  Index Scan using idx_files_folder_user_exists on files f  (cost=0.57..1155.22 rows=1133 width=48) (actual time=0.007..0.035 rows=31 loops=53)
                          Index Cond: (folder_uuid = fr.uuid)
                          Buffers: shared hit=1270
Planning:
  Buffers: shared hit=14
Planning Time: 0.711 ms
Execution Time: 14.414 ms
```