### PR TITLE
[_] fix: add keys check

### DIFF
--- a/src/externals/asymmetric-encryption/decorators/encrypted-key.validator.spec.ts
+++ b/src/externals/asymmetric-encryption/decorators/encrypted-key.validator.spec.ts
@@ -1,0 +1,107 @@
+import { validate } from 'class-validator';
+import { IsEncryptedKeyOfSize } from './encrypted-key.validator';
+
+const AES_GCM_HEADER_BYTES = 64 + 16 + 16;
+
+class GenericTestDto {
+  @IsEncryptedKeyOfSize()
+  privateKey: string;
+}
+
+class ExactSizeTestDto {
+  @IsEncryptedKeyOfSize(2176)
+  privateKey: string;
+}
+
+describe('IsEncryptedKeyOfSize', () => {
+  describe('without exactPayloadBytes', () => {
+    it('When decoded blob is larger than the AES-GCM header, then pass', async () => {
+      const dto = new GenericTestDto();
+      dto.privateKey = Buffer.alloc(AES_GCM_HEADER_BYTES + 1, 1).toString(
+        'base64',
+      );
+
+      const errors = await validate(dto);
+
+      expect(errors.length).toBe(0);
+    });
+
+    it('When decoded blob is exactly the AES-GCM header size, then fail', async () => {
+      const dto = new GenericTestDto();
+      dto.privateKey = Buffer.alloc(AES_GCM_HEADER_BYTES, 1).toString('base64');
+
+      const errors = await validate(dto);
+
+      expect(errors.length).toBeGreaterThan(0);
+      expect(errors[0].property).toBe('privateKey');
+      expect(errors[0].constraints).toHaveProperty('isEncryptedKeyOfSize');
+    });
+
+    it('When value is not base64, then fail', async () => {
+      const dto = new GenericTestDto();
+      dto.privateKey = 'not-valid-base64!!!';
+
+      const errors = await validate(dto);
+
+      expect(errors.length).toBeGreaterThan(0);
+      expect(errors[0].constraints).toHaveProperty('isEncryptedKeyOfSize');
+    });
+
+    it('When value is empty string, then fail', async () => {
+      const dto = new GenericTestDto();
+      dto.privateKey = '';
+
+      const errors = await validate(dto);
+
+      expect(errors.length).toBeGreaterThan(0);
+      expect(errors[0].constraints).toHaveProperty('isEncryptedKeyOfSize');
+    });
+
+    it('When value is undefined, then fail', async () => {
+      const dto = new GenericTestDto();
+      dto.privateKey = undefined;
+
+      const errors = await validate(dto);
+
+      expect(errors.length).toBeGreaterThan(0);
+      expect(errors[0].constraints).toHaveProperty('isEncryptedKeyOfSize');
+    });
+  });
+
+  describe('with exactPayloadBytes', () => {
+    it('When decoded blob is exactly header + payload bytes, then pass', async () => {
+      const dto = new ExactSizeTestDto();
+      dto.privateKey = Buffer.alloc(AES_GCM_HEADER_BYTES + 2176, 1).toString(
+        'base64',
+      );
+
+      const errors = await validate(dto);
+
+      expect(errors.length).toBe(0);
+    });
+
+    it('When decoded blob is smaller than expected, then fail', async () => {
+      const dto = new ExactSizeTestDto();
+      dto.privateKey = Buffer.alloc(AES_GCM_HEADER_BYTES + 2175, 1).toString(
+        'base64',
+      );
+
+      const errors = await validate(dto);
+
+      expect(errors.length).toBeGreaterThan(0);
+      expect(errors[0].constraints).toHaveProperty('isEncryptedKeyOfSize');
+    });
+
+    it('When decoded blob is larger than expected, then fail', async () => {
+      const dto = new ExactSizeTestDto();
+      dto.privateKey = Buffer.alloc(AES_GCM_HEADER_BYTES + 2177, 1).toString(
+        'base64',
+      );
+
+      const errors = await validate(dto);
+
+      expect(errors.length).toBeGreaterThan(0);
+      expect(errors[0].constraints).toHaveProperty('isEncryptedKeyOfSize');
+    });
+  });
+});

--- a/src/externals/asymmetric-encryption/decorators/encrypted-key.validator.spec.ts
+++ b/src/externals/asymmetric-encryption/decorators/encrypted-key.validator.spec.ts
@@ -13,6 +13,11 @@ class ExactSizeTestDto {
   privateKey: string;
 }
 
