### PR TITLE
[PB-1960]: feat/add MailService for email handling and integrate with AuthController

### DIFF
--- a/src/config/configuration.ts
+++ b/src/config/configuration.ts
@@ -70,6 +70,9 @@ export default () => ({
     payments: {
       url: process.env.PAYMENTS_API_URL,
     },
+    mail: {
+      url: process.env.MAIL_API_URL,
+    },
   },
   apn: {
     url: process.env.APN_URL,

--- a/src/config/configuration.ts
+++ b/src/config/configuration.ts
@@ -71,6 +71,9 @@ export default () => ({
     payments: {
       url: process.env.PAYMENTS_API_URL,
     },
+    mail: {
+      url: process.env.MAIL_API_URL,
+    },
   },
   apn: {
     url: process.env.APN_URL,

--- a/src/externals/mail/mail.module.ts
+++ b/src/externals/mail/mail.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
+import { HttpClientModule } from '../http/http.module';
+import { MailService } from './mail.service';
+
+@Module({
+  imports: [ConfigModule, HttpClientModule],
+  controllers: [],
+  providers: [MailService],
+  exports: [MailService],
+})
+export class MailServiceModule {}

--- a/src/externals/mail/mail.service.spec.ts
+++ b/src/externals/mail/mail.service.spec.ts
@@ -1,0 +1,104 @@
+import { Test, type TestingModule } from '@nestjs/testing';
+import { type Logger } from '@nestjs/common';
+import { createMock } from '@golevelup/ts-jest';
+import { ConfigService } from '@nestjs/config';
+import { type AxiosResponse, type InternalAxiosRequestConfig } from 'axios';
+import { HttpClient } from '../http/http.service';
+import { MailService } from './mail.service';
+
+jest.mock('jsonwebtoken', () => ({
+  sign: jest.fn().mockReturnValue('mock-gateway-jwt'),
+}));
+
+describe('MailService', () => {
+  let service: MailService;
+  let configService: ConfigService;
+  let httpClient: HttpClient;
+
+  const emptyAxiosResponse = <T>(data: T): AxiosResponse<T> => ({
+    data,
+    status: 200,
+    statusText: 'OK',
+    headers: {},
+    config: {} as InternalAxiosRequestConfig,
+  });
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        MailService,
+        { provide: ConfigService, useValue: { get: jest.fn() } },
+        { provide: HttpClient, useValue: { get: jest.fn() } },
+      ],
+    })
+      .setLogger(createMock<Logger>())
+      .compile();
+
+    service = module.get(MailService);
+    configService = module.get(ConfigService);
+    httpClient = module.get(HttpClient);
+  });
+
+  describe('findUserIdByAddress', () => {
+    const baseUrl = 'https://mail.test';
+
+    beforeEach(() => {
+      jest.spyOn(configService, 'get').mockImplementation((key: string) => {
+        if (key === 'apis.mail.url') return baseUrl;
+        if (key === 'isDevelopment') return false;
+        if (key === 'secrets.gateway') return 'ZHVtbXk=';
+        return undefined;
+      });
+    });
+
+    it('When the gateway returns a userId, then it returns that userId', async () => {
+      const address = 'alias@inxt.eu';
+      const userId = 'resolved-user-uuid';
+      jest
+        .spyOn(httpClient, 'get')
+        .mockResolvedValueOnce(emptyAxiosResponse({ userId }));
+
+      const result = await service.findUserIdByAddress(address);
+
+      expect(result).toBe(userId);
+      expect(httpClient.get).toHaveBeenCalledWith(
+        `${baseUrl}/gateway/addresses/${encodeURIComponent(address)}`,
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            Authorization: 'Bearer mock-gateway-jwt',
+            'Content-Type': 'application/json',
+          }),
+        }),
+      );
+    });
+
+    it('When the gateway returns no userId, then it returns null', async () => {
+      jest
+        .spyOn(httpClient, 'get')
+        .mockResolvedValueOnce(emptyAxiosResponse({}));
+
+      const result = await service.findUserIdByAddress('a@inxt.eu');
+
+      expect(result).toBeNull();
+    });
+
+    it('When the gateway responds with 404, then it returns null', async () => {
+      jest.spyOn(httpClient, 'get').mockRejectedValueOnce({
+        response: { status: 404 },
+      });
+
+      const result = await service.findUserIdByAddress('missing@inxt.eu');
+
+      expect(result).toBeNull();
+    });
+
+    it('When the gateway responds with a non-404 error, then it propagates the error', async () => {
+      const err = new Error('upstream');
+      jest.spyOn(httpClient, 'get').mockRejectedValueOnce(err);
+
+      await expect(service.findUserIdByAddress('a@inxt.eu')).rejects.toThrow(
+        err,
+      );
+    });
+  });
+});

