### PR TITLE
[MKT_949]:feat/integrate turnstile

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -24,6 +24,9 @@ RDS_USERNAME=postgres
 RECAPTCHA_V3=captcha_secret
 RECAPTCHA_V3_ENDPOINT=https://www.google.com/recaptcha/api/siteverify
 REDIS_CONNECTION_STRING=redis://@drive-cache:6380
+TURNSTILE_ENDPOINT=https://challenges.cloudflare.com/turnstile/v0/siteverify
+TURNSTILE_SECRET=captcha_secret
+CAPTCHA_PROVIDER=turnstile
 
 SENDGRID_API_KEY=sendgrid_api_key
 SENDGRID_MODE_SANDBOX=true

--- a/src/config/configuration.ts
+++ b/src/config/configuration.ts
@@ -43,6 +43,7 @@ export default () => ({
     gateway: process.env.GATEWAY_SECRET,
     driveGateway: process.env.DRIVE_GATEWAY_PUBLIC_SECRET,
     captcha: process.env.RECAPTCHA_V3,
+    turnstileCaptcha: process.env.TURNSTILE_SECRET,
     jitsiSecret: process.env.JITSI_SECRET,
   },
   apis: {
@@ -65,8 +66,12 @@ export default () => ({
       url: process.env.SHARE_DOMAINS,
     },
     captcha: {
+      provider: process.env.CAPTCHA_PROVIDER || 'recaptcha',
       url: process.env.RECAPTCHA_V3_ENDPOINT,
       threshold: process.env.RECAPTCHA_V3_SCORE_THRESHOLD,
+      turnstileUrl:
+        process.env.TURNSTILE_ENDPOINT ||
+        'https://challenges.cloudflare.com/turnstile/v0/siteverify',
     },
     payments: {
       url: process.env.PAYMENTS_API_URL,

--- a/src/externals/captcha/captcha.service.spec.ts
+++ b/src/externals/captcha/captcha.service.spec.ts
@@ -1,0 +1,128 @@
+import axios from 'axios';
+import { CaptchaService } from './captcha.service';
+
+jest.mock('axios');
+
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+describe('CaptchaService', () => {
+  let service: CaptchaService;
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    service = new CaptchaService();
+    process.env = { ...originalEnv, NODE_ENV: 'production' };
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  it('When not in production, then it skips verification and returns true', async () => {
+    process.env.NODE_ENV = 'development';
+
+    const result = await service.verifyCaptcha('any-token', '1.2.3.4');
+
+    expect(result).toBe(true);
+    expect(mockedAxios.post).not.toHaveBeenCalled();
+  });
+
+  describe('reCAPTCHA provider (default)', () => {
+    beforeEach(() => {
+      process.env.CAPTCHA_PROVIDER = 'recaptcha';
+      process.env.RECAPTCHA_V3_ENDPOINT = 'https://recaptcha.test/verify';
+      process.env.RECAPTCHA_V3 = 'recaptcha-secret';
+      process.env.RECAPTCHA_V3_SCORE_THRESHOLD = '0.5';
+    });
+
+    it('When success and score is above threshold, then it returns true', async () => {
+      mockedAxios.post.mockResolvedValueOnce({
+        data: { success: true, score: 0.9 },
+      });
+
+      const result = await service.verifyCaptcha('token', '1.2.3.4');
+
+      expect(result).toBe(true);
+      expect(mockedAxios.post).toHaveBeenCalledWith(
+        'https://recaptcha.test/verify',
+        expect.stringContaining('secret=recaptcha-secret'),
+        expect.anything(),
+      );
+    });
+
+    it('When score is below threshold, then it returns false', async () => {
+      mockedAxios.post.mockResolvedValueOnce({
+        data: { success: true, score: 0.1 },
+      });
+
+      const result = await service.verifyCaptcha('token', '1.2.3.4');
+
+      expect(result).toBe(false);
+    });
+
+    it('When verification is not successful, then it returns false', async () => {
+      mockedAxios.post.mockResolvedValueOnce({
+        data: { success: false, 'error-codes': ['invalid-input-response'] },
+      });
+
+      const result = await service.verifyCaptcha('token', '1.2.3.4');
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('Turnstile provider', () => {
+    beforeEach(() => {
+      process.env.CAPTCHA_PROVIDER = 'turnstile';
+      process.env.TURNSTILE_ENDPOINT = 'https://turnstile.test/siteverify';
+      process.env.TURNSTILE_SECRET = 'turnstile-secret';
+    });
+
+    it('When success is true, then it returns true without checking any score', async () => {
+      mockedAxios.post.mockResolvedValueOnce({
+        data: { success: true, challenge_ts: '2026-07-24T00:00:00Z' },
+      });
+
+      const result = await service.verifyCaptcha('token', '1.2.3.4');
+
+      expect(result).toBe(true);
+      expect(mockedAxios.post).toHaveBeenCalledWith(
+        'https://turnstile.test/siteverify',
+        expect.stringContaining('secret=turnstile-secret'),
+        expect.anything(),
+      );
+    });
+
+    it('When it falls back to the default Cloudflare endpoint if none is configured', async () => {
+      delete process.env.TURNSTILE_ENDPOINT;
+      mockedAxios.post.mockResolvedValueOnce({ data: { success: true } });
+
+      await service.verifyCaptcha('token', '1.2.3.4');
+
+      expect(mockedAxios.post).toHaveBeenCalledWith(
+        'https://challenges.cloudflare.com/turnstile/v0/siteverify',
+        expect.any(String),
+        expect.anything(),
+      );
+    });
+
+    it('When success is false, then it returns false', async () => {
+      mockedAxios.post.mockResolvedValueOnce({
+        data: { success: false, 'error-codes': ['timeout-or-duplicate'] },
+      });
+
+      const result = await service.verifyCaptcha('token', '1.2.3.4');
+
+      expect(result).toBe(false);
+    });
+
+    it('When the request throws, then it returns false', async () => {
+      mockedAxios.post.mockRejectedValueOnce(new Error('network error'));
+
+      const result = await service.verifyCaptcha('token', '1.2.3.4');
+
+      expect(result).toBe(false);
+    });
+  });
+});

--- a/src/externals/captcha/captcha.service.ts
+++ b/src/externals/captcha/captcha.service.ts
@@ -12,38 +12,68 @@ export class CaptchaService {
     }
 
     try {
-      const response = await axios.post(
-        getEnv().apis.captcha.url,
-        encode({
-          secret: getEnv().secrets.captcha,
-          response: token,
-          remoteip: ip,
-        }),
-        {
-          headers: {
-            'Content-Type': 'application/x-www-form-urlencoded',
-          },
-        },
-      );
-
-      if (!response.data.success) {
-        throw Error(
-          'Captcha verification failed ' + response.data['error-codes'],
-        );
-      }
-
-      const score = response.data.score;
-
-      if (score < getEnv().apis.captcha.threshold) {
-        throw new Error(`Score ${score} is below threshold`);
-      }
-
-      return response.data.success;
+      return getEnv().apis.captcha.provider === 'turnstile'
+        ? await this.verifyTurnstile(token, ip)
+        : await this.verifyRecaptcha(token, ip);
     } catch (error) {
       Logger.error(
         `[AUTH/CAPTCHA_VERIFICATION] Error while verifying the captcha token: ${error}`,
       );
       return false;
     }
+  }
+
+  private async verifyRecaptcha(token: string, ip: string): Promise<boolean> {
+    const response = await axios.post(
+      getEnv().apis.captcha.url,
+      encode({
+        secret: getEnv().secrets.captcha,
+        response: token,
+        remoteip: ip,
+      }),
+      {
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded',
+        },
+      },
+    );
+
+    if (!response.data.success) {
+      throw new Error(
+        'Captcha verification failed ' + response.data['error-codes'],
+      );
+    }
+
+    const score = response.data.score;
+
+    if (score < getEnv().apis.captcha.threshold) {
+      throw new Error(`Score ${score} is below threshold`);
+    }
+
+    return response.data.success;
+  }
+
+  private async verifyTurnstile(token: string, ip: string): Promise<boolean> {
+    const response = await axios.post(
+      getEnv().apis.captcha.turnstileUrl,
+      encode({
+        secret: getEnv().secrets.turnstileCaptcha,
+        response: token,
+        remoteip: ip,
+      }),
+      {
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded',
+        },
+      },
+    );
+
+    if (!response.data.success) {
+      throw new Error(
+        'Turnstile verification failed ' + response.data['error-codes'],
+      );
+    }
+
+    return response.data.success;
   }
 }


### PR DESCRIPTION
This PR tries to Add support for Cloudflare Turnstile as an alternative CAPTCHA provider alongside the existing Google reCAPTCHA v3. The provider is selectable at runtime via a new CAPTCHA_PROVIDER environment variable, so we can switch between reCAPTCHA and Turnstile without code changes.

Changes:
- captcha.service.ts: Refactored CaptchaService to route verification based on the configured provider. The old inline reCAPTCHA logic is now extracted into a private verifyRecaptcha() method, and a new verifyTurnstile() method handles ------Turnstile's siteverify endpoint. Shared error handling/logging remains in the public verify() method.
configuration.ts: Added captcha.provider (defaults to recaptcha), captcha.turnstileUrl (defaults to Cloudflare's siteverify endpoint), and secrets.turnstileCaptcha.
-.env.template: Added TURNSTILE_ENDPOINT, TURNSTILE_SECRET, and CAPTCHA_PROVIDER.
-captcha.service.spec.ts: New test suite covering both providers, including success, failure, below-threshold (reCAPTCHA), and error scenarios.

### Notes
We will need new Environment variables