### PR TITLE
[_]: fix/add parent id to the get devices as folder query

### DIFF
--- a/src/modules/backups/backup.usecase.ts
+++ b/src/modules/backups/backup.usecase.ts
@@ -142,6 +142,7 @@ export class BackupUseCase {
 
     const folders = await this.folderUsecases.getFoldersByUserId(user.id, {
       bucket: user.backupsBucket,
+      parentId: null,
       removed: false,
       deleted: false,
     });


### PR DESCRIPTION
After the `20260527141826-recreate-index-folders-bucket` migration was introduced this query was performing a sequential scan, adding parent_id null to the query makes it use the index