+class RangeSizeTestDto {
+  @IsEncryptedKeyOfSize({ minPayloadBytes: 712, maxPayloadBytes: 716 })
+  privateKey: string;
+}
+
 describe('IsEncryptedKeyOfSize', () => {
   describe('without exactPayloadBytes', () => {
     it('When decoded blob is larger than the AES-GCM header, then pass', async () => {
@@ -95,6 +100,54 @@ describe('IsEncryptedKeyOfSize', () => {
     it('When decoded blob is larger than expected, then fail', async () => {
       const dto = new ExactSizeTestDto();
       dto.privateKey = Buffer.alloc(AES_GCM_HEADER_BYTES + 2177, 1).toString(
+        'base64',
+      );
+
+      const errors = await validate(dto);
+
+      expect(errors.length).toBeGreaterThan(0);
+      expect(errors[0].constraints).toHaveProperty('isEncryptedKeyOfSize');
+    });
+  });
+
+  describe('with min/max payload bytes range', () => {
+    it('When payload is at the lower bound, then pass', async () => {
+      const dto = new RangeSizeTestDto();
+      dto.privateKey = Buffer.alloc(AES_GCM_HEADER_BYTES + 712, 1).toString(
+        'base64',
+      );
+
+      const errors = await validate(dto);
+
+      expect(errors.length).toBe(0);
+    });
+
+    it('When payload is at the upper bound, then pass', async () => {
+      const dto = new RangeSizeTestDto();
+      dto.privateKey = Buffer.alloc(AES_GCM_HEADER_BYTES + 716, 1).toString(
+        'base64',
+      );
+
+      const errors = await validate(dto);
+
+      expect(errors.length).toBe(0);
+    });
+
+    it('When payload is below the lower bound, then fail', async () => {
+      const dto = new RangeSizeTestDto();
+      dto.privateKey = Buffer.alloc(AES_GCM_HEADER_BYTES + 711, 1).toString(
+        'base64',
+      );
+
+      const errors = await validate(dto);
+
+      expect(errors.length).toBeGreaterThan(0);
+      expect(errors[0].constraints).toHaveProperty('isEncryptedKeyOfSize');
+    });
+
+    it('When payload is above the upper bound, then fail', async () => {
+      const dto = new RangeSizeTestDto();
+      dto.privateKey = Buffer.alloc(AES_GCM_HEADER_BYTES + 717, 1).toString(
         'base64',
       );
 

--- a/src/externals/asymmetric-encryption/decorators/encrypted-key.validator.ts
+++ b/src/externals/asymmetric-encryption/decorators/encrypted-key.validator.ts
@@ -1,0 +1,53 @@
+import {
+  registerDecorator,
+  type ValidationOptions,
+  type ValidationArguments,
+} from 'class-validator';
+
+// AES-256-GCM header: salt(64) + iv(16) + tag(16), see src/externals/crypto/aes.ts
+const AES_GCM_HEADER_BYTES = 64 + 16 + 16;
+
+/**
+ * Validates a key encrypted with AesService.encrypt() (src/externals/crypto/aes.ts).
+ * @param exactPayloadBytes if given, decoded blob must be exactly header + this many bytes
+ *   (AES-GCM has no padding, so encrypting a known-size plaintext yields a known-size blob)
+ */
+export function IsEncryptedKeyOfSize(
+  exactPayloadBytes?: number,
+  validationOptions?: ValidationOptions,
+) {
+  return function (object: object, propertyName: string) {
+    registerDecorator({
+      name: 'isEncryptedKeyOfSize',
+      target: object.constructor,
+      propertyName: propertyName,
+      options: validationOptions,
+      validator: {
+        validate(value: any) {
+          if (typeof value !== 'string' || value.length === 0) {
+            return false;
+          }
+
+          if (!/^[A-Za-z0-9+/]+={0,2}$/.test(value)) {
+            return false;
+          }
+
+          const decoded = Buffer.from(value, 'base64');
+
+          if (exactPayloadBytes !== undefined) {
+            return decoded.length === AES_GCM_HEADER_BYTES + exactPayloadBytes;
+          }
+
+          return decoded.length > AES_GCM_HEADER_BYTES;
+        },
+        defaultMessage(args: ValidationArguments) {
+          const expected =
+            exactPayloadBytes !== undefined
+              ? `exactly ${AES_GCM_HEADER_BYTES + exactPayloadBytes} bytes`
+              : `more than ${AES_GCM_HEADER_BYTES} bytes`;
+          return `${args.property} must be a valid AES-256-GCM encrypted key (base64, salt+iv+tag+payload, ${expected} decoded)`;
+        },
+      },
+    });
+  };
+}

--- a/src/externals/asymmetric-encryption/decorators/encrypted-key.validator.ts
+++ b/src/externals/asymmetric-encryption/decorators/encrypted-key.validator.ts
@@ -7,14 +7,27 @@ import {
 // AES-256-GCM header: salt(64) + iv(16) + tag(16), see src/externals/crypto/aes.ts
 const AES_GCM_HEADER_BYTES = 64 + 16 + 16;
 
+export interface EncryptedKeySizeOptions {
+  /** decoded blob must be exactly header + this many payload bytes */
+  exactPayloadBytes?: number;
+  /** decoded blob's payload bytes must fall within [minPayloadBytes, maxPayloadBytes] */
+  minPayloadBytes?: number;
+  maxPayloadBytes?: number;
+}
+
 /**
  * Validates a key encrypted with AES-256-GCM (base64-encoded, salt+iv+tag+payload).
- * @param exactPayloadBytes if given, decoded blob must be exactly header + this many bytes
+ * @param sizeOptions exact payload size, or a [min, max] payload size range
  */
 export function IsEncryptedKeyOfSize(
-  exactPayloadBytes?: number,
+  sizeOptions?: number | EncryptedKeySizeOptions,
   validationOptions?: ValidationOptions,
 ) {
+  const options: EncryptedKeySizeOptions =
+    typeof sizeOptions === 'number'
+      ? { exactPayloadBytes: sizeOptions }
+      : (sizeOptions ?? {});
+
   return function (object: object, propertyName: string) {
     registerDecorator({
       name: 'isEncryptedKeyOfSize',
@@ -32,9 +45,20 @@ export function IsEncryptedKeyOfSize(
           }
 
           const decoded = Buffer.from(value, 'base64');
+          const payloadBytes = decoded.length - AES_GCM_HEADER_BYTES;
 
-          if (exactPayloadBytes !== undefined) {
-            return decoded.length === AES_GCM_HEADER_BYTES + exactPayloadBytes;
+          if (options.exactPayloadBytes !== undefined) {
+            return payloadBytes === options.exactPayloadBytes;
+          }
+
+          if (
+            options.minPayloadBytes !== undefined &&
+            options.maxPayloadBytes !== undefined
+          ) {
+            return (
+              payloadBytes >= options.minPayloadBytes &&
+              payloadBytes <= options.maxPayloadBytes
+            );
           }
 
           return decoded.length > AES_GCM_HEADER_BYTES;

--- a/src/externals/asymmetric-encryption/decorators/encrypted-key.validator.ts
+++ b/src/externals/asymmetric-encryption/decorators/encrypted-key.validator.ts
@@ -8,9 +8,8 @@ import {
 const AES_GCM_HEADER_BYTES = 64 + 16 + 16;
 
 /**
- * Validates a key encrypted with AesService.encrypt() (src/externals/crypto/aes.ts).
+ * Validates a key encrypted with AES-256-GCM (base64-encoded, salt+iv+tag+payload).
  * @param exactPayloadBytes if given, decoded blob must be exactly header + this many bytes
- *   (AES-GCM has no padding, so encrypting a known-size plaintext yields a known-size blob)
  */
 export function IsEncryptedKeyOfSize(
   exactPayloadBytes?: number,
@@ -41,11 +40,7 @@ export function IsEncryptedKeyOfSize(
           return decoded.length > AES_GCM_HEADER_BYTES;
         },
         defaultMessage(args: ValidationArguments) {
-          const expected =
-            exactPayloadBytes !== undefined
-              ? `exactly ${AES_GCM_HEADER_BYTES + exactPayloadBytes} bytes`
-              : `more than ${AES_GCM_HEADER_BYTES} bytes`;
-          return `${args.property} must be a valid AES-256-GCM encrypted key (base64, salt+iv+tag+payload, ${expected} decoded)`;
+          return `${args.property} is not a valid encrypted key`;
         },
       },
     });

--- a/src/externals/asymmetric-encryption/decorators/kyber-public-key.validator.spec.ts
+++ b/src/externals/asymmetric-encryption/decorators/kyber-public-key.validator.spec.ts
@@ -1,0 +1,87 @@
+import { validate } from 'class-validator';
+import { IsKyberPublicKey } from './kyber-public-key.validator';
+import { importEsmPackage } from '../../../lib/import-esm-package';
+import type { KyberBuilder } from '../providers/kyber.provider';
+
+class TestDto {
+  @IsKyberPublicKey()
+  publicKey: string;
+}
+
+const KYBER512_PUBLIC_KEY_BYTES = 800;
+
+describe('IsKyberPublicKey', () => {
+  it('When value is a real Kyber512 public key, then pass', async () => {
+    const kemBuilder = await importEsmPackage<
+      (...args: unknown[]) => Promise<KyberBuilder>
+    >('@dashlane/pqc-kem-kyber512-node');
+    const kem = await kemBuilder();
+    const { publicKey } = await kem.keypair();
+
+    // Confirms the real lib's public key size matches the hardcoded constant
+    // used by the validator (see kyber-public-key.validator.ts).
+    expect(publicKey.length).toBe(KYBER512_PUBLIC_KEY_BYTES);
+
+    const dto = new TestDto();
+    dto.publicKey = Buffer.from(publicKey).toString('base64');
+
+    const errors = await validate(dto);
+
+    expect(errors.length).toBe(0);
+  });
+
+  it('When value decodes to fewer than 800 bytes, then fail', async () => {
+    const dto = new TestDto();
+    dto.publicKey = Buffer.alloc(KYBER512_PUBLIC_KEY_BYTES - 1, 1).toString(
+      'base64',
+    );
+
+    const errors = await validate(dto);
+
+    expect(errors.length).toBeGreaterThan(0);
+    expect(errors[0].property).toBe('publicKey');
+    expect(errors[0].constraints).toHaveProperty('isKyberPublicKey');
+  });
+
+  it('When value decodes to more than 800 bytes, then fail', async () => {
+    const dto = new TestDto();
+    dto.publicKey = Buffer.alloc(KYBER512_PUBLIC_KEY_BYTES + 1, 1).toString(
+      'base64',
+    );
+
+    const errors = await validate(dto);
+
+    expect(errors.length).toBeGreaterThan(0);
+    expect(errors[0].constraints).toHaveProperty('isKyberPublicKey');
+  });
+
+  it('When value is not base64, then fail', async () => {
+    const dto = new TestDto();
+    dto.publicKey = 'not-valid-base64!!!';
+
+    const errors = await validate(dto);
+
+    expect(errors.length).toBeGreaterThan(0);
+    expect(errors[0].constraints).toHaveProperty('isKyberPublicKey');
+  });
+
+  it('When value is empty string, then fail', async () => {
+    const dto = new TestDto();
+    dto.publicKey = '';
+
+    const errors = await validate(dto);
+
+    expect(errors.length).toBeGreaterThan(0);
+    expect(errors[0].constraints).toHaveProperty('isKyberPublicKey');
+  });
+
+  it('When value is undefined, then fail', async () => {
+    const dto = new TestDto();
+    dto.publicKey = undefined;
+
+    const errors = await validate(dto);
+
+    expect(errors.length).toBeGreaterThan(0);
+    expect(errors[0].constraints).toHaveProperty('isKyberPublicKey');
+  });
+});

--- a/src/externals/asymmetric-encryption/decorators/kyber-public-key.validator.ts
+++ b/src/externals/asymmetric-encryption/decorators/kyber-public-key.validator.ts
@@ -1,0 +1,37 @@
+import {
+  registerDecorator,
+  type ValidationOptions,
+  type ValidationArguments,
+} from 'class-validator';
+
+// Confirmed via kem.publicKeyBytes from @dashlane/pqc-kem-kyber512-node, the lib used in
+// src/externals/asymmetric-encryption/providers/kyber.provider.ts.
+const KYBER512_PUBLIC_KEY_BYTES = 800;
+
+export function IsKyberPublicKey(validationOptions?: ValidationOptions) {
+  return function (object: object, propertyName: string) {
+    registerDecorator({
+      name: 'isKyberPublicKey',
+      target: object.constructor,
+      propertyName: propertyName,
+      options: validationOptions,
+      validator: {
+        validate(value: any) {
+          if (typeof value !== 'string' || value.length === 0) {
+            return false;
+          }
+
+          try {
+            const decoded = Buffer.from(value, 'base64');
+            return decoded.length === KYBER512_PUBLIC_KEY_BYTES;
+          } catch {
+            return false;
+          }
+        },
+        defaultMessage(args: ValidationArguments) {
+          return `${args.property} must be a valid Kyber512 public key (${KYBER512_PUBLIC_KEY_BYTES} bytes base64-encoded)`;
+        },
+      },
+    });
+  };
+}

--- a/src/externals/asymmetric-encryption/decorators/kyber-public-key.validator.ts
+++ b/src/externals/asymmetric-encryption/decorators/kyber-public-key.validator.ts
@@ -4,8 +4,7 @@ import {
   type ValidationArguments,
 } from 'class-validator';
 
-// Confirmed via kem.publicKeyBytes from @dashlane/pqc-kem-kyber512-node, the lib used in
-// src/externals/asymmetric-encryption/providers/kyber.provider.ts.
+// Confirmed via kem.publicKeyBytes from @dashlane/pqc-kem-kyber512-node
 const KYBER512_PUBLIC_KEY_BYTES = 800;
 
 export function IsKyberPublicKey(validationOptions?: ValidationOptions) {
@@ -29,7 +28,7 @@ export function IsKyberPublicKey(validationOptions?: ValidationOptions) {
           }
         },
         defaultMessage(args: ValidationArguments) {
-          return `${args.property} must be a valid Kyber512 public key (${KYBER512_PUBLIC_KEY_BYTES} bytes base64-encoded)`;
+          return `${args.property} is not a valid Kyber public key`;
         },
       },
     });

--- a/src/externals/asymmetric-encryption/decorators/openpgp-public-key.validator.spec.ts
+++ b/src/externals/asymmetric-encryption/decorators/openpgp-public-key.validator.spec.ts
@@ -1,0 +1,78 @@
+import { generateKey } from 'openpgp';
+import { validate } from 'class-validator';
+import { IsOpenPgpPublicKey } from './openpgp-public-key.validator';
+
+class TestDto {
+  @IsOpenPgpPublicKey()
+  publicKey: string;
+}
+
+describe('IsOpenPgpPublicKey', () => {
+  it('When value is a valid OpenPGP public key, then pass', async () => {
+    const { publicKey } = await generateKey({
+      userIDs: [{ email: 'inxt@inxt.com' }],
+      curve: 'ed25519',
+    });
+    const dto = new TestDto();
+    dto.publicKey = Buffer.from(publicKey).toString('base64');
+
+    const errors = await validate(dto);
+
+    expect(errors.length).toBe(0);
+  });
+
+  it('When value is a private key armored as base64, then fail', async () => {
+    const { privateKey } = await generateKey({
+      userIDs: [{ email: 'inxt@inxt.com' }],
+      curve: 'ed25519',
+    });
+    const dto = new TestDto();
+    dto.publicKey = Buffer.from(privateKey).toString('base64');
+
+    const errors = await validate(dto);
+
+    expect(errors.length).toBeGreaterThan(0);
+    expect(errors[0].property).toBe('publicKey');
+    expect(errors[0].constraints).toHaveProperty('isOpenPgpPublicKey');
+  });
+
+  it('When value is not base64, then fail', async () => {
+    const dto = new TestDto();
+    dto.publicKey = 'not-a-valid-key!!!';
+
+    const errors = await validate(dto);
+
+    expect(errors.length).toBeGreaterThan(0);
+    expect(errors[0].constraints).toHaveProperty('isOpenPgpPublicKey');
+  });
+
+  it('When value is random base64 garbage, then fail', async () => {
+    const dto = new TestDto();
+    dto.publicKey = Buffer.from('just some random text').toString('base64');
+
+    const errors = await validate(dto);
+
+    expect(errors.length).toBeGreaterThan(0);
+    expect(errors[0].constraints).toHaveProperty('isOpenPgpPublicKey');
+  });
+
+  it('When value is empty string, then fail', async () => {
+    const dto = new TestDto();
+    dto.publicKey = '';
+
+    const errors = await validate(dto);
+
+    expect(errors.length).toBeGreaterThan(0);
+    expect(errors[0].constraints).toHaveProperty('isOpenPgpPublicKey');
+  });
+
+  it('When value is undefined, then fail', async () => {
+    const dto = new TestDto();
+    dto.publicKey = undefined;
+
+    const errors = await validate(dto);
+
+    expect(errors.length).toBeGreaterThan(0);
+    expect(errors[0].constraints).toHaveProperty('isOpenPgpPublicKey');
+  });
+});

--- a/src/externals/asymmetric-encryption/decorators/openpgp-public-key.validator.ts
+++ b/src/externals/asymmetric-encryption/decorators/openpgp-public-key.validator.ts
@@ -1,0 +1,35 @@
+import {
+  registerDecorator,
+  type ValidationOptions,
+  type ValidationArguments,
+} from 'class-validator';
+import { readKey } from 'openpgp';
+
+export function IsOpenPgpPublicKey(validationOptions?: ValidationOptions) {
+  return function (object: object, propertyName: string) {
+    registerDecorator({
+      name: 'isOpenPgpPublicKey',
+      target: object.constructor,
+      propertyName: propertyName,
+      options: validationOptions,
+      validator: {
+        async validate(value: any) {
+          if (typeof value !== 'string' || value.length === 0) {
+            return false;
+          }
+
+          try {
+            const armoredKey = Buffer.from(value, 'base64').toString();
+            const key = await readKey({ armoredKey });
+            return !key.isPrivate();
+          } catch {
+            return false;
+          }
+        },
+        defaultMessage(args: ValidationArguments) {
+          return `${args.property} must be a valid OpenPGP public key`;
+        },
+      },
+    });
+  };
+}

--- a/src/externals/asymmetric-encryption/decorators/openpgp-public-key.validator.ts
+++ b/src/externals/asymmetric-encryption/decorators/openpgp-public-key.validator.ts
@@ -27,7 +27,7 @@ export function IsOpenPgpPublicKey(validationOptions?: ValidationOptions) {
           }
         },
         defaultMessage(args: ValidationArguments) {
-          return `${args.property} must be a valid OpenPGP public key`;
+          return `${args.property} is not a valid OpenPGP public key`;
         },
       },
     });

--- a/src/externals/crypto/decorators/is-encrypted-mnemonic.decorator.spec.ts
+++ b/src/externals/crypto/decorators/is-encrypted-mnemonic.decorator.spec.ts
@@ -35,18 +35,6 @@ describe('IsEncryptedMnemonic', () => {
     });
   });
 
-  it('When encrypted 12-word mnemonic is provided, then validation error returned', async () => {
-    const mnemonic = generateMnemonic(128);
-    const encrypted = encryptMnemonicForTest(mnemonic, 'password');
-
-    const errors = await validate(buildDto(encrypted));
-
-    expect(errors.length).toBeGreaterThan(0);
-    expect(errors[0].constraints).toMatchObject({
-      minLength: 'Invalid encrypted mnemonic.',
-    });
-  });
-
   it('When mnemonic is too long, then validation error returned', async () => {
     const errors = await validate(buildDto('a'.repeat(481)));
 

--- a/src/modules/keyserver/dto/keys.dto.ts
+++ b/src/modules/keyserver/dto/keys.dto.ts
@@ -10,8 +10,8 @@ import { IsOpenPgpPublicKey } from '../../../externals/asymmetric-encryption/dec
 import { IsKyberPublicKey } from '../../../externals/asymmetric-encryption/decorators/kyber-public-key.validator';
 import { IsEncryptedKeyOfSize } from '../../../externals/asymmetric-encryption/decorators/encrypted-key.validator';
 
-// Kyber512 raw private key is 1632 bytes (confirmed via kem.privateKeyBytes from @dashlane/pqc-kem-kyber512-node)
-// // aes.encrypt() is fed its base64 string (see getKeys() in the key-generation client),
+// Kyber512 raw private key is 1632 bytes (see kyber-public-key.validator.ts).
+// aes.encrypt() is fed its base64 string (see getKeys() in the key-generation client),
 // so the plaintext payload is Math.ceil(1632 / 3) * 4 = 2176 bytes.
 const KYBER512_PRIVATE_KEY_BASE64_BYTES = 2176;
 

--- a/src/modules/keyserver/dto/keys.dto.ts
+++ b/src/modules/keyserver/dto/keys.dto.ts
@@ -15,11 +15,6 @@ import { IsEncryptedKeyOfSize } from '../../../externals/asymmetric-encryption/d
 // so the plaintext payload is Math.ceil(1632 / 3) * 4 = 2176 bytes.
 const KYBER512_PRIVATE_KEY_BASE64_BYTES = 2176;
 
-// Encrypted ECC key (openpgp@6, ed25519Legacy, drive-web, always same fixed
-// userID 'inxt@inxt.com') weighs 907 bytes, rarely 903.
-const ECC_PRIVATE_KEY_MIN_PAYLOAD_BYTES = 903;
-const ECC_PRIVATE_KEY_MAX_PAYLOAD_BYTES = 907;
-
 export class KyberKeysDto {
   @IsString()
   @IsNotEmpty()
@@ -52,10 +47,7 @@ export class EccKeysDto {
 
   @IsString()
   @IsNotEmpty()
-  @IsEncryptedKeyOfSize({
-    minPayloadBytes: ECC_PRIVATE_KEY_MIN_PAYLOAD_BYTES,
-    maxPayloadBytes: ECC_PRIVATE_KEY_MAX_PAYLOAD_BYTES,
-  })
+  @IsEncryptedKeyOfSize()
   @ApiProperty({
     example: 'privateKeyExample',
     description: 'Private key',

--- a/src/modules/keyserver/dto/keys.dto.ts
+++ b/src/modules/keyserver/dto/keys.dto.ts
@@ -15,6 +15,11 @@ import { IsEncryptedKeyOfSize } from '../../../externals/asymmetric-encryption/d
 // so the plaintext payload is Math.ceil(1632 / 3) * 4 = 2176 bytes.
 const KYBER512_PRIVATE_KEY_BASE64_BYTES = 2176;
 
+// Encrypted ECC key (openpgp@6, ed25519Legacy, drive-web, always same fixed
+// userID 'inxt@inxt.com') weighs 907 bytes, rarely 903.
+const ECC_PRIVATE_KEY_MIN_PAYLOAD_BYTES = 903;
+const ECC_PRIVATE_KEY_MAX_PAYLOAD_BYTES = 907;
+
 export class KyberKeysDto {
   @IsString()
   @IsNotEmpty()
@@ -47,7 +52,10 @@ export class EccKeysDto {
 
   @IsString()
   @IsNotEmpty()
-  @IsEncryptedKeyOfSize()
+  @IsEncryptedKeyOfSize({
+    minPayloadBytes: ECC_PRIVATE_KEY_MIN_PAYLOAD_BYTES,
+    maxPayloadBytes: ECC_PRIVATE_KEY_MAX_PAYLOAD_BYTES,
+  })
   @ApiProperty({
     example: 'privateKeyExample',
     description: 'Private key',

--- a/src/modules/keyserver/dto/keys.dto.ts
+++ b/src/modules/keyserver/dto/keys.dto.ts
@@ -6,10 +6,19 @@ import {
   ValidateNested,
   IsOptional,
 } from 'class-validator';
+import { IsOpenPgpPublicKey } from '../../../externals/asymmetric-encryption/decorators/openpgp-public-key.validator';
+import { IsKyberPublicKey } from '../../../externals/asymmetric-encryption/decorators/kyber-public-key.validator';
+import { IsEncryptedKeyOfSize } from '../../../externals/asymmetric-encryption/decorators/encrypted-key.validator';
+
+// Kyber512 raw private key is 1632 bytes (confirmed via kem.privateKeyBytes from @dashlane/pqc-kem-kyber512-node)
+// // aes.encrypt() is fed its base64 string (see getKeys() in the key-generation client),
+// so the plaintext payload is Math.ceil(1632 / 3) * 4 = 2176 bytes.
+const KYBER512_PRIVATE_KEY_BASE64_BYTES = 2176;
 
 export class KyberKeysDto {
   @IsString()
   @IsNotEmpty()
+  @IsKyberPublicKey()
   @ApiProperty({
     example: 'publicKeyExample',
     description: 'Public key',
@@ -18,6 +27,7 @@ export class KyberKeysDto {
 
   @IsString()
   @IsNotEmpty()
+  @IsEncryptedKeyOfSize(KYBER512_PRIVATE_KEY_BASE64_BYTES)
   @ApiProperty({
     example: 'privateKeyExample',
     description: 'Private key',
@@ -28,6 +38,7 @@ export class KyberKeysDto {
 export class EccKeysDto {
   @IsString()
   @IsNotEmpty()
+  @IsOpenPgpPublicKey()
   @ApiProperty({
     example: 'publicKeyExample',
     description: 'Public key',
@@ -36,6 +47,7 @@ export class EccKeysDto {
 
   @IsString()
   @IsNotEmpty()
+  @IsEncryptedKeyOfSize()
   @ApiProperty({
     example: 'privateKeyExample',
     description: 'Private key',
@@ -61,8 +73,8 @@ export class KeysDto {
   ecc: EccKeysDto;
 
   // TODO: uncomment validations when frontend stops sending kyber object as {privateKey: null, publicKey: null}
-  //@Type(() => KyberKeysDto)
-  //@ValidateNested()
+  @Type(() => KyberKeysDto)
+  @ValidateNested()
   @ApiProperty({
     type: KyberKeysDto,
     description: 'Kyber keys',

--- a/test/helpers/register.helper.ts
+++ b/test/helpers/register.helper.ts
@@ -1,7 +1,10 @@
 import { v4 } from 'uuid';
 import { generateMnemonic } from 'bip39';
+import { aes } from '@internxt/lib';
 import { generateNewKeys } from '../../src/externals/asymmetric-encryption/openpgp';
 import { importEsmPackage } from '../../src/lib/import-esm-package';
+
+const TEST_KEYS_ENCRYPTION_PASSWORD = 'test-keys-password';
 
 export interface RegisterUserDto {
   name: string;
@@ -46,7 +49,10 @@ async function generateEccKeys(): Promise<EccKeys> {
   const keys = await generateNewKeys();
   return {
     publicKey: keys.publicKeyArmored,
-    privateKey: keys.privateKeyArmored,
+    privateKey: aes.encrypt(
+      keys.privateKeyArmored,
+      TEST_KEYS_ENCRYPTION_PASSWORD,
+    ),
     revocationKey: keys.revocationCertificate,
   };
 }
@@ -57,9 +63,10 @@ async function generateKyberKeys(): Promise<KyberKeys> {
   >('@dashlane/pqc-kem-kyber512-node');
   const kem = await kemBuilder();
   const keys = await kem.keypair();
+  const privateKeyBase64 = Buffer.from(keys.privateKey).toString('base64');
   return {
     publicKey: Buffer.from(keys.publicKey).toString('base64'),
-    privateKey: Buffer.from(keys.privateKey).toString('base64'),
+    privateKey: aes.encrypt(privateKeyBase64, TEST_KEYS_ENCRYPTION_PASSWORD),
   };
 }
 


### PR DESCRIPTION
## What

Input keys format / bytes validation.

- `IsOpenPgpPublicKey()` — Ecc `publicKey`
- `IsKyberPublicKey()` — Kyber `publicKey`
- `IsEncryptedKeyOfSize(exactPayloadBytes?)` — both `privateKey` fields

## Why

Before this, `publicKey`/`privateKey` only had `@IsString() @IsNotEmpty()`, any string passed.

## How

**publicKey**: real checks against known constraints.
- Ecc: `openpgp.readKey()` must parse + `!key.isPrivate()`. Real structural parse, not heuristic.
- Kyber512: must decode to exactly 800 bytes (confirmed via `kem.publicKeyBytes` from `@dashlane/pqc-kem-kyber512-node`). We do not use the library here because NestJS fails getting ESM only modules.

**privateKey**: both are AES-256-GCM blobs (`salt(64)+iv(16)+tag(16)+payload`), base64. Server never sees plaintext key:
- Kyber: exact size works. Client encrypts the raw key's base64 string; raw key is always 1632 bytes → base64 = 2176 bytes → full blob = 96 (AES headers) +2176 = **2272 bytes exact**. Verified with real keypair + real `AesService.encrypt()`.
- Ecc: varies between 903 and 907. Also, according to the openpgp version the key is heavier (there's a difference of ~200 bytes between the keys created with openpgp 5 and 6).
  - ℹ️  I've omitted this test as this repository openpgp version is still 5 and I was not able to create good e2e tests to secure a smooth deployment. We can update in a later PR if required.
