### PR TITLE
[_] fix(password-validation): added password length validation

### DIFF
--- a/src/externals/crypto/decorators/password-dto.validators.spec.ts
+++ b/src/externals/crypto/decorators/password-dto.validators.spec.ts
@@ -1,0 +1,228 @@
+import { validate } from 'class-validator';
+import CryptoJS from 'crypto-js';
+import {
+  IsEncryptedPassword,
+  IsEncryptedSalt,
+} from './password-dto.validators';
+
+class PasswordDto {
+  @IsEncryptedPassword()
+  password: string;
+}
+
+class SaltDto {
+  @IsEncryptedSalt()
+  salt: string;
+}
+
+function encryptTextWithKey(text: string, key: string): string {
+  const bytes = CryptoJS.AES.encrypt(text, key).toString();
+  return CryptoJS.enc.Base64.parse(bytes).toString(CryptoJS.enc.Hex);
+}
+
+function passToHash(password: string): { salt: string; hash: string } {
+  const salt = CryptoJS.lib.WordArray.random(128 / 8);
+  const hash = CryptoJS.PBKDF2(password, salt, {
+    keySize: 256 / 32,
+    iterations: 10000,
+  });
+  return { salt: salt.toString(), hash: hash.toString() };
+}
+
+function generateValidEncryptedPassword(): string {
+  const secret = 'testsecret';
+  const { hash } = passToHash('testpassword');
+  return encryptTextWithKey(hash, secret);
+}
+
+function generateValidEncryptedSalt(): string {
+  const secret = 'testsecret';
+  const { salt } = passToHash('testpassword');
+  return encryptTextWithKey(salt, secret);
+}
+
+describe('IsEncryptedPassword', () => {
+  let validPassword: string;
+
+  beforeEach(() => {
+    validPassword = generateValidEncryptedPassword();
+  });
+
+  it('When valid encrypted password, then pass', async () => {
+    const dto = new PasswordDto();
+    dto.password = validPassword;
+
+    const errors = await validate(dto);
+
+    expect(errors.length).toBe(0);
+  });
+
+  it('When valid uppercase hex, then pass', async () => {
+    const dto = new PasswordDto();
+    dto.password = validPassword.toUpperCase();
+
+    const errors = await validate(dto);
+
+    expect(errors.length).toBe(0);
+  });
+
+  it('When too short, then fail', async () => {
+    const dto = new PasswordDto();
+    dto.password = validPassword.slice(0, 191);
+
+    const errors = await validate(dto);
+
+    expect(errors.length).toBeGreaterThan(0);
+    expect(errors[0].constraints).toHaveProperty('isEncryptedPassword');
+  });
+
+  it('When too long, then fail', async () => {
+    const dto = new PasswordDto();
+    dto.password = validPassword + 'a';
+
+    const errors = await validate(dto);
+
+    expect(errors.length).toBeGreaterThan(0);
+    expect(errors[0].constraints).toHaveProperty('isEncryptedPassword');
+  });
+
+  it('When non-hex char injected at correct length, then fail', async () => {
+    const dto = new PasswordDto();
+    dto.password = validPassword.slice(0, 191) + 'z';
+
+    const errors = await validate(dto);
+
+    expect(errors.length).toBeGreaterThan(0);
+    expect(errors[0].constraints).toHaveProperty('isEncryptedPassword');
+  });
+
+  it('When all non-hex chars with correct length, then fail', async () => {
+    const dto = new PasswordDto();
+    dto.password = 'z'.repeat(192);
+
+    const errors = await validate(dto);
+
+    expect(errors.length).toBeGreaterThan(0);
+    expect(errors[0].constraints).toHaveProperty('isEncryptedPassword');
+  });
+
+  it('When empty string, then fail', async () => {
+    const dto = new PasswordDto();
+    dto.password = '';
+
+    const errors = await validate(dto);
+
+    expect(errors.length).toBeGreaterThan(0);
+  });
+
+  it('When undefined, then fail', async () => {
+    const dto = new PasswordDto();
+    dto.password = undefined;
+
+    const errors = await validate(dto);
+
+    expect(errors.length).toBeGreaterThan(0);
+  });
+
+  it('When number, then fail', async () => {
+    const dto = new PasswordDto();
+    dto.password = 123 as any;
+
+    const errors = await validate(dto);
+
+    expect(errors.length).toBeGreaterThan(0);
+  });
+});
+
+describe('IsEncryptedSalt', () => {
+  let validSalt: string;
+
+  beforeEach(() => {
+    validSalt = generateValidEncryptedSalt();
+  });
+
+  it('When valid encrypted salt, then pass', async () => {
+    const dto = new SaltDto();
+    dto.salt = validSalt;
+
+    const errors = await validate(dto);
+
+    expect(errors.length).toBe(0);
+  });
+
+  it('When valid uppercase hex, then pass', async () => {
+    const dto = new SaltDto();
+    dto.salt = validSalt.toUpperCase();
+
+    const errors = await validate(dto);
+
+    expect(errors.length).toBe(0);
+  });
+
+  it('When too short, then fail', async () => {
+    const dto = new SaltDto();
+    dto.salt = validSalt.slice(0, 127);
+
+    const errors = await validate(dto);
+
+    expect(errors.length).toBeGreaterThan(0);
+    expect(errors[0].constraints).toHaveProperty('isEncryptedSalt');
+  });
+
+  it('When too long, then fail', async () => {
+    const dto = new SaltDto();
+    dto.salt = validSalt + 'a';
+
+    const errors = await validate(dto);
+
+    expect(errors.length).toBeGreaterThan(0);
+    expect(errors[0].constraints).toHaveProperty('isEncryptedSalt');
+  });
+
+  it('When non-hex char injected at correct length, then fail', async () => {
+    const dto = new SaltDto();
+    dto.salt = validSalt.slice(0, 127) + 'z';
+
+    const errors = await validate(dto);
+
+    expect(errors.length).toBeGreaterThan(0);
+    expect(errors[0].constraints).toHaveProperty('isEncryptedSalt');
+  });
+
+  it('When all non-hex chars with correct length, then fail', async () => {
+    const dto = new SaltDto();
+    dto.salt = 'z'.repeat(128);
+
+    const errors = await validate(dto);
+
+    expect(errors.length).toBeGreaterThan(0);
+    expect(errors[0].constraints).toHaveProperty('isEncryptedSalt');
+  });
+
+  it('When empty string, then fail', async () => {
+    const dto = new SaltDto();
+    dto.salt = '';
+
+    const errors = await validate(dto);
+
+    expect(errors.length).toBeGreaterThan(0);
+  });
+
+  it('When undefined, then fail', async () => {
+    const dto = new SaltDto();
+    dto.salt = undefined;
+
+    const errors = await validate(dto);
+
+    expect(errors.length).toBeGreaterThan(0);
+  });
+
+  it('When number, then fail', async () => {
+    const dto = new SaltDto();
+    dto.salt = 123 as any;
+
+    const errors = await validate(dto);
+
+    expect(errors.length).toBeGreaterThan(0);
+  });
+});

