### PR TITLE
[_]: feat/improve-path-limit

### DIFF
--- a/src/modules/file/file.controller.spec.ts
+++ b/src/modules/file/file.controller.spec.ts
@@ -191,11 +191,8 @@ describe('FileController', () => {
       );
     });
 
-    it('When get file metadata by path is requested with a path deep > 20, then it should throw an error', () => {
-      const longPath =
-        '/' +
-        Array.from({ length: 21 }, (_, i) => `folder${i}`).join('/') +
-        '/file.test';
+    it('When get file metadata by path is requested with a path length > 1024, then it should throw an error', () => {
+      const longPath = '/' + 'a'.repeat(1025);
 
       expect(
         fileController.getFileMetaByPath(userMocked, longPath),

--- a/src/modules/file/file.controller.ts
+++ b/src/modules/file/file.controller.ts
@@ -468,7 +468,11 @@ export class FileController {
     @UserDecorator() user: User,
     @Query('path') filePath: string,
   ): Promise<FileDto> {
-    if (!filePath || filePath.length === 0 || !filePath.includes('/')) {
+    if (
+      typeof filePath !== 'string' ||
+      filePath.length === 0 ||
+      !filePath.includes('/')
+    ) {
       throw new BadRequestException('Invalid path provided');
     }
 

--- a/src/modules/file/file.controller.ts
+++ b/src/modules/file/file.controller.ts
@@ -47,7 +47,6 @@ import { SharingPermissionsGuard } from '../sharing/guards/sharing-permissions.g
 import { GetDataFromRequest } from '../../common/extract-data-from-request';
 import { StorageNotificationService } from '../../externals/notifications/storage.notifications.service';
 import { Client } from '../../common/decorators/client.decorator';
-import { getPathDepth } from '../../lib/path';
 import { Requester } from '../auth/decorators/requester.decorator';
 import { FileDto } from './dto/responses/file.dto';
 import { GetFileLimitsDto } from './dto/get-file-limits.dto';
@@ -473,7 +472,7 @@ export class FileController {
       throw new BadRequestException('Invalid path provided');
     }
 
-    if (getPathDepth(filePath) > 20) {
+    if (filePath.length > 1024) {
       throw new BadRequestException('Path is too deep');
     }
 

--- a/src/modules/folder/folder.controller.spec.ts
+++ b/src/modules/folder/folder.controller.spec.ts
@@ -516,9 +516,8 @@ describe('FolderController', () => {
       ).rejects.toThrow(BadRequestException);
     });
 
-    it('When get folder metadata by path is requested with a path deep > 20, then it should throw an error', () => {
-      const longPath =
-        '/' + Array.from({ length: 22 }, (_, i) => `folder${i}`).join('/');
+    it('When get folder metadata by path is requested with a path length > 1024, then it should throw an error', () => {
+      const longPath = '/' + 'a'.repeat(1025);
 
       expect(
         folderController.getFolderMetaByPath(userMocked, longPath),

--- a/src/modules/folder/folder.controller.ts
+++ b/src/modules/folder/folder.controller.ts
@@ -49,7 +49,6 @@ import { StorageNotificationService } from '../../externals/notifications/storag
 import { Client } from '../../common/decorators/client.decorator';
 import { BasicPaginationDto } from '../../common/dto/basic-pagination.dto';
 import { Workspace } from '../workspaces/domains/workspaces.domain';
-import { getPathDepth } from '../../lib/path';
 import { CheckFoldersExistenceOldDto } from './dto/folder-existence-in-folder-old.dto';
 import { Requester } from '../auth/decorators/requester.decorator';
 import {
@@ -800,7 +799,7 @@ export class FolderController {
       throw new BadRequestException('Invalid path provided');
     }
 
-    if (getPathDepth(folderPath) > 20) {
+    if (folderPath.length > 1024) {
       throw new BadRequestException('Path is too deep');
     }
 

--- a/src/modules/folder/folder.controller.ts
+++ b/src/modules/folder/folder.controller.ts
@@ -795,7 +795,11 @@ export class FolderController {
     @UserDecorator() user: User,
     @Query('path') folderPath: string,
   ) {
-    if (!folderPath || folderPath.length === 0 || !folderPath.includes('/')) {
+    if (
+      typeof folderPath !== 'string' ||
+      folderPath.length === 0 ||
+      !folderPath.includes('/')
+    ) {
       throw new BadRequestException('Invalid path provided');
     }
 


### PR DESCRIPTION
It changes the path validation from depth-based to length-based

## Problem
The file/folder metadata-by-path endpoints currently reject any path with a depth greater than 20 segments (getPathDepth(path) > 20). This is overly restrictive, it blocks legitimate deep directory trees that are well within OS limits.
While most users dont hit this limit, we have some reports from users whose paths exceed 20 segments. Forcing them to restructure their folder hierarchy is a poor experience, and the number of affected users is small enough that there is no meaningful performance concern in allowing deeper paths.

## Solution
Replace the depth check with a path length check (path.length > 1024), matching the behaviour of macOS and aligning more closely with common OS path limits:

macOS -> 1024 characters
Linux -> 4096 characters
Windows -> 260 characters (default) / ~32,767 characters (long paths)

Using 1024 characters as the limit provides a generous safety margin below Linux's 4096 limit while allowing deeply nested but legitimate paths that the old 20-segment cap would have rejected. It also matches macOS's documented limit, which is a common reference for some cross-platform tools.
Changes
- src/modules/file/file.controller.ts -> Changed validation from getPathDepth(filePath) > 20 to filePath.length > 1024; removed unused getPathDepth import.
- src/modules/folder/folder.controller.ts -> Same change for folder metadata lookup.
- src/modules/file/file.controller.spec.ts -> Updated test to generate path > 1024 characters instead of 21 segments.
- src/modules/folder/folder.controller.spec.ts -> Same for folder test.
- src/lib/path.ts -> The getPathDepth helper remains available for other uses but is no longer called from the controllers.