### PR TITLE
[_] feat: add photos access per tier

### DIFF
--- a/migrations/20260615114407-add-photos-access-limit.js
+++ b/migrations/20260615114407-add-photos-access-limit.js
@@ -1,0 +1,105 @@
+'use strict';
+
+const { v4 } = require('uuid');
+
+const PHOTOS_ACCESS_LIMIT_LABEL = 'photos-access';
+
+const PHOTOS_ACCESS_ENABLED_TIER_LABELS = [
+  'ultimate_individual',
+  'ultimate_lifetime_individual',
+];
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface) {
+    const transaction = await queryInterface.sequelize.transaction();
+
+    try {
+      const disabledLimitId = v4();
+      const enabledLimitId = v4();
+
+      await queryInterface.bulkInsert(
+        'limits',
+        [
+          {
+            id: disabledLimitId,
+            label: PHOTOS_ACCESS_LIMIT_LABEL,
+            name: 'Photos access disabled',
+            type: 'boolean',
+            value: 'false',
+            created_at: new Date(),
+            updated_at: new Date(),
+          },
+          {
+            id: enabledLimitId,
+            label: PHOTOS_ACCESS_LIMIT_LABEL,
+            name: 'Photos access enabled',
+            type: 'boolean',
+            value: 'true',
+            created_at: new Date(),
+            updated_at: new Date(),
+          },
+        ],
+        { transaction },
+      );
+
+      const [tiers] = await queryInterface.sequelize.query(
+        `SELECT id, label FROM tiers`,
+        { transaction },
+      );
+
+      // Photos access is disabled by default, enabled only for ultimate tiers
+      const tierLimitRelations = tiers.map((tier) => ({
+        id: v4(),
+        tier_id: tier.id,
+        limit_id: PHOTOS_ACCESS_ENABLED_TIER_LABELS.includes(tier.label)
+          ? enabledLimitId
+          : disabledLimitId,
+        created_at: new Date(),
+        updated_at: new Date(),
+      }));
+
+      await queryInterface.bulkInsert('tiers_limits', tierLimitRelations, {
+        transaction,
+      });
+
+      await transaction.commit();
+    } catch (error) {
+      await transaction.rollback();
+      throw error;
+    }
+  },
+
+  async down(queryInterface) {
+    const transaction = await queryInterface.sequelize.transaction();
+
+    try {
+      const [limits] = await queryInterface.sequelize.query(
+        `SELECT id FROM limits WHERE label = :limitLabel`,
+        {
+          replacements: { limitLabel: PHOTOS_ACCESS_LIMIT_LABEL },
+          transaction,
+        },
+      );
+
+      const limitIds = limits.map((l) => l.id);
+
+      if (limitIds.length > 0) {
+        await queryInterface.sequelize.query(
+          `DELETE FROM tiers_limits WHERE limit_id IN (:limitIds)`,
+          { replacements: { limitIds }, transaction },
+        );
+
+        await queryInterface.sequelize.query(
+          `DELETE FROM limits WHERE id IN (:limitIds)`,
+          { replacements: { limitIds }, transaction },
+        );
+      }
+
+      await transaction.commit();
+    } catch (error) {
+      await transaction.rollback();
+      throw error;
+    }
+  },
+};

--- a/src/modules/backups/backup.module.ts
+++ b/src/modules/backups/backup.module.ts
@@ -20,6 +20,7 @@ import { ShareModule } from '../share/share.module';
 import { ThumbnailModule } from '../thumbnail/thumbnail.module';
 import { ThumbnailModel } from '../thumbnail/thumbnail.model';
 import { PhotosController } from './photos/photos.controller';