--- a/src/externals/crypto/decorators/password-dto.validators.ts
+++ b/src/externals/crypto/decorators/password-dto.validators.ts
@@ -1,0 +1,67 @@
+import {
+  isHexadecimal,
+  registerDecorator,
+  type ValidationOptions,
+} from 'class-validator';
+
+/**
+ * Client sends: AES.encrypt(PBKDF2(password, { keySize: 8 words = 32 bytes })) → hex
+ * PBKDF2 → 32 bytes → 64 hex chars plaintext
+ * AES-CBC PKCS7 adds padding: 64→80 bytes, prepends 16-byte OpenSSL header → 96 bytes → 192 hex chars
+ */
+
+export const ENCRYPTED_PASSWORD_HEX_LENGTH = 192;
+
+export function IsEncryptedPassword(validationOptions?: ValidationOptions) {
+  return function (object: object, propertyName: string) {
+    registerDecorator({
+      name: 'isEncryptedPassword',
+      target: object.constructor,
+      propertyName,
+      options: validationOptions,
+      validator: {
+        validate(value: unknown) {
+          return (
+            typeof value === 'string' &&
+            value.length === ENCRYPTED_PASSWORD_HEX_LENGTH &&
+            isHexadecimal(value)
+          );
+        },
+        defaultMessage() {
+          return `${propertyName} must be a valid encrypted password`;
+        },
+      },
+    });
+  };
+}
+
+/**
+ * Client sends: AES.encrypt(PBKDF2 salt) → hex
+ * Salt = random(128/8) = 16 bytes = 32 hex chars plaintext
+ * AES-CBC PKCS7 pads 32→48 bytes, prepends 16-byte OpenSSL header → 64 bytes → 128 hex chars
+ */
+
+export const ENCRYPTED_SALT_HEX_LENGTH = 128;
+
+export function IsEncryptedSalt(validationOptions?: ValidationOptions) {
+  return function (object: object, propertyName: string) {
+    registerDecorator({
+      name: 'isEncryptedSalt',
+      target: object.constructor,
+      propertyName,
+      options: validationOptions,
+      validator: {
+        validate(value: unknown) {
+          return (
+            typeof value === 'string' &&
+            value.length === ENCRYPTED_SALT_HEX_LENGTH &&
+            isHexadecimal(value)
+          );
+        },
+        defaultMessage() {
+          return `${propertyName} must be a valid encrypted salt`;
+        },
+      },
+    });
+  };
+}

