### PR TITLE
[PB-6706]: fix/enhance file upload notifications based on user backup bucket

### DIFF
--- a/src/externals/notifications/storage.notifications.service.spec.ts
+++ b/src/externals/notifications/storage.notifications.service.spec.ts
@@ -83,6 +83,47 @@ describe('StorageNotificationService', () => {
         user.uuid,
       );
     });
+
+    it('When the file is uploaded to the user backups bucket, then it should add the notification event but not send an APN notification', () => {
+      jest.spyOn(service, 'getTokensAndSendApnNotification');
+      const backupUser = newUser({
+        attributes: { backupsBucket: 'backup-bucket' },
+      });
+      const backupPayload = {
+        ...payload,
+        bucket: backupUser.backupsBucket,
+      } as unknown as FileDto;
+
+      service.fileCreated({
+        payload: backupPayload,
+        user: backupUser,
+        clientId,
+      });
+
+      expect(notificationService.add).toHaveBeenCalled();
+      expect(service.getTokensAndSendApnNotification).not.toHaveBeenCalled();
+    });
+
+    it('When the file is uploaded to a bucket other than the backups one, then it should send an APN notification', () => {
+      jest.spyOn(service, 'getTokensAndSendApnNotification');
+      const backupUser = newUser({
+        attributes: { backupsBucket: 'backups-bucket' },
+      });
+      const drivePayload = {
+        ...payload,
+        bucket: 'drive-bucket',
+      } as unknown as FileDto;
+
+      service.fileCreated({
+        payload: drivePayload,
+        user: backupUser,
+        clientId,
+      });
+
+      expect(service.getTokensAndSendApnNotification).toHaveBeenCalledWith(
+        backupUser.uuid,
+      );
+    });
   });
 
   describe('fileUpdated', () => {

--- a/src/externals/notifications/storage.notifications.service.ts
+++ b/src/externals/notifications/storage.notifications.service.ts
@@ -48,7 +48,10 @@ export class StorageNotificationService {
     );
 
     this.notificationService.add(event);
-    this.getTokensAndSendApnNotification(user.uuid);
+
+    if (!user.ownsBackupsBucket(payload.bucket)) {
+      this.getTokensAndSendApnNotification(user.uuid);
+    }
   }
 
   fileUpdated({ payload, user, clientId }: EventArguments<FileDto>) {
@@ -62,7 +65,10 @@ export class StorageNotificationService {
     );
 
     this.notificationService.add(event);
-    this.getTokensAndSendApnNotification(user.uuid);
+
+    if (!user.ownsBackupsBucket(payload.bucket)) {
+      this.getTokensAndSendApnNotification(user.uuid);
+    }
   }
 
   fileDeleted({

--- a/src/modules/user/user.domain.ts
+++ b/src/modules/user/user.domain.ts
@@ -111,6 +111,10 @@ export class User implements UserAttributes {
     return !!this.backupsBucket;
   }
 
+  ownsBackupsBucket(bucket?: string): boolean {
+    return this.hasBackupsEnabled() && bucket === this.backupsBucket;
+  }
+
   hasPhotosEnabled(): boolean {
     return !!this.photosBucket;
   }


### PR DESCRIPTION
Skipped sending APN notifications when backup files are uploaded.
- Added logic to conditionally send APN notifications based on whether the uploaded file is in the user's backups bucket.
- Introduced a new method `ownsBackupsBucket` in the User class to check bucket ownership.
- Updated unit tests to cover scenarios for both backup and non-backup bucket uploads.