--- a/src/externals/mail/mail.service.ts
+++ b/src/externals/mail/mail.service.ts
@@ -1,0 +1,55 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { sign } from 'jsonwebtoken';
+import { ConfigService } from '@nestjs/config';
+import { HttpClient } from '../http/http.service';
+
+function signToken(duration: string, secret: string, isDevelopment?: boolean) {
+  return sign({}, Buffer.from(secret, 'base64').toString('utf8'), {
+    algorithm: 'RS256',
+    expiresIn: duration,
+    ...(isDevelopment ? { allowInsecureKeySizes: true } : null),
+  });
+}
+
+@Injectable()
+export class MailService {
+  constructor(
+    @Inject(ConfigService)
+    private readonly configService: ConfigService,
+    @Inject(HttpClient)
+    private readonly httpClient: HttpClient,
+  ) {}
+
+  private getAuthHeaders() {
+    const isDevelopment = this.configService.get('isDevelopment');
+    const jwt = signToken(
+      '5m',
+      this.configService.get('secrets.gateway'),
+      isDevelopment,
+    );
+
+    return {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${jwt}`,
+    };
+  }
+
+  async findUserIdByAddress(address: string): Promise<string | null> {
+    const baseUrl = this.configService.get('apis.mail.url');
+    const headers = this.getAuthHeaders();
+
+    try {
+      const res = await this.httpClient.get(
+        `${baseUrl}/gateway/addresses/${encodeURIComponent(address)}`,
+        { headers },
+      );
+
+      return res.data?.userId ?? null;
+    } catch (error) {
+      if (error?.response?.status === 404) {
+        return null;
+      }
+      throw error;
+    }
+  }
+}

--- a/src/externals/mail/mail.service.ts
+++ b/src/externals/mail/mail.service.ts
@@ -1,10 +1,10 @@
 import { Inject, Injectable } from '@nestjs/common';
-import { sign } from 'jsonwebtoken';
+import { signWithExpiry } from '../../middlewares/passport';
 import { ConfigService } from '@nestjs/config';
 import { HttpClient } from '../http/http.service';
 
 function signToken(duration: string, secret: string, isDevelopment?: boolean) {
-  return sign({}, Buffer.from(secret, 'base64').toString('utf8'), {
+  return signWithExpiry({}, Buffer.from(secret, 'base64').toString('utf8'), {
     algorithm: 'RS256',
     expiresIn: duration,
     ...(isDevelopment ? { allowInsecureKeySizes: true } : null),

--- a/src/modules/auth/auth.controller.spec.ts
+++ b/src/modules/auth/auth.controller.spec.ts
@@ -24,6 +24,7 @@ import { FeatureLimitService } from '../feature-limit/feature-limit.service';
 import { PaymentRequiredException } from '../feature-limit/exceptions/payment-required.exception';
 import { PlatformName } from '../../common/constants';
 import { ClientEnum } from '../../common/enums/platform.enum';
+import { MailService } from '../../externals/mail/mail.service';
 
 describe('AuthController', () => {
   let authController: AuthController;
@@ -32,6 +33,7 @@ describe('AuthController', () => {
   let cryptoService: DeepMocked<CryptoService>;
   let twoFactorAuthService: DeepMocked<TwoFactorAuthService>;
   let featureLimitService: DeepMocked<FeatureLimitService>;
+  let mailService: DeepMocked<MailService>;
 
   beforeEach(async () => {
     const moduleRef = await Test.createTestingModule({
@@ -46,6 +48,7 @@ describe('AuthController', () => {
     cryptoService = moduleRef.get(CryptoService);
     twoFactorAuthService = moduleRef.get(TwoFactorAuthService);
     featureLimitService = moduleRef.get(FeatureLimitService);
+    mailService = moduleRef.get(MailService);
   });
 
   it('should be defined', () => {
@@ -105,6 +108,73 @@ describe('AuthController', () => {
       await authController.login(body);
 
       expect(userUseCases.findByEmail).toHaveBeenCalledWith(emailLowerCase);
+    });
+
+    it('When the email is not a managed mail domain, then it should not call the mail gateway', async () => {
+      const loginDto = new LoginDto();
+      loginDto.email = 'user@gmail.com';
+      const user = newUser({ attributes: { email: loginDto.email } });
+
+      jest.spyOn(userUseCases, 'findByEmail').mockResolvedValueOnce(user);
+      jest.spyOn(keyServerUseCases, 'findUserKeys').mockResolvedValueOnce({
+        ecc: newKeyServer({ userId: user.id }),
+        kyber: null,
+      });
+      jest.spyOn(cryptoService, 'encryptText').mockReturnValue('x');
+
+      await authController.login(loginDto);
+
+      expect(mailService.findUserIdByAddress).not.toHaveBeenCalled();
+    });
+
+    it('When the email is managed and the gateway resolves a primary email, then findByEmail uses the primary email', async () => {
+      const loginDto = new LoginDto();
+      loginDto.email = 'alias@inxt.eu';
+      const canonicalEmail = 'primary@gmail.com';
+      const resolvedUuid = v4();
+      const loginUser = newUser({
+        attributes: { email: canonicalEmail, id: 9 },
+      });
+
+      jest
+        .spyOn(mailService, 'findUserIdByAddress')
+        .mockResolvedValueOnce(resolvedUuid);
+      jest.spyOn(userUseCases, 'findByUuid').mockResolvedValueOnce(loginUser);
+      jest.spyOn(userUseCases, 'findByEmail').mockResolvedValueOnce(loginUser);
+      jest.spyOn(keyServerUseCases, 'findUserKeys').mockResolvedValueOnce({
+        ecc: newKeyServer({ userId: loginUser.id }),
+        kyber: null,
+      });
+      jest.spyOn(cryptoService, 'encryptText').mockReturnValue('encryptedText');
+
+      await authController.login(loginDto);
+
+      expect(mailService.findUserIdByAddress).toHaveBeenCalledWith(
+        loginDto.email,
+      );
+      expect(userUseCases.findByUuid).toHaveBeenCalledWith(resolvedUuid);
+      expect(userUseCases.findByEmail).toHaveBeenCalledWith(canonicalEmail);
+    });
+
+    it('When the email is managed but the gateway finds no user, then findByEmail uses the original address', async () => {
+      const loginDto = new LoginDto();
+      loginDto.email = 'unknown@inxt.me';
+      const user = newUser({ attributes: { email: loginDto.email } });
+
+      jest
+        .spyOn(mailService, 'findUserIdByAddress')
+        .mockResolvedValueOnce(null);
+      jest.spyOn(userUseCases, 'findByEmail').mockResolvedValueOnce(user);
+      jest.spyOn(keyServerUseCases, 'findUserKeys').mockResolvedValueOnce({
+        ecc: newKeyServer({ userId: user.id }),
+        kyber: null,
+      });
+      jest.spyOn(cryptoService, 'encryptText').mockReturnValue('encryptedText');
+
+      await authController.login(loginDto);
+
+      expect(userUseCases.findByUuid).not.toHaveBeenCalled();
+      expect(userUseCases.findByEmail).toHaveBeenCalledWith(loginDto.email);
     });
   });
 
@@ -189,6 +259,41 @@ describe('AuthController', () => {
           kyber: {
             ...kyberKey.toJSON(),
           },
+        },
+      });
+    });
+
+    it('When the email is managed and resolves to a primary account, then loginAccess receives the resolved email', async () => {
+      const dto = { ...loginAccessDto };
+      dto.email = 'alias@inxt.eu';
+      const canonicalEmail = 'primary@gmail.com';
+      const eccKey = newKeyServer({ ...dto });
+      const driveUser = newUser({ attributes: { email: canonicalEmail } });
+
+      jest.spyOn(keyServerUseCases, 'parseKeysInput').mockReturnValueOnce({
+        ecc: eccKey.toJSON(),
+        kyber: null,
+      });
+      jest
+        .spyOn(mailService, 'findUserIdByAddress')
+        .mockResolvedValueOnce(driveUser.uuid);
+      jest.spyOn(userUseCases, 'findByUuid').mockResolvedValueOnce(driveUser);
+      jest
+        .spyOn(userUseCases, 'loginAccess')
+        .mockResolvedValueOnce({ success: true } as any);
+
+      await authController.loginAccess(dto);
+
+      expect(userUseCases.loginAccess).toHaveBeenCalledWith({
+        ...dto,
+        email: canonicalEmail,
+        keys: {
+          ecc: {
+            publicKey: eccKey.publicKey,
+            privateKey: eccKey.privateKey,
+            revocationKey: eccKey.revocationKey,
+          },
+          kyber: null,
         },
       });
     });

--- a/src/modules/auth/auth.controller.ts
+++ b/src/modules/auth/auth.controller.ts
@@ -48,6 +48,8 @@ import { FeatureLimitService } from '../feature-limit/feature-limit.service';
 import { PaymentRequiredException } from '../feature-limit/exceptions/payment-required.exception';
 import { Client } from '../../common/decorators/client.decorator';
 import { type ClientEnum } from '../../common/enums/platform.enum';
+import { MailService } from '../../externals/mail/mail.service';
+import { isManagedMailDomain } from './managed-mail-domains';
 
 @ApiTags('Auth')
 @Controller('auth')
@@ -60,7 +62,18 @@ export class AuthController {
     private readonly twoFactorAuthService: TwoFactorAuthService,
     private readonly authUseCases: AuthUsecases,
     private readonly featureLimitService: FeatureLimitService,
+    private readonly mailService: MailService,
   ) {}
+
+  private async resolveLoginEmail(email: string): Promise<string> {
+    if (!isManagedMailDomain(email)) return email;
+
+    const userId = await this.mailService.findUserIdByAddress(email);
+    if (!userId) return email;
+
+    const user = await this.userUseCases.findByUuid(userId);
+    return user?.email ?? email;
+  }
 
   @Post('/login')
   @HttpCode(HttpStatus.OK)
@@ -70,7 +83,7 @@ export class AuthController {
   @ApiOkResponse({ description: 'Retrieve details', type: LoginResponseDto })
   @Public()
   async login(@Body() body: LoginDto): Promise<LoginResponseDto> {
-    const email = body.email.toLowerCase();
+    const email = await this.resolveLoginEmail(body.email.toLowerCase());
 
     const user = await this.userUseCases.findByEmail(email);
 
@@ -128,8 +141,11 @@ export class AuthController {
         revocationKey: body.revocateKey,
       });
 
+      const email = await this.resolveLoginEmail(body.email.toLowerCase());
+
       const result = await this.userUseCases.loginAccess({
         ...body,
+        email,
         keys: { kyber, ecc },
       });
 
@@ -299,8 +315,11 @@ export class AuthController {
         revocationKey: body.revocateKey,
       });
 
+      const email = await this.resolveLoginEmail(body.email.toLowerCase());
+
       const result = await this.userUseCases.loginAccess({
         ...body,
+        email,
         keys: { kyber, ecc },
         platform,
       });

--- a/src/modules/auth/auth.controller.ts
+++ b/src/modules/auth/auth.controller.ts
@@ -49,6 +49,8 @@ import { FeatureLimitService } from '../feature-limit/feature-limit.service';
 import { PaymentRequiredException } from '../feature-limit/exceptions/payment-required.exception';
 import { Client } from '../../common/decorators/client.decorator';
 import { type ClientEnum } from '../../common/enums/platform.enum';
+import { MailService } from '../../externals/mail/mail.service';
+import { isManagedMailDomain } from './managed-mail-domains';
 
 @ApiTags('Auth')
 @Controller('auth')
@@ -61,7 +63,18 @@ export class AuthController {
     private readonly twoFactorAuthService: TwoFactorAuthService,
     private readonly authUseCases: AuthUsecases,
     private readonly featureLimitService: FeatureLimitService,
+    private readonly mailService: MailService,
   ) {}
+
+  private async resolveLoginEmail(email: string): Promise<string> {
+    if (!isManagedMailDomain(email)) return email;
+
+    const userId = await this.mailService.findUserIdByAddress(email);
+    if (!userId) return email;
+
+    const user = await this.userUseCases.findByUuid(userId);
+    return user?.email ?? email;
+  }
 
   @Post('/login')
   @HttpCode(HttpStatus.OK)
@@ -71,7 +84,7 @@ export class AuthController {
   @ApiOkResponse({ description: 'Retrieve details', type: LoginResponseDto })
   @Public()
   async login(@Body() body: LoginDto): Promise<LoginResponseDto> {
-    const email = body.email.toLowerCase();
+    const email = await this.resolveLoginEmail(body.email.toLowerCase());
 
     const user = await this.userUseCases.findByEmail(email);
 
@@ -129,8 +142,11 @@ export class AuthController {
         revocationKey: body.revocateKey,
       });
 
+      const email = await this.resolveLoginEmail(body.email.toLowerCase());
+
       const result = await this.userUseCases.loginAccess({
         ...body,
+        email,
         keys: { kyber, ecc },
       });
 
@@ -296,8 +312,11 @@ export class AuthController {
     try {
       const { ecc } = this.keyServerUseCases.parseKeysInput(body.keys);
 
+      const email = await this.resolveLoginEmail(body.email.toLowerCase());
+
       const result = await this.userUseCases.loginAccess({
         ...body,
+        email,
         keys: { ecc, kyber: null },
         platform,
       });

--- a/src/modules/auth/auth.module.ts
+++ b/src/modules/auth/auth.module.ts
@@ -18,6 +18,7 @@ import { AuthUsecases } from './auth.usecase';
 import { CaptchaService } from '../../externals/captcha/captcha.service';
 import { FeatureLimitModule } from '../feature-limit/feature-limit.module';
 import { AuditLogsModule } from '../../common/audit-logs/audit-logs.module';
+import { MailServiceModule } from '../../externals/mail/mail.module';
 
 @Module({
   imports: [
@@ -41,6 +42,7 @@ import { AuditLogsModule } from '../../common/audit-logs/audit-logs.module';
     CacheManagerModule,
     FeatureLimitModule,
     AuditLogsModule,
+    MailServiceModule,
   ],
   providers: [
     CaptchaService,

--- a/src/modules/auth/managed-mail-domains.spec.ts
+++ b/src/modules/auth/managed-mail-domains.spec.ts
@@ -1,0 +1,30 @@
+import { isManagedMailDomain } from './managed-mail-domains';
+
+describe('managed-mail-domains', () => {
+  describe('isManagedMailDomain', () => {
+    it('When the domain is inxt.eu, then it returns true', () => {
+      expect(isManagedMailDomain('alias@inxt.eu')).toBe(true);
+    });
+
+    it('When the domain is inxt.me, then it returns true', () => {
+      expect(isManagedMailDomain('alias@inxt.me')).toBe(true);
+    });
+
+    it('When the domain uses different casing, then it returns true', () => {
+      expect(isManagedMailDomain('alias@INXT.EU')).toBe(true);
+      expect(isManagedMailDomain('alias@InXt.Me')).toBe(true);
+    });
+
+    it('When the domain is not managed, then it returns false', () => {
+      expect(isManagedMailDomain('user@gmail.com')).toBe(false);
+    });
+
+    it('When the address has no @ sign, then it returns false', () => {
+      expect(isManagedMailDomain('not-an-email')).toBe(false);
+    });
+
+    it('When the subdomain is not exactly managed, then it returns false', () => {
+      expect(isManagedMailDomain('user@mail.inxt.eu')).toBe(false);
+    });
+  });
+});

--- a/src/modules/auth/managed-mail-domains.ts
+++ b/src/modules/auth/managed-mail-domains.ts
@@ -1,0 +1,9 @@
+export const MANAGED_MAIL_DOMAINS: ReadonlySet<string> = new Set([
+  'inxt.eu',
+  'inxt.me',
+]);
+
+export function isManagedMailDomain(email: string): boolean {
+  const domain = email.split('@')[1]?.toLowerCase();
+  return !!domain && MANAGED_MAIL_DOMAINS.has(domain);
+}


### PR DESCRIPTION
When attempting login with an internxt owned email domain a lookup is performed against mail api if a match is found login continues as normal for that user. 

Mail side changes in this pr: https://github.com/internxt/mail-server/pull/28


---
⚠️ Needs new env variable `MAIL_API_URL`