--- a/src/modules/auth/auth.e2e-spec.ts
+++ b/src/modules/auth/auth.e2e-spec.ts
@@ -232,7 +232,10 @@ describe('User Authentication E2E', () => {
 
         await request(app.getHttpServer())
           .post('/auth/login/access')
-          .send({ email, password: generateHashedPassword() })
+          .send({
+            email,
+            password: cryptoService.encryptText(generateHashedPassword()),
+          })
           .expect(HttpStatus.UNAUTHORIZED);
       });
 
@@ -241,7 +244,7 @@ describe('User Authentication E2E', () => {
           .post('/auth/login/access')
           .send({
             email: 'nonexistent@test.com',
-            password: generateHashedPassword(),
+            password: cryptoService.encryptText(generateHashedPassword()),
           })
           .expect(HttpStatus.UNAUTHORIZED);
       });
@@ -279,7 +282,10 @@ describe('User Authentication E2E', () => {
         for (let i = 1; i <= 3; i++) {
           await request(app.getHttpServer())
             .post('/auth/login/access')
-            .send({ email, password: generateHashedPassword() })
+            .send({
+              email,
+              password: cryptoService.encryptText(generateHashedPassword()),
+            })
             .expect(HttpStatus.UNAUTHORIZED);
 
           const user = await userModel.findOne({ where: { id: userId } });
@@ -298,7 +304,10 @@ describe('User Authentication E2E', () => {
 
         await request(app.getHttpServer())
           .post('/auth/login/access')
-          .send({ email, password: generateHashedPassword() })
+          .send({
+            email,
+            password: cryptoService.encryptText(generateHashedPassword()),
+          })
           .expect(HttpStatus.FORBIDDEN);
       });
 

--- a/src/modules/auth/dto/login-access.dto.ts
+++ b/src/modules/auth/dto/login-access.dto.ts
@@ -8,6 +8,7 @@ import {
   ValidateNested,
 } from 'class-validator';
 import { KeysDto } from '../../keyserver/dto/keys.dto';
+import { IsEncryptedPassword } from '../../../externals/crypto/decorators/password-dto.validators';
 
 class OptionalKeyGroup extends PartialType(KeysDto) {}
 
@@ -24,8 +25,7 @@ export class LoginAccessDto {
     example: 'some_hashed_pass',
     description: 'User password',
   })
-  @IsNotEmpty()
-  @IsString()
+  @IsEncryptedPassword()
   password: string;
 
   @ApiProperty({

--- a/src/modules/user/dto/create-user.dto.ts
+++ b/src/modules/user/dto/create-user.dto.ts
@@ -10,6 +10,10 @@ import { ApiProperty } from '@nestjs/swagger';
 import { type UserAttributes } from '../user.attributes';
 import { Type } from 'class-transformer';
 import { EccKeysDto, KyberKeysDto } from '../../keyserver/dto/keys.dto';
+import {
+  IsEncryptedPassword,
+  IsEncryptedSalt,
+} from '../../../externals/crypto/decorators/password-dto.validators';
 
 class KeysDto {
   @Type(() => EccKeysDto)
@@ -59,8 +63,7 @@ export class CreateUserDto {
   })
   email: UserAttributes['email'];
 
-  @IsNotEmpty()
-  @IsString()
+  @IsEncryptedPassword()
   @ApiProperty({
     example: '$2a$08$4SN2l.8dM0fSUTzni3i61u047Sr/R3ocJYxbxmKdEmGJcVOj1sHIi',
     description: 'Hashed password',
@@ -76,8 +79,7 @@ export class CreateUserDto {
   })
   mnemonic: UserAttributes['mnemonic'];
 
-  @IsNotEmpty()
-  @IsString()
+  @IsEncryptedSalt()
   @ApiProperty({
     example: 'salt',
     description: 'Salt',

--- a/src/modules/user/dto/legacy-recover-account.dto.ts
+++ b/src/modules/user/dto/legacy-recover-account.dto.ts
@@ -1,6 +1,10 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { IsNotEmpty, ValidateNested } from 'class-validator';
 import { Type } from 'class-transformer';
+import {
+  IsEncryptedPassword,
+  IsEncryptedSalt,
+} from '../../../externals/crypto/decorators/password-dto.validators';
 
 class EncryptedMnemonicDto {
   @ApiProperty({
@@ -73,14 +77,14 @@ export class LegacyRecoverAccountDto {
     example: 'hashed_password',
     description: 'New user pass hashed',
   })
-  @IsNotEmpty()
+  @IsEncryptedPassword()
   password: string;
 
   @ApiProperty({
     example: 'password_salt',
     description: 'Hashed password salt',
   })
-  @IsNotEmpty()
+  @IsEncryptedSalt()
   salt: string;
 
   @ApiProperty({

--- a/src/modules/user/dto/recover-account.dto.ts
+++ b/src/modules/user/dto/recover-account.dto.ts
@@ -8,6 +8,10 @@ import {
   ValidateNested,
 } from 'class-validator';
 import { Type } from 'class-transformer';
+import {
+  IsEncryptedPassword,
+  IsEncryptedSalt,
+} from '../../../externals/crypto/decorators/password-dto.validators';
 
 class PrivateKeysDto {
   @ApiProperty()
@@ -34,7 +38,7 @@ export class RecoverAccountDto {
     example: 'some_hashed_pass',
     description: 'New user pass hashed',
   })
-  @IsNotEmpty()
+  @IsEncryptedPassword()
   password: string;
 
   @ApiProperty({
@@ -48,7 +52,7 @@ export class RecoverAccountDto {
     example: 'some_salt',
     description: 'Hashed password salt',
   })
-  @IsNotEmpty()
+  @IsEncryptedSalt()
   salt: string;
 
   @ApiProperty({
@@ -81,14 +85,14 @@ export class DeprecatedRecoverAccountDto {
     example: 'some_hashed_pass',
     description: 'New user pass hashed',
   })
-  @IsNotEmpty()
+  @IsEncryptedPassword()
   password: string;
 
   @ApiProperty({
     example: 'some_salt',
     description: 'Hashed password salt',
   })
-  @IsNotEmpty()
+  @IsEncryptedSalt()
   salt: string;
 
   @ApiProperty({

--- a/src/modules/user/dto/update-password.dto.ts
+++ b/src/modules/user/dto/update-password.dto.ts
@@ -1,22 +1,26 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { IsOptional, IsString, MaxLength } from 'class-validator';
+import {
+  IsEncryptedPassword,
+  IsEncryptedSalt,
+} from '../../../externals/crypto/decorators/password-dto.validators';
 
 export class UpdatePasswordDto {
-  @IsString()
+  @IsEncryptedPassword()
   @ApiProperty({
     example: 'currentPassword',
     description: 'Current password',
   })
   currentPassword: string;
 
-  @IsString()
+  @IsEncryptedPassword()
   @ApiProperty({
     example: 'newPassword',
     description: 'New password',
   })
   newPassword: string;
 
-  @IsString()
+  @IsEncryptedSalt()
   @ApiProperty({
     example: 'newSalt',
     description: 'New salt',

--- a/test/helpers/register.helper.ts
+++ b/test/helpers/register.helper.ts
@@ -106,7 +106,7 @@ export async function generateValidRegistrationData(
 }
 
 export function generateHashedPassword(): string {
-  return '$2a$08$' + v4().replace(/-/g, '').substring(0, 53);
+  return (v4() + v4()).replace(/-/g, '').substring(0, 64);
 }
 
 export function generateSalt(): string {


### PR DESCRIPTION
## What

Adds `@IsEncryptedPassword()` and `@IsEncryptedSalt()` class-validator decorators and applies them to all DTOs that receive password or salt fields

Related info:
- Client Hash function: https://github.com/internxt/drive-web/blob/2a0ea45088f20d51b8780cd6496c8a7de3ed0de5/src/app/crypto/services/utils.ts#L63
- Register function: https://github.com/internxt/drive-web/blob/2a0ea45088f20d51b8780cd6496c8a7de3ed0de5/src/views/Signup/hooks/useSignup.ts#L68
- Login function: https://github.com/internxt/sdk/blob/e49cc83749471cb28b28efbfd7674c55d71f5535/src/auth/index.ts#L319

## Why

The client always sends an AES-encrypted hex string derived from a PBKDF2 hash. Because the encryption pipeline is deterministic, the output length is fixed:

- **Password** → PBKDF2 (keySize=8 words=32B) → 64B plaintext → AES-CBC PKCS7 → 80B ciphertext + 16B OpenSSL header → **96B → 192 hex chars**
- **Salt** → 16B random → AES-CBC → 48B ciphertext + 16B header → **64B → 128 hex chars**

Before this change, any string was accepted as a valid password field. A malformed payload (wrong length, non-hex characters) would pass DTO validation and only get stored. The new decorators reject malformed payloads at the controller boundary.
