### PR TITLE
[PB-6706]: feat/implement APN refresh processor and notification queuing

### DIFF
--- a/src/externals/notifications/apn-refresh-queue.module.ts
+++ b/src/externals/notifications/apn-refresh-queue.module.ts
@@ -1,0 +1,19 @@
+import { Module } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { BullModule } from '@nestjs/bullmq';
+import { buildBullConnectionOptions } from '../../lib/bull-connection';
+import { APN_REFRESH_QUEUE } from './storage.notifications.service';
+
+@Module({
+  imports: [
+    BullModule.registerQueueAsync({
+      name: APN_REFRESH_QUEUE,
+      inject: [ConfigService],
+      useFactory: (configService: ConfigService) => ({
+        connection: buildBullConnectionOptions(configService),
+      }),
+    }),
+  ],
+  exports: [BullModule],
+})
+export class ApnRefreshQueueModule {}

--- a/src/externals/notifications/apn-refresh.processor.spec.ts
+++ b/src/externals/notifications/apn-refresh.processor.spec.ts
@@ -1,0 +1,57 @@
+import { createMock, type DeepMocked } from '@golevelup/ts-jest';
+import { Test } from '@nestjs/testing';
+import { type Logger } from '@nestjs/common';
+import { type Job } from 'bullmq';
+import { ApnRefreshProcessor } from './apn-refresh.processor';
+import {
+  type ApnRefreshJobData,
+  StorageNotificationService,
+} from './storage.notifications.service';
+import { newUser } from '../../../test/fixtures';
+
+describe('ApnRefreshProcessor', () => {
+  let processor: ApnRefreshProcessor;
+  let storageNotificationService: DeepMocked<StorageNotificationService>;
+
+  const user = newUser();
+  const job = { data: { userUuid: user.uuid } } as Job<ApnRefreshJobData>;
+
+  beforeEach(async () => {
+    const moduleRef = await Test.createTestingModule({
+      providers: [ApnRefreshProcessor],
+    })
+      .setLogger(createMock<Logger>())
+      .useMocker(() => createMock())
+      .compile();
+
+    processor = moduleRef.get(ApnRefreshProcessor);
+    storageNotificationService = moduleRef.get(StorageNotificationService);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('When initialized, then processor should be defined', () => {
+    expect(processor).toBeDefined();
+  });
+
+  describe('process', () => {
+    it('When a job is processed, then it should send the APN storage notification for the job user', async () => {
+      await processor.process(job);
+
+      expect(
+        storageNotificationService.getTokensAndSendApnNotification,
+      ).toHaveBeenCalledWith(user.uuid);
+    });
+
+    it('When sending the notification fails, then the error should propagate so BullMQ retries', async () => {
+      const error = new Error('APN unavailable');
+      storageNotificationService.getTokensAndSendApnNotification.mockRejectedValueOnce(
+        error,
+      );
+
+      await expect(processor.process(job)).rejects.toThrow(error);
+    });
+  });
+});

--- a/src/externals/notifications/apn-refresh.processor.ts
+++ b/src/externals/notifications/apn-refresh.processor.ts
@@ -1,0 +1,35 @@
+import { Logger } from '@nestjs/common';
+import { Processor, WorkerHost } from '@nestjs/bullmq';
+import { type Job } from 'bullmq';
+import {
+  APN_REFRESH_QUEUE,
+  type ApnRefreshJobData,
+  StorageNotificationService,
+} from './storage.notifications.service';
+
+@Processor(APN_REFRESH_QUEUE, { concurrency: 10 })
+export class ApnRefreshProcessor extends WorkerHost {
+  private readonly logger = new Logger(APN_REFRESH_QUEUE);
+
+  constructor(
+    private readonly storageNotificationService: StorageNotificationService,
+  ) {
+    super();
+  }
+
+  async process(job: Job<ApnRefreshJobData>) {
+    const { userUuid } = job.data;
+
+    try {
+      await this.storageNotificationService.getTokensAndSendApnNotification(
+        userUuid,
+      );
+    } catch (error) {
+      this.logger.error(
+        { userUuid, jobId: job.id, error },
+        'APN refresh job failed.',
+      );
+      throw error;
+    }
+  }
+}

--- a/src/externals/notifications/notifications.module.ts
+++ b/src/externals/notifications/notifications.module.ts
@@ -1,13 +1,17 @@
 import { Module } from '@nestjs/common';
 import { NotificationService } from './notification.service';
-import { ConfigModule } from '@nestjs/config';
+import { ConfigModule, ConfigService } from '@nestjs/config';
+import { BullModule } from '@nestjs/bullmq';
 import { NotificationListener } from './listeners/notification.listener';
 import { HttpClientModule } from '../http/http.module';
 import { MailerModule } from '../mailer/mailer.module';
 import { SendLinkListener } from './listeners/send-link.listener';
 import { AuthListener } from './listeners/auth.listener';
 import { NewsletterService } from '../newsletter';
-import { StorageNotificationService } from './storage.notifications.service';
+import {
+  APN_REFRESH_QUEUE,
+  StorageNotificationService,
+} from './storage.notifications.service';
 import { ApnModule } from '../apn/apn.module';
 import {
   SequelizeUserRepository,
@@ -15,6 +19,8 @@ import {
 } from '../../modules/user/user.repository';
 import { SequelizeModule } from '@nestjs/sequelize';
 import { UserNotificationTokensModel } from '../../modules/user/user-notification-tokens.model';
+import { ApnRefreshProcessor } from './apn-refresh.processor';
+import { buildBullConnectionOptions } from '../../lib/bull-connection';
 
 @Module({
   imports: [
@@ -23,12 +29,20 @@ import { UserNotificationTokensModel } from '../../modules/user/user-notificatio
     MailerModule,
     SequelizeModule.forFeature([UserModel, UserNotificationTokensModel]),
     ApnModule,
+    BullModule.registerQueueAsync({
+      name: APN_REFRESH_QUEUE,
+      inject: [ConfigService],
+      useFactory: (configService: ConfigService) => ({
+        connection: buildBullConnectionOptions(configService),
+      }),
+    }),
   ],
   controllers: [],
   providers: [
     NotificationService,
     NotificationListener,
     StorageNotificationService,
+    ApnRefreshProcessor,
     SendLinkListener,
     AuthListener,
     NewsletterService,

--- a/src/externals/notifications/notifications.module.ts
+++ b/src/externals/notifications/notifications.module.ts
@@ -1,17 +1,13 @@
 import { Module } from '@nestjs/common';
 import { NotificationService } from './notification.service';
-import { ConfigModule, ConfigService } from '@nestjs/config';
-import { BullModule } from '@nestjs/bullmq';
+import { ConditionalModule, ConfigModule } from '@nestjs/config';
 import { NotificationListener } from './listeners/notification.listener';
 import { HttpClientModule } from '../http/http.module';
 import { MailerModule } from '../mailer/mailer.module';
 import { SendLinkListener } from './listeners/send-link.listener';
 import { AuthListener } from './listeners/auth.listener';
 import { NewsletterService } from '../newsletter';
-import {
-  APN_REFRESH_QUEUE,
-  StorageNotificationService,
-} from './storage.notifications.service';
+import { StorageNotificationService } from './storage.notifications.service';
 import { ApnModule } from '../apn/apn.module';
 import {
   SequelizeUserRepository,
@@ -20,7 +16,7 @@ import {
 import { SequelizeModule } from '@nestjs/sequelize';
 import { UserNotificationTokensModel } from '../../modules/user/user-notification-tokens.model';
 import { ApnRefreshProcessor } from './apn-refresh.processor';
-import { buildBullConnectionOptions } from '../../lib/bull-connection';
+import { ApnRefreshQueueModule } from './apn-refresh-queue.module';
 
 @Module({
   imports: [
@@ -29,13 +25,10 @@ import { buildBullConnectionOptions } from '../../lib/bull-connection';
     MailerModule,
     SequelizeModule.forFeature([UserModel, UserNotificationTokensModel]),
     ApnModule,
-    BullModule.registerQueueAsync({
-      name: APN_REFRESH_QUEUE,
-      inject: [ConfigService],
-      useFactory: (configService: ConfigService) => ({
-        connection: buildBullConnectionOptions(configService),
-      }),
-    }),
+    ConditionalModule.registerWhen(
+      ApnRefreshQueueModule,
+      (env) => !!env.REDIS_JOBS_CONNECTION_STRING,
+    ),
   ],
   controllers: [],
   providers: [

--- a/src/externals/notifications/storage.notifications.service.spec.ts
+++ b/src/externals/notifications/storage.notifications.service.spec.ts
@@ -1,7 +1,13 @@
 import { Test, type TestingModule } from '@nestjs/testing';
 import { createMock, type DeepMocked } from '@golevelup/ts-jest';
 import { type Logger } from '@nestjs/common';
-import { StorageNotificationService } from './storage.notifications.service';
+import { getQueueToken } from '@nestjs/bullmq';
+import { type Queue } from 'bullmq';
+import {
+  APN_REFRESH_DEBOUNCE_MS,
+  APN_REFRESH_QUEUE,
+  StorageNotificationService,
+} from './storage.notifications.service';
 import { NotificationService } from './notification.service';
 import { ApnService } from '../apn/apn.service';
 import { SequelizeUserRepository } from '../../modules/user/user.repository';
@@ -22,13 +28,20 @@ describe('StorageNotificationService', () => {
   let notificationService: NotificationService;
   let apnService: ApnService;
   let userRepository: SequelizeUserRepository;
+  let apnRefreshQueue: DeepMocked<Queue>;
   let loggerMock: DeepMocked<Logger>;
 
   beforeEach(async () => {
     loggerMock = createMock<Logger>();
 
     const module: TestingModule = await Test.createTestingModule({
-      providers: [StorageNotificationService],
+      providers: [
+        StorageNotificationService,
+        {
+          provide: getQueueToken(APN_REFRESH_QUEUE),
+          useValue: createMock<Queue>(),
+        },
+      ],
     })
       .setLogger(loggerMock)
       .useMocker(createMock)
@@ -45,6 +58,7 @@ describe('StorageNotificationService', () => {
     userRepository = module.get<SequelizeUserRepository>(
       SequelizeUserRepository,
     );
+    apnRefreshQueue = module.get(getQueueToken(APN_REFRESH_QUEUE));
   });
 
   it('should be defined', () => {
@@ -60,11 +74,11 @@ describe('StorageNotificationService', () => {
     const payload = {
       fileId: '123',
       fileName: 'test.pdf',
+      bucket: 'drive-bucket',
     } as unknown as FileDto;
     const clientId = 'test-client';
 
-    it('When called, then it should add a notification event and send APN notification', () => {
-      jest.spyOn(service, 'getTokensAndSendApnNotification');
+    it('When called, then it should add a notification event and enqueue an APN refresh', () => {
       const notification = new NotificationEvent(
         'notification.itemCreated',
         payload,
@@ -79,16 +93,16 @@ describe('StorageNotificationService', () => {
       expect(notificationService.add).toHaveBeenCalledWith(
         expect.objectContaining(notification),
       );
-      expect(service.getTokensAndSendApnNotification).toHaveBeenCalledWith(
-        user.uuid,
+      expect(apnRefreshQueue.add).toHaveBeenCalledWith(
+        'refresh',
+        { userUuid: user.uuid },
+        expect.anything(),
       );
     });
 
-    it('When the file is uploaded to the user backups bucket, then it should add the notification event but not send an APN notification', () => {
-      jest.spyOn(service, 'getTokensAndSendApnNotification');
-      const backupUser = newUser({
-        attributes: { backupsBucket: 'backup-bucket' },
-      });
+    it('When the file belongs to the user backups bucket, then it should add the notification event but not enqueue an APN refresh', () => {
+      const backupUser = newUser();
+      backupUser.backupsBucket = 'backups-bucket';
       const backupPayload = {
         ...payload,
         bucket: backupUser.backupsBucket,
@@ -101,11 +115,28 @@ describe('StorageNotificationService', () => {
       });
 
       expect(notificationService.add).toHaveBeenCalled();
-      expect(service.getTokensAndSendApnNotification).not.toHaveBeenCalled();
+      expect(apnRefreshQueue.add).not.toHaveBeenCalled();
     });
 
-    it('When the file is uploaded to a bucket other than the backups one, then it should send an APN notification', () => {
-      jest.spyOn(service, 'getTokensAndSendApnNotification');
+    it('When the file has no bucket and the user has no backups bucket, then it should still enqueue an APN refresh', () => {
+      const userWithoutBackups = newUser();
+      userWithoutBackups.backupsBucket = null;
+      const payloadWithoutBucket = { fileId: '123' } as unknown as FileDto;
+
+      service.fileCreated({
+        payload: payloadWithoutBucket,
+        user: userWithoutBackups,
+        clientId,
+      });
+
+      expect(apnRefreshQueue.add).toHaveBeenCalledWith(
+        'refresh',
+        { userUuid: userWithoutBackups.uuid },
+        expect.anything(),
+      );
+    });
+
+    it('When the file is uploaded to a bucket other than the backups one, then it should enqueue an APN refresh', () => {
       const backupUser = newUser({
         attributes: { backupsBucket: 'backups-bucket' },
       });
@@ -120,8 +151,10 @@ describe('StorageNotificationService', () => {
         clientId,
       });
 
-      expect(service.getTokensAndSendApnNotification).toHaveBeenCalledWith(
-        backupUser.uuid,
+      expect(apnRefreshQueue.add).toHaveBeenCalledWith(
+        'refresh',
+        { userUuid: backupUser.uuid },
+        expect.anything(),
       );
     });
   });
@@ -131,11 +164,11 @@ describe('StorageNotificationService', () => {
     const payload = {
       fileId: '123',
       fileName: 'test.pdf',
+      bucket: 'drive-bucket',
     } as unknown as FileDto;
     const clientId = 'test-client';
 
-    it('When called, then it should add a notification event and send APN notification', () => {
-      jest.spyOn(service, 'getTokensAndSendApnNotification');
+    it('When called, then it should add a notification event and enqueue an APN refresh', () => {
       const notification = new NotificationEvent(
         'notification.itemUpdated',
         payload,
@@ -149,8 +182,84 @@ describe('StorageNotificationService', () => {
       expect(notificationService.add).toHaveBeenCalledWith(
         expect.objectContaining(notification),
       );
-      expect(service.getTokensAndSendApnNotification).toHaveBeenCalledWith(
+      expect(apnRefreshQueue.add).toHaveBeenCalledWith(
+        'refresh',
+        { userUuid: user.uuid },
+        expect.anything(),
+      );
+    });
+
+    it('When the file belongs to the user backups bucket, then it should add the notification event but not enqueue an APN refresh', () => {
+      const backupUser = newUser();
+      backupUser.backupsBucket = 'backups-bucket';
+      const backupPayload = {
+        ...payload,
+        bucket: backupUser.backupsBucket,
+      } as unknown as FileDto;
+
+      service.fileUpdated({
+        payload: backupPayload,
+        user: backupUser,
+        clientId,
+      });
+
+      expect(notificationService.add).toHaveBeenCalled();
+      expect(apnRefreshQueue.add).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('fileDeleted', () => {
+    const user = newUser();
+    const payload = { id: 123, uuid: v4() };
+    const clientId = 'test-client';
+
+    it('When called, then it should add a notification event and enqueue an APN refresh', () => {
+      const notification = new NotificationEvent(
+        'notification.itemDeleted',
+        payload,
+        user.email,
+        clientId,
         user.uuid,
+        'FILE_DELETED',
+      );
+
+      service.fileDeleted({ payload, user, clientId });
+
+      expect(notificationService.add).toHaveBeenCalledWith(
+        expect.objectContaining(notification),
+      );
+      expect(apnRefreshQueue.add).toHaveBeenCalledWith(
+        'refresh',
+        { userUuid: user.uuid },
+        expect.anything(),
+      );
+    });
+  });
+
+  describe('folderDeleted', () => {
+    const user = newUser();
+    const payload = { id: 123, uuid: v4(), userId: user.id };
+    const clientId = 'test-client';
+
+    it('When called, then it should add a notification event and enqueue an APN refresh', () => {
+      const notification = new NotificationEvent(
+        'notification.itemDeleted',
+        payload,
+        user.email,
+        clientId,
+        user.uuid,
+        'FOLDER_DELETED',
+      );
+
+      service.folderDeleted({ payload, user, clientId });
+
+      expect(notificationService.add).toHaveBeenCalledWith(
+        expect.objectContaining(notification),
+      );
+      expect(apnRefreshQueue.add).toHaveBeenCalledWith(
+        'refresh',
+        { userUuid: user.uuid },
+        expect.anything(),
       );
     });
   });
@@ -163,8 +272,7 @@ describe('StorageNotificationService', () => {
     } as unknown as FolderDto;
     const clientId = 'test-client';
 
-    it('When called, then it should add a notification event and send APN notification', () => {
-      jest.spyOn(service, 'getTokensAndSendApnNotification');
+    it('When called, then it should add a notification event and enqueue an APN refresh', () => {
       const notification = new NotificationEvent(
         'notification.itemCreated',
         payload,
@@ -179,8 +287,10 @@ describe('StorageNotificationService', () => {
       expect(notificationService.add).toHaveBeenCalledWith(
         expect.objectContaining(notification),
       );
-      expect(service.getTokensAndSendApnNotification).toHaveBeenCalledWith(
-        user.uuid,
+      expect(apnRefreshQueue.add).toHaveBeenCalledWith(
+        'refresh',
+        { userUuid: user.uuid },
+        expect.anything(),
       );
     });
   });
@@ -193,8 +303,7 @@ describe('StorageNotificationService', () => {
     } as unknown as FolderDto;
     const clientId = 'test-client';
 
-    it('When called, then it should add a notification event and send APN notification', () => {
-      jest.spyOn(service, 'getTokensAndSendApnNotification');
+    it('When called, then it should add a notification event and enqueue an APN refresh', () => {
       const notification = new NotificationEvent(
         'notification.itemUpdated',
         payload,
@@ -209,8 +318,10 @@ describe('StorageNotificationService', () => {
       expect(notificationService.add).toHaveBeenCalledWith(
         expect.objectContaining(notification),
       );
-      expect(service.getTokensAndSendApnNotification).toHaveBeenCalledWith(
-        user.uuid,
+      expect(apnRefreshQueue.add).toHaveBeenCalledWith(
+        'refresh',
+        { userUuid: user.uuid },
+        expect.anything(),
       );
     });
   });
@@ -222,8 +333,7 @@ describe('StorageNotificationService', () => {
     ];
     const clientId = 'test-client';
 
-    it('When called, then it should add a notification event and send APN notification', () => {
-      jest.spyOn(service, 'getTokensAndSendApnNotification');
+    it('When called, then it should add a notification event and enqueue an APN refresh', () => {
       const notification = new NotificationEvent(
         'notification.itemsToTrash',
         payload,
@@ -238,8 +348,10 @@ describe('StorageNotificationService', () => {
       expect(notificationService.add).toHaveBeenCalledWith(
         expect.objectContaining(notification),
       );
-      expect(service.getTokensAndSendApnNotification).toHaveBeenCalledWith(
-        user.uuid,
+      expect(apnRefreshQueue.add).toHaveBeenCalledWith(
+        'refresh',
+        { userUuid: user.uuid },
+        expect.anything(),
       );
     });
   });
@@ -272,6 +384,7 @@ describe('StorageNotificationService', () => {
           customKeys: { event: 'PLAN_UPDATED' },
         },
       );
+      expect(apnRefreshQueue.add).not.toHaveBeenCalled();
     });
   });
 
@@ -303,6 +416,7 @@ describe('StorageNotificationService', () => {
           customKeys: { event: 'WORKSPACE_JOINED' },
         },
       );
+      expect(apnRefreshQueue.add).not.toHaveBeenCalled();
     });
   });
 
@@ -334,6 +448,40 @@ describe('StorageNotificationService', () => {
           customKeys: { event: 'WORKSPACE_LEFT' },
         },
       );
+      expect(apnRefreshQueue.add).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('enqueueApnRefresh', () => {
+    const user = newUser();
+
+    it('When called, then it should enqueue a deduplicated delayed job for the user', () => {
+      service.enqueueApnRefresh(user.uuid);
+
+      expect(apnRefreshQueue.add).toHaveBeenCalledWith(
+        'refresh',
+        { userUuid: user.uuid },
+        expect.objectContaining({
+          delay: APN_REFRESH_DEBOUNCE_MS,
+          deduplication: { id: user.uuid },
+          attempts: 3,
+          backoff: { type: 'exponential', delay: 5_000 },
+          removeOnComplete: true,
+          removeOnFail: true,
+        }),
+      );
+    });
+
+    it('When the queue rejects, then it should log the error instead of throwing', async () => {
+      const error = new Error('Queue unavailable');
+      apnRefreshQueue.add.mockRejectedValueOnce(error);
+      const errorSpy = jest.spyOn(loggerMock, 'error');
+
+      expect(() => service.enqueueApnRefresh(user.uuid)).not.toThrow();
+
+      await Promise.resolve();
+
+      expect(errorSpy).toHaveBeenCalled();
     });
   });
 

--- a/src/externals/notifications/storage.notifications.service.spec.ts
+++ b/src/externals/notifications/storage.notifications.service.spec.ts
@@ -483,6 +483,24 @@ describe('StorageNotificationService', () => {
 
       expect(errorSpy).toHaveBeenCalled();
     });
+
+    it('When the APN refresh queue is not registered, then it should skip enqueuing without throwing', async () => {
+      const moduleWithoutQueue = await Test.createTestingModule({
+        providers: [
+          StorageNotificationService,
+          { provide: getQueueToken(APN_REFRESH_QUEUE), useValue: null },
+        ],
+      })
+        .useMocker(createMock)
+        .compile();
+      const serviceWithoutQueue = moduleWithoutQueue.get(
+        StorageNotificationService,
+      );
+
+      expect(() =>
+        serviceWithoutQueue.enqueueApnRefresh(user.uuid),
+      ).not.toThrow();
+    });
   });
 
   describe('getTokensAndSendApnNotification', () => {

--- a/src/externals/notifications/storage.notifications.service.ts
+++ b/src/externals/notifications/storage.notifications.service.ts
@@ -1,4 +1,6 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { InjectQueue } from '@nestjs/bullmq';
+import { type Queue } from 'bullmq';
 import { NotificationService } from './notification.service';
 import { type User } from '../../modules/user/user.domain';
 import { NotificationEvent } from './events/notification.event';
@@ -7,6 +9,13 @@ import { SequelizeUserRepository } from '../../modules/user/user.repository';
 import { type FolderDto } from '../../modules/folder/dto/responses/folder.dto';
 import { type FileDto } from '../../modules/file/dto/responses/file.dto';
 import { type ItemToTrashDto } from '../../modules/trash/dto/controllers/move-items-to-trash.dto';
+
+export const APN_REFRESH_QUEUE = 'apn-refresh';
+export const APN_REFRESH_DEBOUNCE_MS = 15_000;
+
+export interface ApnRefreshJobData {
+  userUuid: string;
+}
 
 enum StorageEvents {
   FILE_CREATED = 'FILE_CREATED',
@@ -35,6 +44,8 @@ export class StorageNotificationService {
     private readonly notificationService: NotificationService,
     private readonly apnService: ApnService,
     private readonly userRepository: SequelizeUserRepository,
+    @InjectQueue(APN_REFRESH_QUEUE)
+    private readonly apnRefreshQueue: Queue<ApnRefreshJobData>,
   ) {}
 
   fileCreated({ payload, user, clientId }: EventArguments<FileDto>) {
@@ -50,7 +61,7 @@ export class StorageNotificationService {
     this.notificationService.add(event);
 
     if (!user.ownsBackupsBucket(payload.bucket)) {
-      this.getTokensAndSendApnNotification(user.uuid);
+      this.enqueueApnRefresh(user.uuid);
     }
   }
 
@@ -67,7 +78,7 @@ export class StorageNotificationService {
     this.notificationService.add(event);
 
     if (!user.ownsBackupsBucket(payload.bucket)) {
-      this.getTokensAndSendApnNotification(user.uuid);
+      this.enqueueApnRefresh(user.uuid);
     }
   }
 
@@ -86,7 +97,7 @@ export class StorageNotificationService {
     );
 
     this.notificationService.add(event);
-    this.getTokensAndSendApnNotification(user.uuid);
+    this.enqueueApnRefresh(user.uuid);
   }
 
   folderCreated({ payload, user, clientId }: EventArguments<FolderDto>) {
@@ -100,7 +111,7 @@ export class StorageNotificationService {
     );
 
     this.notificationService.add(event);
-    this.getTokensAndSendApnNotification(user.uuid);
+    this.enqueueApnRefresh(user.uuid);
   }
 
   folderUpdated({ payload, user, clientId }: EventArguments<FolderDto>) {
@@ -114,7 +125,7 @@ export class StorageNotificationService {
     );
 
     this.notificationService.add(event);
-    this.getTokensAndSendApnNotification(user.uuid);
+    this.enqueueApnRefresh(user.uuid);
   }
 
   folderDeleted({
@@ -132,7 +143,7 @@ export class StorageNotificationService {
     );
 
     this.notificationService.add(event);
-    this.getTokensAndSendApnNotification(user.uuid);
+    this.enqueueApnRefresh(user.uuid);
   }
 
   itemsTrashed({ payload, user, clientId }: EventArguments<ItemToTrashDto[]>) {
@@ -146,7 +157,7 @@ export class StorageNotificationService {
     );
 
     this.notificationService.add(event);
-    this.getTokensAndSendApnNotification(user.uuid);
+    this.enqueueApnRefresh(user.uuid);
   }
 
   planUpdated({
@@ -210,6 +221,25 @@ export class StorageNotificationService {
       isStorageNotification: false,
       customKeys: { event: StorageEvents.WORKSPACE_LEFT },
     });
+  }
+
+  enqueueApnRefresh(userUuid: string) {
+    this.apnRefreshQueue
+      .add(
+        'refresh',
+        { userUuid },
+        {
+          delay: APN_REFRESH_DEBOUNCE_MS,
+          deduplication: { id: userUuid },
+          attempts: 3,
+          backoff: { type: 'exponential', delay: 5_000 },
+          removeOnComplete: true,
+          removeOnFail: true,
+        },
+      )
+      .catch((error) => {
+        this.logger.error({ userUuid, error }, 'Error enqueuing APN refresh.');
+      });
   }
 
   async getTokensAndSendApnNotification(

--- a/src/externals/notifications/storage.notifications.service.ts
+++ b/src/externals/notifications/storage.notifications.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable, Logger, Optional } from '@nestjs/common';
 import { InjectQueue } from '@nestjs/bullmq';
 import { type Queue } from 'bullmq';
 import { NotificationService } from './notification.service';
@@ -44,8 +44,9 @@ export class StorageNotificationService {
     private readonly notificationService: NotificationService,
     private readonly apnService: ApnService,
     private readonly userRepository: SequelizeUserRepository,
+    @Optional()
     @InjectQueue(APN_REFRESH_QUEUE)
-    private readonly apnRefreshQueue: Queue<ApnRefreshJobData>,
+    private readonly apnRefreshQueue?: Queue<ApnRefreshJobData>,
   ) {}
 
   fileCreated({ payload, user, clientId }: EventArguments<FileDto>) {
@@ -224,6 +225,10 @@ export class StorageNotificationService {
   }
 
   enqueueApnRefresh(userUuid: string) {
+    if (!this.apnRefreshQueue) {
+      return;
+    }
+
     this.apnRefreshQueue
       .add(
         'refresh',

--- a/src/lib/bull-connection.ts
+++ b/src/lib/bull-connection.ts
@@ -1,0 +1,28 @@
+import { type ConfigService } from '@nestjs/config';
+import { type ConnectionOptions } from 'bullmq';
+
+export const buildBullConnectionOptions = (
+  configService: ConfigService,
+): ConnectionOptions => {
+  const connectionString = configService.get<string>(
+    'cache.redisJobsConnection',
+  );
+
+  if (!connectionString) {
+    throw new Error(
+      'REDIS_JOBS_CONNECTION_STRING is required to build the BullMQ connection',
+    );
+  }
+
+  const url = new URL(connectionString);
+
+  return {
+    host: url.hostname,
+    port: Number(url.port) || 6379,
+    password: url.password || undefined,
+    username: url.username || undefined,
+    maxRetriesPerRequest: null,
+    enableOfflineQueue: false,
+    tls: {},
+  };
+};

--- a/src/modules/jobs/jobs.module.ts
+++ b/src/modules/jobs/jobs.module.ts
@@ -36,28 +36,17 @@ import {
 } from './tasks/cleanup-deleted-files-table/cleanup-deleted-files-table.scheduler';
 import { CleanupDeletedFilesTableProcessor } from './tasks/cleanup-deleted-files-table/cleanup-deleted-files-table.processor';
 import { SequelizeDeletedFilesRepository } from './repositories/deleted-files.repository';
+import { buildBullConnectionOptions } from '../../lib/bull-connection';
+
 @Module({
   imports: [
     SequelizeModule.forFeature([JobExecutionModel]),
     ScheduleModule.forRoot(),
     BullModule.forRootAsync({
       inject: [ConfigService],
-      useFactory: (configService: ConfigService) => {
-        const url = new URL(
-          configService.get<string>('cache.redisJobsConnection'),
-        );
-        return {
-          connection: {
-            host: url.hostname,
-            port: Number(url.port) || 6379,
-            password: url.password || undefined,
-            username: url.username || undefined,
-            maxRetriesPerRequest: null,
-            enableOfflineQueue: false,
-            tls: {},
-          },
-        };
-      },
+      useFactory: (configService: ConfigService) => ({
+        connection: buildBullConnectionOptions(configService),
+      }),
     }),
     BullModule.registerQueue({ name: TRASH_CLEANUP_QUEUE }),
     BullModule.registerQueue({ name: HARD_DELETE_OLD_FILES_QUEUE }),


### PR DESCRIPTION
- Introduced `ApnRefreshProcessor` to handle APN refresh jobs with error handling and logging.
- Added `enqueueApnRefresh` method in `StorageNotificationService` to queue APN refresh jobs based on user actions.
- Updated unit tests to validate the new processor and queuing logic.
- Configured BullMQ for APN refresh queue with connection options.