### PR TITLE
[IN-144] fix(old-deleted-files-cleanup): prevent query timeout

### DIFF
--- a/src/modules/file/file.repository.spec.ts
+++ b/src/modules/file/file.repository.spec.ts
@@ -1263,6 +1263,7 @@ describe('FileRepository', () => {
   describe('findDeletedFilesUpdatedBefore', () => {
     const cutoffDate = Time.now('2025-09-01T00:00:00Z');
     const limit = 100;
+    const orderBy = [['updatedAt', 'ASC']];
 
     it('When no files match, then it should return an empty array', async () => {
       jest.spyOn(fileModel, 'findAll').mockResolvedValueOnce([] as FileModel[]);
@@ -1303,6 +1304,7 @@ describe('FileRepository', () => {
             status: FileStatus.DELETED,
             updatedAt: expect.objectContaining({ [Op.lt]: cutoffDate }),
           }),
+          order: orderBy,
         }),
       );
     });
@@ -1313,7 +1315,7 @@ describe('FileRepository', () => {
       await repository.findDeletedFilesUpdatedBefore(cutoffDate, limit);
 
       expect(fileModel.findAll).toHaveBeenCalledWith(
-        expect.objectContaining({ limit }),
+        expect.objectContaining({ limit, order: orderBy }),
       );
     });
   });

--- a/src/modules/file/file.repository.ts
+++ b/src/modules/file/file.repository.ts
@@ -1089,6 +1089,7 @@ export class SequelizeFileRepository implements FileRepository {
       },
       useMaster: opts?.useMaster,
       limit,
+      order: [['updatedAt', 'ASC']],
     });
 
     return rows.map((r) => r.uuid);


### PR DESCRIPTION
## What
The job was throwing query timeouts due to the planner choosing a sequential scan. It appears the planner assumes this is faster, but when there are no files to delete in that date range, a seq scan is significantly slower. We have an index that should cover this query and was working fine until Apr 24, so this is probably due to the index being too bloated / bad stats.

## How
Unlike MySQL, PostgreSQL doesn't support index hints, but since we created an index specifically for this job, we can force the planner to use it by adding `ORDER BY updated_at`, the indexed field. This should have been in place from the start, as it also makes the job deterministic rather than returning random results.

## Benchmark

### Before

```sql
select * from files where status = 'DELETED' and updated_at < '2025-11-01 07:44:14.901 +00:00' limit 100

Limit  (cost=0.00..41.23 rows=100 width=188)
  ->  Seq Scan on files  (cost=0.00..39701380.16 rows=96291513 width=188)
        Filter: ((updated_at < '2025-11-01 07:44:14.901'::timestamp without time zone) AND (status = 'DELETED'::enum_files_status))
```


### After

```sql
select * from files where status = 'DELETED' and updated_at < '2025-11-01 07:44:14.901 +00:00' orde by updated_at limit 100

Limit  (cost=0.57..85.93 rows=100 width=188) (actual time=38.773..48.544 rows=100 loops=1)
  Buffers: shared hit=22 read=535
  ->  Index Scan using idx_deleted_files_updated_at on files  (cost=0.57..82194296.11 rows=96291513 width=188) (actual time=38.771..48.510 rows=100 loops=1)
        Index Cond: (updated_at < '2025-11-01 07:44:14.901'::timestamp without time zone)
        Buffers: shared hit=22 read=535
Planning:
  Buffers: shared hit=6
Planning Time: 0.356 ms
Execution Time: 48.626 ms
```