### PR TITLE
[_] fix/remove keys check from cli if not received

### DIFF
--- a/src/modules/auth/auth.controller.ts
+++ b/src/modules/auth/auth.controller.ts
@@ -30,6 +30,7 @@ import { KeyServerUseCases } from '../keyserver/key-server.usecase';
 import { CryptoService } from '../../externals/crypto/crypto.service';
 import { LoginDto } from './dto/login-dto';
 import { LoginAccessDto } from './dto/login-access.dto';
+import { CliLoginAccessDto } from './dto/cli-login-access.dto';
 import { User as UserDecorator } from './decorators/user.decorator';
 import { TwoFactorAuthService } from './two-factor-auth.service';
 import { DeleteTfaDto } from './dto/delete-tfa.dto';
@@ -279,7 +280,7 @@ export class AuthController {
   })
   @Public()
   async cliLoginAccess(
-    @Body() body: LoginAccessDto,
+    @Body() body: CliLoginAccessDto,
     @Client() client: string,
   ): Promise<LoginAccessResponseDto> {
     let platform = ClientToPlatformMap[client as ClientEnum];
@@ -293,11 +294,7 @@ export class AuthController {
       'Attempting platform login',
     );
     try {
-      const { ecc, kyber } = this.keyServerUseCases.parseKeysInput(body.keys, {
-        privateKey: body.privateKey,
-        publicKey: body.publicKey,
-        revocationKey: body.revocateKey,
-      });
+      const { ecc, kyber } = this.keyServerUseCases.parseKeysInput(body.keys);
 
       const result = await this.userUseCases.loginAccess({
         ...body,

--- a/src/modules/auth/dto/cli-login-access.dto.ts
+++ b/src/modules/auth/dto/cli-login-access.dto.ts
@@ -1,0 +1,97 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import {
+  IsEmail,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  ValidateNested,
+} from 'class-validator';
+import { IsEncryptedPassword } from '../../../externals/crypto/decorators/password-dto.validators';
+import { IsOpenPgpPublicKey } from '../../../externals/asymmetric-encryption/decorators/openpgp-public-key.validator';
+import { IsKyberPublicKey } from '../../../externals/asymmetric-encryption/decorators/kyber-public-key.validator';
+import { IsEncryptedKeyOfSize } from '../../../externals/asymmetric-encryption/decorators/encrypted-key.validator';
+import { KYBER512_PRIVATE_KEY_BASE64_BYTES } from '../../keyserver/dto/keys.dto';
+
+class CliEccKeysDto {
+  @IsString()
+  @IsNotEmpty()
+  @IsOpenPgpPublicKey()
+  @ApiProperty({ example: 'publicKeyExample', required: false })
+  publicKey: string;
+
+  @IsString()
+  @IsNotEmpty()
+  @IsEncryptedKeyOfSize()
+  @ApiProperty({ example: 'privateKeyExample', required: false })
+  privateKey: string;
+
+  @IsOptional()
+  @IsString()
+  @ApiProperty({ example: 'revocationKeyExample', required: false })
+  revocationKey?: string;
+}
+
+class CliKyberKeysDto {
+  @IsString()
+  @IsNotEmpty()
+  @IsKyberPublicKey()
+  @ApiProperty({ example: 'publicKeyExample', required: false })
+  publicKey: string;
+
+  @IsString()
+  @IsNotEmpty()
+  @IsEncryptedKeyOfSize(KYBER512_PRIVATE_KEY_BASE64_BYTES)
+  @ApiProperty({ example: 'privateKeyExample', required: false })
+  privateKey: string;
+}
+
+class CliKeysDto {
+  @IsOptional()
+  @Type(() => CliEccKeysDto)
+  @ValidateNested()
+  @ApiProperty({ type: CliEccKeysDto, required: false })
+  ecc?: CliEccKeysDto;
+
+  @IsOptional()
+  @Type(() => CliKyberKeysDto)
+  @ValidateNested()
+  @ApiProperty({ type: CliKyberKeysDto, required: false })
+  kyber?: CliKyberKeysDto;
+}
+
+export class CliLoginAccessDto {
+  @ApiProperty({
+    example: 'user@internxt.com',
+    description: 'The email of the user',
+  })
+  @IsNotEmpty()
+  @IsEmail()
+  email: string;
+
+  @ApiProperty({
+    example: 'some_hashed_pass',
+    description: 'User password',
+  })
+  @IsEncryptedPassword()
+  password: string;
+
+  @ApiProperty({
+    example: 'two_factor_authentication_code',
+    description: 'TFA',
+    required: false,
+  })
+  @IsOptional()
+  @IsString()
+  tfa?: string;
+
+  @Type(() => CliKeysDto)
+  @IsOptional()
+  @ValidateNested()
+  @ApiProperty({
+    type: CliKeysDto,
+    description: 'keys',
+    required: false,
+  })
+  keys?: CliKeysDto;
+}


### PR DESCRIPTION
CLI legacy access got broken because of the enforcement of keys. As making the kyber keys optional in the web login just opens more paths for that flow (we want to enforce the format, etc, etc), I suggest to create a different dto for cli.

## Changes
- Added a different dto for cli access to prevent breaking the flow with any new check we add for web.