### PR TITLE
[_]: fix/make parent folder as optional

### DIFF
--- a/src/modules/send/dto/create-send-link.dto.ts
+++ b/src/modules/send/dto/create-send-link.dto.ts
@@ -64,12 +64,13 @@ export class SendLinkItemDto {
   })
   encryptionKey: string;
 
+  @IsOptional()
   @IsString()
   @ApiProperty({
     example: 'b4aef6a2-daca-47f1-8bee-34ab5a47c9f',
     description: 'parent folder id of item (uuidv4 format)',
   })
-  parent_folder: string;
+  parent_folder?: string;
 }
 
 export class CreateSendLinkDto {


### PR DESCRIPTION
Making the parent folder property optional when creating a shared link.