### PR TITLE
[_] chore: set uuid as PK in file model

### DIFF
--- a/src/modules/file/file.model.ts
+++ b/src/modules/file/file.model.ts
@@ -12,7 +12,6 @@ import {
   Model,
   PrimaryKey,
   Table,
-  Unique,
 } from 'sequelize-typescript';
 import { FolderModel } from '../folder/folder.model';
 import { type FileAttributes, FileStatus } from './file.domain';

--- a/src/modules/file/file.model.ts
+++ b/src/modules/file/file.model.ts
@@ -31,7 +31,6 @@ import { FavoriteModel } from '../favorite/favorite.model';
   tableName: 'files',
 })
 export class FileModel extends Model implements FileAttributes {
-  @Unique
   @PrimaryKey
   @Column(DataType.UUIDV4)
   uuid: string;

--- a/src/modules/file/file.model.ts
+++ b/src/modules/file/file.model.ts
@@ -31,14 +31,14 @@ import { FavoriteModel } from '../favorite/favorite.model';
   tableName: 'files',
 })
 export class FileModel extends Model implements FileAttributes {
+  @Unique
   @PrimaryKey
+  @Column(DataType.UUIDV4)
+  uuid: string;
+
   @AutoIncrement
   @Column
   id: number;
-
-  @Unique
-  @Column(DataType.UUIDV4)
-  uuid: string;
 
   @AllowNull
   @Column(DataType.STRING(24))

--- a/src/modules/thumbnail/thumbnail.model.ts
+++ b/src/modules/thumbnail/thumbnail.model.ts
@@ -23,7 +23,6 @@ export class ThumbnailModel extends Model implements ThumbnailAttributes {
   @Column
   id: number;
 
-  @ForeignKey(() => FileModel)
   @Column(DataType.INTEGER)
   fileId: number;
 


### PR DESCRIPTION
From the ORM's standpoint, the primary key is just a way to create joins when a `targetKey` is not defined in the relation. In our case, we've been referencing `uuid` all along.

We can afford setting this before doing the real swap.

## Changes
- Set UUID as PK