+import { FeatureLimitModule } from '../feature-limit/feature-limit.module';
 
 @Module({
   imports: [
@@ -40,6 +41,7 @@ import { PhotosController } from './photos/photos.controller';
     CryptoModule,
     BridgeModule,
     NotificationModule,
+    FeatureLimitModule,
   ],
   controllers: [BackupController, PhotosController],
   providers: [

--- a/src/modules/backups/photos/photos.controller.ts
+++ b/src/modules/backups/photos/photos.controller.ts
@@ -6,6 +6,7 @@ import {
   Param,
   Patch,
   Post,
+  UseGuards,
 } from '@nestjs/common';
 import {
   ApiBearerAuth,
@@ -19,9 +20,14 @@ import { BackupUseCase } from '../backup.usecase';
 import { CreateDeviceAsFolderDto } from '../dto/create-device-as-folder.dto';
 import { ValidateUUIDPipe } from '../../../common/pipes/validate-uuid.pipe';
 import { DeviceAsFolder } from '../dto/responses/device-as-folder.dto';
+import { FeatureLimit } from '../../feature-limit/feature-limits.guard';
+import { ApplyLimit } from '../../feature-limit/decorators/apply-limit.decorator';
+import { LimitLabels } from '../../feature-limit/limits.enum';
 
 @ApiTags('Photos')
 @Controller('photos')
+@ApplyLimit({ limitLabels: [LimitLabels.PhotosAccess] })
+@UseGuards(FeatureLimit)
 export class PhotosController {
   constructor(private readonly backupUseCases: BackupUseCase) {}
 

--- a/src/modules/feature-limit/decorators/apply-limit.decorator.ts
+++ b/src/modules/feature-limit/decorators/apply-limit.decorator.ts
@@ -1,3 +1,4 @@
+import { SetMetadata } from '@nestjs/common';
 import { type LimitLabels } from '../limits.enum';
 
 interface DataSource {
@@ -12,3 +13,6 @@ export interface ApplyLimitMetadata {
 }
 
 export const FEATURE_LIMIT_KEY = 'feature-limit';
+
+export const ApplyLimit = (metadata: ApplyLimitMetadata) =>
+  SetMetadata(FEATURE_LIMIT_KEY, { dataSources: [], ...metadata });

--- a/src/modules/feature-limit/feature-limits.guard.spec.ts
+++ b/src/modules/feature-limit/feature-limits.guard.spec.ts
@@ -42,7 +42,7 @@ describe('FeatureLimitUsecases', () => {
   });
 
   it('When metadata is missing, it should throw', async () => {
-    jest.spyOn(reflector, 'get').mockReturnValue(undefined);
+    jest.spyOn(reflector, 'getAllAndMerge').mockReturnValue(undefined);
 
     const context = createMockExecutionContext({});
 
@@ -141,6 +141,9 @@ const createMockExecutionContext = (requestData: any): ExecutionContext => {
   return {
     getHandler: () => ({
       name: 'endPointHandler',
+    }),
+    getClass: () => ({
+      name: 'EndPointController',
     }),
     switchToHttp: () => ({
       getRequest: () => requestData,

--- a/src/modules/feature-limit/feature-limits.guard.ts
+++ b/src/modules/feature-limit/feature-limits.guard.ts
@@ -24,11 +24,13 @@ export class FeatureLimit implements CanActivate {
 
   async canActivate(context: ExecutionContext): Promise<boolean> {
     const handler = context.getHandler();
+    const controller = context.getClass();
+
     const request = context.switchToHttp().getRequest();
     const user = request.user;
-    const metadata = this.reflector.get<ApplyLimitMetadata>(
+    const metadata = this.reflector.getAllAndMerge<ApplyLimitMetadata>(
       FEATURE_LIMIT_KEY,
-      handler,
+      [handler, controller],
     );
 
     if (!metadata) {

--- a/src/modules/feature-limit/limits.enum.ts
+++ b/src/modules/feature-limit/limits.enum.ts
@@ -12,6 +12,7 @@ export enum LimitLabels {
   TrashRetentionDays = 'trash-retention-days',
   ReferralAccess = 'referral-access',
   MaxUploadFileSize = 'max-upload-file-size',
+  PhotosAccess = 'photos-access',
 }
 
 export enum LimitTypes {

--- a/src/modules/file/dto/get-file-limits.dto.ts
+++ b/src/modules/file/dto/get-file-limits.dto.ts
@@ -24,4 +24,9 @@ export class GetFileLimitsDto {
 
   @ApiProperty({ nullable: true, type: Number })
   maxUploadFileSize: number | null;
+
+  @ApiProperty({
+    description: 'Whether photos access is enabled for this tier',
+  })
+  photosEnabled: boolean;
 }

--- a/src/modules/file/dto/get-file-limits.dto.ts
+++ b/src/modules/file/dto/get-file-limits.dto.ts
@@ -28,5 +28,5 @@ export class GetFileLimitsDto {
   @ApiProperty({
     description: 'Whether photos access is enabled for this tier',
   })
-  photosEnabled: boolean;
+  photosAccess: boolean;
 }

--- a/src/modules/file/file.controller.spec.ts
+++ b/src/modules/file/file.controller.spec.ts
@@ -753,6 +753,7 @@ describe('FileController', () => {
       const limits = {
         versioning: versioningLimits,
         maxUploadFileSize: 1073741824,
+        photosAccess: true,
       };
       jest.spyOn(fileUseCases, 'getFileLimits').mockResolvedValue(limits);
 
@@ -769,7 +770,11 @@ describe('FileController', () => {
         retentionDays: 0,
         maxVersions: 0,
       });
-      const limits = { versioning: freeLimits, maxUploadFileSize: null };
+      const limits = {
+        versioning: freeLimits,
+        maxUploadFileSize: null,
+        photosAccess: false,
+      };
       jest.spyOn(fileUseCases, 'getFileLimits').mockResolvedValue(limits);
 
       const result = await fileController.getLimits(userMocked);

--- a/src/modules/file/file.usecase.ts
+++ b/src/modules/file/file.usecase.ts
@@ -1274,12 +1274,22 @@ export class FileUseCases {
       maxVersions: number;
     };
     maxUploadFileSize: number | null;
+    photosEnabled: boolean;
   }> {
-    const [versioning, maxUploadFileSize] = await Promise.all([
-      this.featureLimitService.getFileVersioningLimits(user.uuid),
-      this.featureLimitService.getMaxUploadFileSize(user),
-    ]);
-    return { versioning, maxUploadFileSize };
+    const [versioning, maxUploadFileSize, photosAccessLimit] =
+      await Promise.all([
+        this.featureLimitService.getFileVersioningLimits(user.uuid),
+        this.featureLimitService.getMaxUploadFileSize(user),
+        this.featureLimitService.getUserLimitByLabel(
+          LimitLabels.PhotosAccess,
+          user,
+        ),
+      ]);
+    return {
+      versioning,
+      maxUploadFileSize,
+      photosEnabled: photosAccessLimit?.isFeatureEnabled() ?? false,
+    };
   }
 
   async undoFileVersioning(

--- a/src/modules/file/file.usecase.ts
+++ b/src/modules/file/file.usecase.ts
@@ -1274,7 +1274,7 @@ export class FileUseCases {
       maxVersions: number;
     };
     maxUploadFileSize: number | null;
-    photosEnabled: boolean;
+    photosAccess: boolean;
   }> {
     const [versioning, maxUploadFileSize, photosAccessLimit] =
       await Promise.all([
@@ -1288,7 +1288,7 @@ export class FileUseCases {
     return {
       versioning,
       maxUploadFileSize,
-      photosEnabled: photosAccessLimit?.isFeatureEnabled() ?? false,
+      photosAccess: photosAccessLimit?.isFeatureEnabled() ?? false,
     };
   }
 


### PR DESCRIPTION
## What
Allow photos access for ultimate users

## How
- Add photos-access to limits
- Use featureLimits guard to prevent unauthorized users from accessing photos

⚠️ requires migration