### PR TITLE
[_] chore: create free id index

### DIFF
--- a/migrations/20260807120000-step-3-part-1-create-files-id-standalone-index.js
+++ b/migrations/20260807120000-step-3-part-1-create-files-id-standalone-index.js
@@ -1,0 +1,17 @@
+'use strict';
+
+// UUID as PK: Step 3 - 1: Create standalone index on id, not owned by files_pkey.
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.sequelize.query(`
+        CREATE UNIQUE INDEX CONCURRENTLY ux_files_id_idx ON files USING btree (id);
+      `);
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.sequelize.query(`
+        DROP INDEX CONCURRENTLY IF EXISTS ux_files_id_idx;
+      `);
+  }
+};


### PR DESCRIPTION
The current index is tied to the PK constraint so a free id index is required so the column retains an index after the PK constraint drop.