### PR TITLE
[PB-6722] feat: add files sync cursor pagination

### DIFF
--- a/src/modules/backups/backup.usecase.ts
+++ b/src/modules/backups/backup.usecase.ts
@@ -26,7 +26,7 @@ import { type File } from '../file/file.domain';
 import {
   decodeCursor,
   encodeCursor,
-  type FileUpdatedAtIdCursorDto,
+  FileUpdatedAtIdCursorDto,
 } from '../file/utils/file-cursor.util';
 
 @Injectable()
@@ -54,7 +54,7 @@ export class BackupUseCase {
     }
 
     const cursor: FileUpdatedAtIdCursorDto | undefined = cursorToken
-      ? decodeCursor<FileUpdatedAtIdCursorDto>(cursorToken)
+      ? decodeCursor(FileUpdatedAtIdCursorDto, cursorToken)
       : undefined;
 
     const { files, hasMore } =

--- a/src/modules/file/dto/get-files-sync.dto.ts
+++ b/src/modules/file/dto/get-files-sync.dto.ts
@@ -1,0 +1,58 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import {
+  IsEnum,
+  IsISO8601,
+  IsInt,
+  IsOptional,
+  IsString,
+  Max,
+  MaxLength,
+  Min,
+  ValidateIf,
+} from 'class-validator';
+import { FileStatus } from '../file.domain';
+
+const allowedStatuses = [...Object.values(FileStatus), 'ALL'];
+
+export class GetFilesSyncDto {
+  @ApiProperty({
+    description: 'File status filter',
+    enum: allowedStatuses,
+    required: true,
+  })
+  @IsEnum(allowedStatuses)
+  status: FileStatus | 'ALL';
+
+  @ApiProperty({
+    description:
+      'Filter files updated after this date. Required if cursor is not provided',
+    required: false,
+  })
+  @ValidateIf((dto) => !dto.cursor)
+  @IsISO8601(
+    { strict: true },
+    { message: 'updatedAt must be a valid ISO8601 date' },
+  )
+  updatedAt?: string;
+
+  @ApiProperty({
+    description: 'Cursor token to fetch the next page of results',
+    required: false,
+  })
+  @IsOptional()
+  @IsString()
+  @MaxLength(256)
+  cursor?: string;
+
+  @ApiProperty({
+    description: 'Page size, max 1000',
+    required: false,
+  })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(1000)
+  limit?: number;
+}

--- a/src/modules/file/dto/get-files-sync.dto.ts
+++ b/src/modules/file/dto/get-files-sync.dto.ts
@@ -11,18 +11,16 @@ import {
   Min,
   ValidateIf,
 } from 'class-validator';
-import { FileStatus } from '../file.domain';
-
-const allowedStatuses = [...Object.values(FileStatus), 'ALL'];
+import { FileQueryStatus } from '../file-query-status.enum';
 
 export class GetFilesSyncDto {
   @ApiProperty({
     description: 'File status filter',
-    enum: allowedStatuses,
+    enum: FileQueryStatus,
     required: true,
   })
-  @IsEnum(allowedStatuses)
-  status: FileStatus | 'ALL';
+  @IsEnum(FileQueryStatus)
+  status: FileQueryStatus;
 
   @ApiProperty({
     description:

--- a/src/modules/file/dto/get-files-sync.dto.ts
+++ b/src/modules/file/dto/get-files-sync.dto.ts
@@ -11,16 +11,17 @@ import {
   Min,
   ValidateIf,
 } from 'class-validator';
-import { FileQueryStatus } from '../file-query-status.enum';
+import { FileStatus } from '../file.domain';
 
 export class GetFilesSyncDto {
   @ApiProperty({
     description: 'File status filter',
-    enum: FileQueryStatus,
-    required: true,
+    enum: FileStatus,
+    required: false,
   })
-  @IsEnum(FileQueryStatus)
-  status: FileQueryStatus;
+  @IsOptional()
+  @IsEnum(FileStatus)
+  status?: FileStatus;
 
   @ApiProperty({
     description:

--- a/src/modules/file/dto/responses/get-files-sync.dto.ts
+++ b/src/modules/file/dto/responses/get-files-sync.dto.ts
@@ -1,0 +1,10 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { FileDto } from './file.dto';
+
+export class GetFilesSyncResponseDto {
+  @ApiProperty({ type: FileDto, isArray: true })
+  files: FileDto[];
+
+  @ApiProperty({ type: String, nullable: true })
+  nextCursor: string | null;
+}

--- a/src/modules/file/dto/responses/get-files-sync.dto.ts
+++ b/src/modules/file/dto/responses/get-files-sync.dto.ts
@@ -1,9 +1,11 @@
-import { ApiProperty } from '@nestjs/swagger';
+import { ApiProperty, OmitType } from '@nestjs/swagger';
 import { FileDto } from './file.dto';
 
+export class FileSyncDto extends OmitType(FileDto, ['thumbnails', 'isFavorite']) {}
+
 export class GetFilesSyncResponseDto {
-  @ApiProperty({ type: FileDto, isArray: true })
-  files: FileDto[];
+  @ApiProperty({ type: FileSyncDto, isArray: true })
+  files: FileSyncDto[];
 
   @ApiProperty({ type: String, nullable: true })
   nextCursor: string | null;

--- a/src/modules/file/file-query-status.enum.ts
+++ b/src/modules/file/file-query-status.enum.ts
@@ -1,0 +1,8 @@
+import { FileStatus } from './file.domain';
+
+export enum FileQueryStatus {
+  EXISTS = FileStatus.EXISTS,
+  TRASHED = FileStatus.TRASHED,
+  DELETED = FileStatus.DELETED,
+  ALL = 'ALL',
+}

--- a/src/modules/file/file-query-status.enum.ts
+++ b/src/modules/file/file-query-status.enum.ts
@@ -1,8 +1,0 @@
-import { FileStatus } from './file.domain';
-
-export enum FileQueryStatus {
-  EXISTS = FileStatus.EXISTS,
-  TRASHED = FileStatus.TRASHED,
-  DELETED = FileStatus.DELETED,
-  ALL = 'ALL',
-}

--- a/src/modules/file/file.controller.spec.ts
+++ b/src/modules/file/file.controller.spec.ts
@@ -790,4 +790,170 @@ describe('FileController', () => {
       );
     });
   });
+
+  describe('getFilesSync', () => {
+    const buildQuery = (overrides = {}) => ({
+      status: FileStatus.EXISTS,
+      updatedAt: new Date('2024-01-01T00:00:00.000Z').toISOString(),
+      cursor: undefined,
+      limit: undefined,
+      ...overrides,
+    });
+
+    it('When called, then it should call the usecase with parsed params', async () => {
+      const query = buildQuery();
+      jest
+        .spyOn(fileUseCases, 'getFilesUpdatedAfterWithCursor')
+        .mockResolvedValueOnce({
+          files: [],
+          hasMore: false,
+          nextCursor: null,
+        });
+
+      await fileController.getFilesSync(userMocked, query as any);
+
+      expect(
+        fileUseCases.getFilesUpdatedAfterWithCursor,
+      ).toHaveBeenCalledWith(
+        userMocked.id,
+        query.status,
+        new Date(query.updatedAt),
+        1000,
+        undefined,
+      );
+    });
+
+    it('When updatedAt is not provided, then it should default to the epoch', async () => {
+      const query = buildQuery({ updatedAt: undefined, cursor: 'abc' });
+      jest
+        .spyOn(fileUseCases, 'getFilesUpdatedAfterWithCursor')
+        .mockResolvedValueOnce({
+          files: [],
+          hasMore: false,
+          nextCursor: null,
+        });
+
+      await fileController.getFilesSync(userMocked, query as any);
+
+      expect(
+        fileUseCases.getFilesUpdatedAfterWithCursor,
+      ).toHaveBeenCalledWith(
+        userMocked.id,
+        query.status,
+        new Date(1),
+        1000,
+        'abc',
+      );
+    });
+
+    it('When a limit is provided, then it should forward it instead of the default', async () => {
+      const query = buildQuery({ limit: 50 });
+      jest
+        .spyOn(fileUseCases, 'getFilesUpdatedAfterWithCursor')
+        .mockResolvedValueOnce({
+          files: [],
+          hasMore: false,
+          nextCursor: null,
+        });
+
+      await fileController.getFilesSync(userMocked, query as any);
+
+      expect(
+        fileUseCases.getFilesUpdatedAfterWithCursor,
+      ).toHaveBeenCalledWith(
+        userMocked.id,
+        query.status,
+        expect.any(Date),
+        50,
+        undefined,
+      );
+    });
+
+    it('When files are returned, then it should strip deleted/removed fields', async () => {
+      const rawFile = {
+        ...newFile(),
+        plainName: 'already-set',
+        deleted: true,
+        deletedAt: new Date(),
+        removed: true,
+        removedAt: new Date(),
+      };
+      jest
+        .spyOn(fileUseCases, 'getFilesUpdatedAfterWithCursor')
+        .mockResolvedValueOnce({
+          files: [rawFile as any],
+          hasMore: false,
+          nextCursor: null,
+        });
+
+      const result = await fileController.getFilesSync(
+        userMocked,
+        buildQuery() as any,
+      );
+
+      expect(result.files[0]).not.toHaveProperty('deleted');
+      expect(result.files[0]).not.toHaveProperty('deletedAt');
+      expect(result.files[0]).not.toHaveProperty('removed');
+      expect(result.files[0]).not.toHaveProperty('removedAt');
+    });
+
+    it('When a file has no plainName, then it should decrypt it via decrypFileName', async () => {
+      const rawFile = { ...newFile(), plainName: undefined };
+      jest
+        .spyOn(fileUseCases, 'getFilesUpdatedAfterWithCursor')
+        .mockResolvedValueOnce({
+          files: [rawFile as any],
+          hasMore: false,
+          nextCursor: null,
+        });
+      jest
+        .spyOn(fileUseCases, 'decrypFileName')
+        .mockReturnValue({ plainName: 'decrypted-name' } as any);
+
+      const result = await fileController.getFilesSync(
+        userMocked,
+        buildQuery() as any,
+      );
+
+      expect(fileUseCases.decrypFileName).toHaveBeenCalledWith(rawFile);
+      expect(result.files[0].plainName).toBe('decrypted-name');
+    });
+
+    it('When a file already has a plainName, then it should not call decrypFileName', async () => {
+      const rawFile = { ...newFile(), plainName: 'already-set' };
+      jest
+        .spyOn(fileUseCases, 'getFilesUpdatedAfterWithCursor')
+        .mockResolvedValueOnce({
+          files: [rawFile as any],
+          hasMore: false,
+          nextCursor: null,
+        });
+      jest.spyOn(fileUseCases, 'decrypFileName');
+
+      const result = await fileController.getFilesSync(
+        userMocked,
+        buildQuery() as any,
+      );
+
+      expect(fileUseCases.decrypFileName).not.toHaveBeenCalled();
+      expect(result.files[0].plainName).toBe('already-set');
+    });
+
+    it('When the usecase returns a nextCursor, then it should be returned as-is', async () => {
+      jest
+        .spyOn(fileUseCases, 'getFilesUpdatedAfterWithCursor')
+        .mockResolvedValueOnce({
+          files: [],
+          hasMore: true,
+          nextCursor: 'encoded-cursor-token',
+        });
+
+      const result = await fileController.getFilesSync(
+        userMocked,
+        buildQuery() as any,
+      );
+
+      expect(result.nextCursor).toBe('encoded-cursor-token');
+    });
+  });
 });

--- a/src/modules/file/file.controller.ts
+++ b/src/modules/file/file.controller.ts
@@ -41,6 +41,8 @@ import { ValidateUUIDPipe } from '../../common/pipes/validate-uuid.pipe';
 import { WorkspacesInBehalfValidationFile } from '../workspaces/guards/workspaces-resources-in-behalf.decorator';
 import { CreateFileDto } from './dto/create-file.dto';
 import { GetFilesDto } from './dto/get-files.dto';
+import { GetFilesSyncDto } from './dto/get-files-sync.dto';
+import { GetFilesSyncResponseDto } from './dto/responses/get-files-sync.dto';
 import { RequiredSharingPermissions } from '../sharing/guards/sharing-permissions.decorator';
 import { SharingActionName } from '../sharing/sharing.domain';
 import { SharingPermissionsGuard } from '../sharing/guards/sharing-permissions.guard';
@@ -400,6 +402,42 @@ export class FileController {
 
       return f;
     });
+  }
+
+  @Get('/sync')
+  @ApiOperation({
+    summary: 'Get delta of files since a date',
+  })
+  @ApiOkResponse({ type: GetFilesSyncResponseDto })
+  async getFilesSync(
+    @UserDecorator() user: User,
+    @Query() queryParams: GetFilesSyncDto,
+  ): Promise<GetFilesSyncResponseDto> {
+    const { status, updatedAt, cursor, limit } = queryParams;
+
+    const { files, nextCursor } =
+      await this.fileUseCases.getFilesUpdatedAfterWithCursor(
+        user.id,
+        status,
+        new Date(updatedAt || 1),
+        limit ?? 1000,
+        cursor,
+      );
+
+    const cleaned = files.map((f) => {
+      delete f.deleted;
+      delete f.deletedAt;
+      delete f.removed;
+      delete f.removedAt;
+
+      if (!f.plainName) {
+        f.plainName = this.fileUseCases.decrypFileName(f).plainName;
+      }
+
+      return f;
+    });
+
+    return { files: cleaned, nextCursor };
   }
 
   @Patch('/:uuid')

--- a/src/modules/file/file.repository.spec.ts
+++ b/src/modules/file/file.repository.spec.ts
@@ -193,6 +193,90 @@ describe('FileRepository', () => {
     });
   });
 
+  describe('findFilesWithCursorWhereUpdatedAfter', () => {
+    it('When called without a cursor, then it should filter by updatedAfter and mark hasMore false when rows fit the page', async () => {
+      const where = { userId: user.id, status: FileStatus.EXISTS };
+      const updatedAfter = new Date();
+      const file = newFile();
+
+      jest.spyOn(fileModel, 'findAll').mockResolvedValueOnce([file] as any);
+
+      const result = await repository.findFilesWithCursorWhereUpdatedAfter({
+        where,
+        updatedAfter,
+        pageSize: 1000,
+      });
+
+      expect(fileModel.findAll).toHaveBeenCalledWith({
+        where: {
+          ...where,
+          updatedAt: { [Op.gt]: updatedAfter },
+        },
+        replacements: undefined,
+        order: [
+          ['updatedAt', 'ASC'],
+          ['uuid', 'ASC'],
+        ],
+        limit: 1001,
+      });
+      expect(result).toEqual({ files: expect.any(Array), hasMore: false });
+      expect(result.files).toHaveLength(1);
+    });
+
+    it('When there is one more row than the page size, then hasMore is true and the extra row is dropped', async () => {
+      const where = { userId: user.id };
+      const updatedAfter = new Date();
+      const files = [newFile(), newFile()];
+
+      jest.spyOn(fileModel, 'findAll').mockResolvedValueOnce(files as any);
+
+      const result = await repository.findFilesWithCursorWhereUpdatedAfter({
+        where,
+        updatedAfter,
+        pageSize: 1,
+      });
+
+      expect(result.hasMore).toBe(true);
+      expect(result.files).toHaveLength(1);
+    });
+
+    it('When a cursor is provided, then it filters by the cursor tuple and ignores updatedAfter', async () => {
+      const where = { userId: user.id };
+      const updatedAfter = new Date();
+      const cursorUpdatedAt = new Date('2024-01-01T00:00:00.000Z');
+      const cursorId = v4();
+
+      jest.spyOn(fileModel, 'findAll').mockResolvedValueOnce([]);
+
+      await repository.findFilesWithCursorWhereUpdatedAfter({
+        where,
+        updatedAfter,
+        pageSize: 1000,
+        cursor: {
+          updatedAt: cursorUpdatedAt.toISOString(),
+          uuid: cursorId,
+        },
+      });
+
+      expect(fileModel.findAll).toHaveBeenCalledWith({
+        where: {
+          ...where,
+          [Op.and]: [
+            Sequelize.literal(
+              '("updated_at", "uuid") > (:cursorUpdatedAt, :cursorId)',
+            ),
+          ],
+        },
+        replacements: { cursorUpdatedAt, cursorId },
+        order: [
+          ['updatedAt', 'ASC'],
+          ['uuid', 'ASC'],
+        ],
+        limit: 1001,
+      });
+    });
+  });
+
   describe('findFilesInFolderByName', () => {
     const folderUuid = v4();
 

--- a/src/modules/file/file.repository.ts
+++ b/src/modules/file/file.repository.ts
@@ -152,6 +152,12 @@ export interface FileRepository {
     userId: User['id'];
     cursor?: FileUpdatedAtIdCursorDto;
   }): Promise<{ files: File[]; hasMore: boolean }>;
+  findFilesWithCursorWhereUpdatedAfter(params: {
+    where: Partial<FileAttributes>;
+    updatedAfter: Date;
+    pageSize: number;
+    cursor?: FileUpdatedAtIdCursorDto;
+  }): Promise<{ files: File[]; hasMore: boolean }>;
   getFilesWithUserByUuuid(
     fileUuids: string[],
     order?: [keyof FileModel, 'ASC' | 'DESC'][],

--- a/src/modules/file/file.repository.ts
+++ b/src/modules/file/file.repository.ts
@@ -386,6 +386,50 @@ export class SequelizeFileRepository implements FileRepository {
     return files.map(this.toDomain.bind(this));
   }
 
+  async findFilesWithCursorWhereUpdatedAfter({
+    where,
+    updatedAfter,
+    pageSize,
+    cursor,
+  }: {
+    where: Partial<FileAttributes>;
+    updatedAfter: Date;
+    pageSize: number;
+    cursor?: FileUpdatedAtIdCursorDto;
+  }): Promise<{ files: File[]; hasMore: boolean }> {
+    const cursorUpdatedAt = cursor ? Time.now(cursor.updatedAt) : null;
+
+    const whereCondition: WhereOptions<FileAttributes> = {
+      ...where,
+      ...(cursor
+        ? {
+            [Op.and]: [
+              Sequelize.literal(
+                '("updated_at", "uuid") > (:cursorUpdatedAt, :cursorId)',
+              ),
+            ],
+          }
+        : { updatedAt: { [Op.gt]: updatedAfter } }),
+    };
+
+    const rows = await this.fileModel.findAll({
+      where: whereCondition,
+      replacements: cursor
+        ? { cursorUpdatedAt, cursorId: cursor.uuid }
+        : undefined,
+      order: [
+        ['updatedAt', 'ASC'],
+        ['uuid', 'ASC'],
+      ],
+      limit: pageSize + 1,
+    });
+
+    const hasMore = rows.length > pageSize;
+    const page = hasMore ? rows.slice(0, pageSize) : rows;
+
+    return { files: page.map(this.toDomain.bind(this)), hasMore };
+  }
+
   async findAllNotDeleted(
     where: Partial<Record<keyof FileAttributes, any>>,
     limit: number,

--- a/src/modules/file/file.usecase.spec.ts
+++ b/src/modules/file/file.usecase.spec.ts
@@ -2284,6 +2284,172 @@ describe('FileUseCases', () => {
     });
   });
 
+  describe('getFilesUpdatedAfterWithCursor', () => {
+    const userIdForSync = 1;
+    const updatedAfter = new Date();
+    const mockFiles = [newFile(), newFile()];
+
+    it('When status is not ALL, then it should filter the repository query by status', async () => {
+      jest
+        .spyOn(fileRepository, 'findFilesWithCursorWhereUpdatedAfter')
+        .mockResolvedValueOnce({ files: mockFiles, hasMore: false });
+
+      await service.getFilesUpdatedAfterWithCursor(
+        userIdForSync,
+        FileStatus.EXISTS,
+        updatedAfter,
+        1000,
+        undefined,
+      );
+
+      expect(
+        fileRepository.findFilesWithCursorWhereUpdatedAfter,
+      ).toHaveBeenCalledWith({
+        where: { userId: userIdForSync, status: FileStatus.EXISTS },
+        updatedAfter,
+        pageSize: 1000,
+        cursor: undefined,
+      });
+    });
+
+    it('When status is ALL, then it should not filter the repository query by status', async () => {
+      jest
+        .spyOn(fileRepository, 'findFilesWithCursorWhereUpdatedAfter')
+        .mockResolvedValueOnce({ files: mockFiles, hasMore: false });
+
+      await service.getFilesUpdatedAfterWithCursor(
+        userIdForSync,
+        'ALL',
+        updatedAfter,
+        1000,
+        undefined,
+      );
+
+      expect(
+        fileRepository.findFilesWithCursorWhereUpdatedAfter,
+      ).toHaveBeenCalledWith({
+        where: { userId: userIdForSync },
+        updatedAfter,
+        pageSize: 1000,
+        cursor: undefined,
+      });
+    });
+
+    it('When a valid cursorToken is provided, then it should decode it and pass it to the repository', async () => {
+      const cursorData = { updatedAt: updatedAfter.toISOString(), uuid: v4() };
+      const cursorToken = Buffer.from(JSON.stringify(cursorData)).toString(
+        'base64',
+      );
+
+      jest
+        .spyOn(fileRepository, 'findFilesWithCursorWhereUpdatedAfter')
+        .mockResolvedValueOnce({ files: mockFiles, hasMore: false });
+
+      await service.getFilesUpdatedAfterWithCursor(
+        userIdForSync,
+        'ALL',
+        updatedAfter,
+        1000,
+        cursorToken,
+      );
+
+      expect(
+        fileRepository.findFilesWithCursorWhereUpdatedAfter,
+      ).toHaveBeenCalledWith(
+        expect.objectContaining({ cursor: cursorData }),
+      );
+    });
+
+    it('When an invalid cursorToken is provided, then it should throw BadRequestException and not call the repository', async () => {
+      jest.spyOn(fileRepository, 'findFilesWithCursorWhereUpdatedAfter');
+
+      await expect(
+        service.getFilesUpdatedAfterWithCursor(
+          userIdForSync,
+          'ALL',
+          updatedAfter,
+          1000,
+          'not-a-valid-cursor',
+        ),
+      ).rejects.toThrow(BadRequestException);
+      expect(
+        fileRepository.findFilesWithCursorWhereUpdatedAfter,
+      ).not.toHaveBeenCalled();
+    });
+
+    it('When hasMore is true, then it should return an encoded nextCursor built from the last file', async () => {
+      const lastFile = mockFiles[mockFiles.length - 1];
+      jest
+        .spyOn(fileRepository, 'findFilesWithCursorWhereUpdatedAfter')
+        .mockResolvedValueOnce({ files: mockFiles, hasMore: true });
+
+      const result = await service.getFilesUpdatedAfterWithCursor(
+        userIdForSync,
+        'ALL',
+        updatedAfter,
+        1000,
+        undefined,
+      );
+
+      expect(result.nextCursor).not.toBeNull();
+      const decoded = JSON.parse(
+        Buffer.from(result.nextCursor, 'base64').toString('utf-8'),
+      );
+      expect(decoded).toEqual({
+        updatedAt: lastFile.updatedAt.toISOString(),
+        uuid: lastFile.uuid,
+      });
+    });
+
+    it('When hasMore is false, then nextCursor should be null', async () => {
+      jest
+        .spyOn(fileRepository, 'findFilesWithCursorWhereUpdatedAfter')
+        .mockResolvedValueOnce({ files: mockFiles, hasMore: false });
+
+      const result = await service.getFilesUpdatedAfterWithCursor(
+        userIdForSync,
+        'ALL',
+        updatedAfter,
+        1000,
+        undefined,
+      );
+
+      expect(result.nextCursor).toBeNull();
+    });
+
+    it('When hasMore is true but there are no files, then nextCursor should be null', async () => {
+      jest
+        .spyOn(fileRepository, 'findFilesWithCursorWhereUpdatedAfter')
+        .mockResolvedValueOnce({ files: [], hasMore: true });
+
+      const result = await service.getFilesUpdatedAfterWithCursor(
+        userIdForSync,
+        'ALL',
+        updatedAfter,
+        1000,
+        undefined,
+      );
+
+      expect(result.nextCursor).toBeNull();
+    });
+
+    it('When files are returned, then it should map them through toJSON', async () => {
+      jest
+        .spyOn(fileRepository, 'findFilesWithCursorWhereUpdatedAfter')
+        .mockResolvedValueOnce({ files: mockFiles, hasMore: false });
+
+      const result = await service.getFilesUpdatedAfterWithCursor(
+        userIdForSync,
+        'ALL',
+        updatedAfter,
+        1000,
+        undefined,
+      );
+
+      expect(result.files).toEqual(mockFiles.map((file) => file.toJSON()));
+    });
+  });
+
   describe('getUserUsedStorage', () => {
     it('When called, it should return the sum of files and versions usage', async () => {
       const filesUsage = 1000;

--- a/src/modules/file/file.usecase.spec.ts
+++ b/src/modules/file/file.usecase.spec.ts
@@ -2336,7 +2336,11 @@ describe('FileUseCases', () => {
     });
 
     it('When a valid cursorToken is provided, then it should decode it and pass it to the repository', async () => {
-      const cursorData = { updatedAt: updatedAfter.toISOString(), uuid: v4() };
+      const cursorData = {
+        updatedAt: updatedAfter.toISOString(),
+        uuid: v4(),
+        status: 'ALL',
+      };
       const cursorToken = Buffer.from(JSON.stringify(cursorData)).toString(
         'base64',
       );
@@ -2358,6 +2362,32 @@ describe('FileUseCases', () => {
       ).toHaveBeenCalledWith(
         expect.objectContaining({ cursor: cursorData }),
       );
+    });
+
+    it('When the cursor status does not match the requested status, then it should throw BadRequestException and not call the repository', async () => {
+      const cursorData = {
+        updatedAt: updatedAfter.toISOString(),
+        uuid: v4(),
+        status: FileStatus.EXISTS,
+      };
+      const cursorToken = Buffer.from(JSON.stringify(cursorData)).toString(
+        'base64',
+      );
+
+      jest.spyOn(fileRepository, 'findFilesWithCursorWhereUpdatedAfter');
+
+      await expect(
+        service.getFilesUpdatedAfterWithCursor(
+          userIdForSync,
+          FileStatus.TRASHED,
+          updatedAfter,
+          1000,
+          cursorToken,
+        ),
+      ).rejects.toThrow(BadRequestException);
+      expect(
+        fileRepository.findFilesWithCursorWhereUpdatedAfter,
+      ).not.toHaveBeenCalled();
     });
 
     it('When an invalid cursorToken is provided, then it should throw BadRequestException and not call the repository', async () => {
@@ -2398,6 +2428,7 @@ describe('FileUseCases', () => {
       expect(decoded).toEqual({
         updatedAt: lastFile.updatedAt.toISOString(),
         uuid: lastFile.uuid,
+        status: 'ALL',
       });
     });
 

--- a/src/modules/file/file.usecase.spec.ts
+++ b/src/modules/file/file.usecase.spec.ts
@@ -25,6 +25,7 @@ import {
   FileStatus,
   type SortableFileAttributes,
 } from './file.domain';
+import { FileQueryStatus } from './file-query-status.enum';
 import { type User } from '../user/user.domain';
 import { CryptoModule } from '../../externals/crypto/crypto.module';
 import { CryptoService } from '../../externals/crypto/crypto.service';
@@ -2296,7 +2297,7 @@ describe('FileUseCases', () => {
 
       await service.getFilesUpdatedAfterWithCursor(
         userIdForSync,
-        FileStatus.EXISTS,
+        FileQueryStatus.EXISTS,
         updatedAfter,
         1000,
         undefined,
@@ -2319,7 +2320,7 @@ describe('FileUseCases', () => {
 
       await service.getFilesUpdatedAfterWithCursor(
         userIdForSync,
-        'ALL',
+        FileQueryStatus.ALL,
         updatedAfter,
         1000,
         undefined,
@@ -2339,7 +2340,7 @@ describe('FileUseCases', () => {
       const cursorData = {
         updatedAt: updatedAfter.toISOString(),
         uuid: v4(),
-        status: 'ALL',
+        status: FileQueryStatus.ALL,
       };
       const cursorToken = Buffer.from(JSON.stringify(cursorData)).toString(
         'base64',
@@ -2351,7 +2352,7 @@ describe('FileUseCases', () => {
 
       await service.getFilesUpdatedAfterWithCursor(
         userIdForSync,
-        'ALL',
+        FileQueryStatus.ALL,
         updatedAfter,
         1000,
         cursorToken,
@@ -2368,7 +2369,7 @@ describe('FileUseCases', () => {
       const cursorData = {
         updatedAt: updatedAfter.toISOString(),
         uuid: v4(),
-        status: FileStatus.EXISTS,
+        status: FileQueryStatus.EXISTS,
       };
       const cursorToken = Buffer.from(JSON.stringify(cursorData)).toString(
         'base64',
@@ -2379,7 +2380,7 @@ describe('FileUseCases', () => {
       await expect(
         service.getFilesUpdatedAfterWithCursor(
           userIdForSync,
-          FileStatus.TRASHED,
+          FileQueryStatus.TRASHED,
           updatedAfter,
           1000,
           cursorToken,
@@ -2396,7 +2397,7 @@ describe('FileUseCases', () => {
       await expect(
         service.getFilesUpdatedAfterWithCursor(
           userIdForSync,
-          'ALL',
+          FileQueryStatus.ALL,
           updatedAfter,
           1000,
           'not-a-valid-cursor',
@@ -2415,7 +2416,7 @@ describe('FileUseCases', () => {
 
       const result = await service.getFilesUpdatedAfterWithCursor(
         userIdForSync,
-        'ALL',
+        FileQueryStatus.ALL,
         updatedAfter,
         1000,
         undefined,
@@ -2439,7 +2440,7 @@ describe('FileUseCases', () => {
 
       const result = await service.getFilesUpdatedAfterWithCursor(
         userIdForSync,
-        'ALL',
+        FileQueryStatus.ALL,
         updatedAfter,
         1000,
         undefined,
@@ -2455,7 +2456,7 @@ describe('FileUseCases', () => {
 
       const result = await service.getFilesUpdatedAfterWithCursor(
         userIdForSync,
-        'ALL',
+        FileQueryStatus.ALL,
         updatedAfter,
         1000,
         undefined,
@@ -2471,7 +2472,7 @@ describe('FileUseCases', () => {
 
       const result = await service.getFilesUpdatedAfterWithCursor(
         userIdForSync,
-        'ALL',
+        FileQueryStatus.ALL,
         updatedAfter,
         1000,
         undefined,

--- a/src/modules/file/file.usecase.spec.ts
+++ b/src/modules/file/file.usecase.spec.ts
@@ -25,7 +25,6 @@ import {
   FileStatus,
   type SortableFileAttributes,
 } from './file.domain';
-import { FileQueryStatus } from './file-query-status.enum';
 import { type User } from '../user/user.domain';
 import { CryptoModule } from '../../externals/crypto/crypto.module';
 import { CryptoService } from '../../externals/crypto/crypto.service';
@@ -2290,14 +2289,14 @@ describe('FileUseCases', () => {
     const updatedAfter = new Date();
     const mockFiles = [newFile(), newFile()];
 
-    it('When status is not ALL, then it should filter the repository query by status', async () => {
+    it('When status is provided, then it should filter the repository query by status', async () => {
       jest
         .spyOn(fileRepository, 'findFilesWithCursorWhereUpdatedAfter')
         .mockResolvedValueOnce({ files: mockFiles, hasMore: false });
 
       await service.getFilesUpdatedAfterWithCursor(
         userIdForSync,
-        FileQueryStatus.EXISTS,
+        FileStatus.EXISTS,
         updatedAfter,
         1000,
         undefined,
@@ -2313,14 +2312,14 @@ describe('FileUseCases', () => {
       });
     });
 
-    it('When status is ALL, then it should not filter the repository query by status', async () => {
+    it('When status is not provided, then it should not filter the repository query by status', async () => {
       jest
         .spyOn(fileRepository, 'findFilesWithCursorWhereUpdatedAfter')
         .mockResolvedValueOnce({ files: mockFiles, hasMore: false });
 
       await service.getFilesUpdatedAfterWithCursor(
         userIdForSync,
-        FileQueryStatus.ALL,
+        undefined,
         updatedAfter,
         1000,
         undefined,
@@ -2340,7 +2339,6 @@ describe('FileUseCases', () => {
       const cursorData = {
         updatedAt: updatedAfter.toISOString(),
         uuid: v4(),
-        status: FileQueryStatus.ALL,
       };
       const cursorToken = Buffer.from(JSON.stringify(cursorData)).toString(
         'base64',
@@ -2352,7 +2350,7 @@ describe('FileUseCases', () => {
 
       await service.getFilesUpdatedAfterWithCursor(
         userIdForSync,
-        FileQueryStatus.ALL,
+        undefined,
         updatedAfter,
         1000,
         cursorToken,
@@ -2365,11 +2363,11 @@ describe('FileUseCases', () => {
       );
     });
 
-    it('When the cursor status does not match the requested status, then it should throw BadRequestException and not call the repository', async () => {
+    it('When the cursor status does not match the requested status, then it should throw', async () => {
       const cursorData = {
         updatedAt: updatedAfter.toISOString(),
         uuid: v4(),
-        status: FileQueryStatus.EXISTS,
+        status: FileStatus.EXISTS,
       };
       const cursorToken = Buffer.from(JSON.stringify(cursorData)).toString(
         'base64',
@@ -2380,7 +2378,7 @@ describe('FileUseCases', () => {
       await expect(
         service.getFilesUpdatedAfterWithCursor(
           userIdForSync,
-          FileQueryStatus.TRASHED,
+          FileStatus.TRASHED,
           updatedAfter,
           1000,
           cursorToken,
@@ -2391,13 +2389,13 @@ describe('FileUseCases', () => {
       ).not.toHaveBeenCalled();
     });
 
-    it('When an invalid cursorToken is provided, then it should throw BadRequestException and not call the repository', async () => {
+    it('When an invalid cursorToken is provided, then it should throw', async () => {
       jest.spyOn(fileRepository, 'findFilesWithCursorWhereUpdatedAfter');
 
       await expect(
         service.getFilesUpdatedAfterWithCursor(
           userIdForSync,
-          FileQueryStatus.ALL,
+          undefined,
           updatedAfter,
           1000,
           'not-a-valid-cursor',
@@ -2416,7 +2414,7 @@ describe('FileUseCases', () => {
 
       const result = await service.getFilesUpdatedAfterWithCursor(
         userIdForSync,
-        FileQueryStatus.ALL,
+        undefined,
         updatedAfter,
         1000,
         undefined,
@@ -2429,7 +2427,6 @@ describe('FileUseCases', () => {
       expect(decoded).toEqual({
         updatedAt: lastFile.updatedAt.toISOString(),
         uuid: lastFile.uuid,
-        status: 'ALL',
       });
     });
 
@@ -2440,7 +2437,7 @@ describe('FileUseCases', () => {
 
       const result = await service.getFilesUpdatedAfterWithCursor(
         userIdForSync,
-        FileQueryStatus.ALL,
+        undefined,
         updatedAfter,
         1000,
         undefined,
@@ -2456,7 +2453,7 @@ describe('FileUseCases', () => {
 
       const result = await service.getFilesUpdatedAfterWithCursor(
         userIdForSync,
-        FileQueryStatus.ALL,
+        undefined,
         updatedAfter,
         1000,
         undefined,
@@ -2472,7 +2469,7 @@ describe('FileUseCases', () => {
 
       const result = await service.getFilesUpdatedAfterWithCursor(
         userIdForSync,
-        FileQueryStatus.ALL,
+        undefined,
         updatedAfter,
         1000,
         undefined,

--- a/src/modules/file/file.usecase.ts
+++ b/src/modules/file/file.usecase.ts
@@ -41,6 +41,11 @@ import { type FileModel } from './file.model';
 import { ThumbnailUseCases } from '../thumbnail/thumbnail.usecase';
 import { UsageService } from '../usage/usage.service';
 import { Time } from '../../lib/time';
+import {
+  decodeCursor,
+  encodeCursor,
+  type FileUpdatedAtIdCursorDto,
+} from './utils/file-cursor.util';
 import { type MoveFileDto } from './dto/move-file.dto';
 import { MailerService } from '../../externals/mailer/mailer.service';
 import { FeatureLimitService } from '../feature-limit/feature-limit.service';
@@ -597,6 +602,51 @@ export class FileUseCases {
       pagination.lastId,
     );
     return files.map((file) => file.toJSON());
+  }
+
+  async getFilesUpdatedAfterWithCursor(
+    userId: UserAttributes['id'],
+    status: FileStatus | 'ALL',
+    updatedAfter: Date,
+    pageSize: number,
+    cursorToken: string | undefined,
+  ): Promise<{ files: File[]; hasMore: boolean; nextCursor: string | null }> {
+    const cursor = cursorToken
+      ? decodeCursor<FileUpdatedAtIdCursorDto>(cursorToken)
+      : undefined;
+
+    if (cursorToken && !cursor) {
+      throw new BadRequestException('Invalid cursor');
+    }
+
+    const filter: Partial<FileAttributes> = { userId };
+
+    if (status !== 'ALL') {
+      filter.status = status;
+    }
+
+    const { files, hasMore } =
+      await this.fileRepository.findFilesWithCursorWhereUpdatedAfter({
+        where: filter,
+        updatedAfter,
+        pageSize,
+        cursor,
+      });
+
+    const lastFile = files.at(-1);
+    const nextCursor =
+      hasMore && lastFile
+        ? encodeCursor({
+            updatedAt: lastFile.updatedAt.toISOString(),
+            uuid: lastFile.uuid,
+          })
+        : null;
+
+    return {
+      files: files.map((file) => file.toJSON()) as File[],
+      hasMore,
+      nextCursor,
+    };
   }
 
   async getWorkspaceFilesUpdatedAfter(

--- a/src/modules/file/file.usecase.ts
+++ b/src/modules/file/file.usecase.ts
@@ -44,7 +44,7 @@ import { Time } from '../../lib/time';
 import {
   decodeCursor,
   encodeCursor,
-  type FileUpdatedAtIdCursorDto,
+  FileSyncCursorDto,
 } from './utils/file-cursor.util';
 import { type MoveFileDto } from './dto/move-file.dto';
 import { MailerService } from '../../externals/mailer/mailer.service';
@@ -612,11 +612,15 @@ export class FileUseCases {
     cursorToken: string | undefined,
   ): Promise<{ files: File[]; hasMore: boolean; nextCursor: string | null }> {
     const cursor = cursorToken
-      ? decodeCursor<FileUpdatedAtIdCursorDto>(cursorToken)
+      ? decodeCursor(FileSyncCursorDto, cursorToken)
       : undefined;
 
     if (cursorToken && !cursor) {
       throw new BadRequestException('Invalid cursor');
+    }
+
+    if (cursor && cursor.status !== status) {
+      throw new BadRequestException('Cursor does not match status filter');
     }
 
     const filter: Partial<FileAttributes> = { userId };
@@ -639,6 +643,7 @@ export class FileUseCases {
         ? encodeCursor({
             updatedAt: lastFile.updatedAt.toISOString(),
             uuid: lastFile.uuid,
+            status,
           })
         : null;
 

--- a/src/modules/file/file.usecase.ts
+++ b/src/modules/file/file.usecase.ts
@@ -24,7 +24,6 @@ import {
   FileStatus,
   type SortableFileAttributes,
 } from './file.domain';
-import { FileQueryStatus } from './file-query-status.enum';
 import { SequelizeFileRepository } from './file.repository';
 import { FolderUseCases } from '../folder/folder.usecase';
 import { type ReplaceFileDto } from './dto/replace-file.dto';
@@ -607,7 +606,7 @@ export class FileUseCases {
 
   async getFilesUpdatedAfterWithCursor(
     userId: UserAttributes['id'],
-    status: FileQueryStatus,
+    status: FileStatus | undefined,
     updatedAfter: Date,
     pageSize: number,
     cursorToken: string | undefined,
@@ -626,8 +625,8 @@ export class FileUseCases {
 
     const filter: Partial<FileAttributes> = { userId };
 
-    if (status !== FileQueryStatus.ALL) {
-      filter.status = FileStatus[status];
+    if (status) {
+      filter.status = status;
     }
 
     const { files, hasMore } =

--- a/src/modules/file/file.usecase.ts
+++ b/src/modules/file/file.usecase.ts
@@ -24,6 +24,7 @@ import {
   FileStatus,
   type SortableFileAttributes,
 } from './file.domain';
+import { FileQueryStatus } from './file-query-status.enum';
 import { SequelizeFileRepository } from './file.repository';
 import { FolderUseCases } from '../folder/folder.usecase';
 import { type ReplaceFileDto } from './dto/replace-file.dto';
@@ -606,7 +607,7 @@ export class FileUseCases {
 
   async getFilesUpdatedAfterWithCursor(
     userId: UserAttributes['id'],
-    status: FileStatus | 'ALL',
+    status: FileQueryStatus,
     updatedAfter: Date,
     pageSize: number,
     cursorToken: string | undefined,
@@ -625,8 +626,8 @@ export class FileUseCases {
 
     const filter: Partial<FileAttributes> = { userId };
 
-    if (status !== 'ALL') {
-      filter.status = status;
+    if (status !== FileQueryStatus.ALL) {
+      filter.status = FileStatus[status];
     }
 
     const { files, hasMore } =

--- a/src/modules/file/utils/file-cursor.util.spec.ts
+++ b/src/modules/file/utils/file-cursor.util.spec.ts
@@ -2,7 +2,8 @@ import { v4 } from 'uuid';
 import {
   decodeCursor,
   encodeCursor,
-  type FileUpdatedAtIdCursorDto,
+  FileUpdatedAtIdCursorDto,
+  FileSyncCursorDto,
 } from './file-cursor.util';
 
 describe('file-cursor.util', () => {
@@ -14,13 +15,29 @@ describe('file-cursor.util', () => {
       };
 
       const token = encodeCursor(cursor);
-      const decoded = decodeCursor<FileUpdatedAtIdCursorDto>(token);
+      const decoded = decodeCursor(FileUpdatedAtIdCursorDto, token);
+
+      expect(decoded).toEqual(cursor);
+    });
+
+    it('When a valid sync cursor (with status) is encoded and decoded, then it should return the original data', () => {
+      const cursor: FileSyncCursorDto = {
+        updatedAt: new Date().toISOString(),
+        uuid: v4(),
+        status: 'EXISTS',
+      };
+
+      const token = encodeCursor(cursor);
+      const decoded = decodeCursor(FileSyncCursorDto, token);
 
       expect(decoded).toEqual(cursor);
     });
 
     it('When the token is not valid base64/JSON, then it should return null', () => {
-      const decoded = decodeCursor('not-a-valid-token!!!');
+      const decoded = decodeCursor(
+        FileUpdatedAtIdCursorDto,
+        'not-a-valid-token!!!',
+      );
 
       expect(decoded).toBeNull();
     });
@@ -30,7 +47,7 @@ describe('file-cursor.util', () => {
         JSON.stringify({ updatedAt: new Date().toISOString(), uuid: 'nope' }),
       ).toString('base64');
 
-      expect(decodeCursor(token)).toBeNull();
+      expect(decodeCursor(FileUpdatedAtIdCursorDto, token)).toBeNull();
     });
 
     it('When the decoded JSON has an invalid updatedAt, then it should return null', () => {
@@ -38,7 +55,7 @@ describe('file-cursor.util', () => {
         JSON.stringify({ updatedAt: 'not-a-date', uuid: v4() }),
       ).toString('base64');
 
-      expect(decodeCursor(token)).toBeNull();
+      expect(decodeCursor(FileUpdatedAtIdCursorDto, token)).toBeNull();
     });
 
     it('When the decoded JSON is missing fields, then it should return null', () => {
@@ -46,7 +63,7 @@ describe('file-cursor.util', () => {
         'base64',
       );
 
-      expect(decodeCursor(token)).toBeNull();
+      expect(decodeCursor(FileUpdatedAtIdCursorDto, token)).toBeNull();
     });
   });
 });

--- a/src/modules/file/utils/file-cursor.util.spec.ts
+++ b/src/modules/file/utils/file-cursor.util.spec.ts
@@ -5,7 +5,7 @@ import {
   FileUpdatedAtIdCursorDto,
   FileSyncCursorDto,
 } from './file-cursor.util';
-import { FileQueryStatus } from '../file-query-status.enum';
+import { FileStatus } from '../file.domain';
 
 describe('file-cursor.util', () => {
   describe('encodeCursor/decodeCursor', () => {
@@ -25,7 +25,7 @@ describe('file-cursor.util', () => {
       const cursor: FileSyncCursorDto = {
         updatedAt: new Date().toISOString(),
         uuid: v4(),
-        status: FileQueryStatus.EXISTS,
+        status: FileStatus.EXISTS,
       };
 
       const token = encodeCursor(cursor);

--- a/src/modules/file/utils/file-cursor.util.spec.ts
+++ b/src/modules/file/utils/file-cursor.util.spec.ts
@@ -5,6 +5,7 @@ import {
   FileUpdatedAtIdCursorDto,
   FileSyncCursorDto,
 } from './file-cursor.util';
+import { FileQueryStatus } from '../file-query-status.enum';
 
 describe('file-cursor.util', () => {
   describe('encodeCursor/decodeCursor', () => {
@@ -24,7 +25,7 @@ describe('file-cursor.util', () => {
       const cursor: FileSyncCursorDto = {
         updatedAt: new Date().toISOString(),
         uuid: v4(),
-        status: 'EXISTS',
+        status: FileQueryStatus.EXISTS,
       };
 
       const token = encodeCursor(cursor);

--- a/src/modules/file/utils/file-cursor.util.spec.ts
+++ b/src/modules/file/utils/file-cursor.util.spec.ts
@@ -1,0 +1,52 @@
+import { v4 } from 'uuid';
+import {
+  decodeCursor,
+  encodeCursor,
+  type FileUpdatedAtIdCursorDto,
+} from './file-cursor.util';
+
+describe('file-cursor.util', () => {
+  describe('encodeCursor/decodeCursor', () => {
+    it('When a valid cursor is encoded and decoded, then it should return the original data', () => {
+      const cursor: FileUpdatedAtIdCursorDto = {
+        updatedAt: new Date().toISOString(),
+        uuid: v4(),
+      };
+
+      const token = encodeCursor(cursor);
+      const decoded = decodeCursor<FileUpdatedAtIdCursorDto>(token);
+
+      expect(decoded).toEqual(cursor);
+    });
+
+    it('When the token is not valid base64/JSON, then it should return null', () => {
+      const decoded = decodeCursor('not-a-valid-token!!!');
+
+      expect(decoded).toBeNull();
+    });
+
+    it('When the decoded JSON has an invalid uuid, then it should return null', () => {
+      const token = Buffer.from(
+        JSON.stringify({ updatedAt: new Date().toISOString(), uuid: 'nope' }),
+      ).toString('base64');
+
+      expect(decodeCursor(token)).toBeNull();
+    });
+
+    it('When the decoded JSON has an invalid updatedAt, then it should return null', () => {
+      const token = Buffer.from(
+        JSON.stringify({ updatedAt: 'not-a-date', uuid: v4() }),
+      ).toString('base64');
+
+      expect(decodeCursor(token)).toBeNull();
+    });
+
+    it('When the decoded JSON is missing fields, then it should return null', () => {
+      const token = Buffer.from(JSON.stringify({ uuid: v4() })).toString(
+        'base64',
+      );
+
+      expect(decodeCursor(token)).toBeNull();
+    });
+  });
+});

--- a/src/modules/file/utils/file-cursor.util.ts
+++ b/src/modules/file/utils/file-cursor.util.ts
@@ -1,5 +1,6 @@
 import { plainToInstance } from 'class-transformer';
-import { validateSync, IsISO8601, IsUUID, IsString } from 'class-validator';
+import { validateSync, IsISO8601, IsUUID, IsIn } from 'class-validator';
+import { FileQueryStatus } from '../file-query-status.enum';
 
 export class FileUpdatedAtIdCursorDto {
   @IsISO8601()
@@ -10,8 +11,8 @@ export class FileUpdatedAtIdCursorDto {
 }
 
 export class FileSyncCursorDto extends FileUpdatedAtIdCursorDto {
-  @IsString()
-  status: string;
+  @IsIn(Object.values(FileQueryStatus))
+  status: FileQueryStatus;
 }
 
 export function encodeCursor<T>(cursor: T): string {

--- a/src/modules/file/utils/file-cursor.util.ts
+++ b/src/modules/file/utils/file-cursor.util.ts
@@ -1,5 +1,5 @@
 import { plainToInstance } from 'class-transformer';
-import { validateSync, IsISO8601, IsUUID } from 'class-validator';
+import { validateSync, IsISO8601, IsUUID, IsString } from 'class-validator';
 
 export class FileUpdatedAtIdCursorDto {
   @IsISO8601()
@@ -9,24 +9,35 @@ export class FileUpdatedAtIdCursorDto {
   uuid: string;
 }
 
+export class FileSyncCursorDto extends FileUpdatedAtIdCursorDto {
+  @IsString()
+  status: string;
+}
+
 export function encodeCursor<T>(cursor: T): string {
   return Buffer.from(JSON.stringify(cursor)).toString('base64');
 }
 
-function validateCursor(decoded: unknown): FileUpdatedAtIdCursorDto | null {
-  const instance = plainToInstance(FileUpdatedAtIdCursorDto, decoded);
-  const errors = validateSync(instance);
+function validateCursor<T extends object>(
+  cursorClass: new () => T,
+  decodedPayload: unknown,
+): T | null {
+  const instance = plainToInstance(cursorClass, decodedPayload);
+  const errors = validateSync(instance as object);
 
   return errors.length === 0 ? instance : null;
 }
 
 export function decodeCursor<T extends FileUpdatedAtIdCursorDto>(
+  cursorClass: new () => T,
   token: string,
 ): T | null {
   try {
-    const decoded = JSON.parse(Buffer.from(token, 'base64').toString('utf-8'));
+    const decodedPayload = JSON.parse(
+      Buffer.from(token, 'base64').toString('utf-8'),
+    );
 
-    return validateCursor(decoded) as T | null;
+    return validateCursor(cursorClass, decodedPayload);
   } catch {
     return null;
   }

--- a/src/modules/file/utils/file-cursor.util.ts
+++ b/src/modules/file/utils/file-cursor.util.ts
@@ -1,6 +1,12 @@
 import { plainToInstance } from 'class-transformer';
-import { validateSync, IsISO8601, IsUUID, IsIn } from 'class-validator';
-import { FileQueryStatus } from '../file-query-status.enum';
+import {
+  validateSync,
+  IsISO8601,
+  IsUUID,
+  IsIn,
+  IsOptional,
+} from 'class-validator';
+import { FileStatus } from '../file.domain';
 
 export class FileUpdatedAtIdCursorDto {
   @IsISO8601()
@@ -11,8 +17,9 @@ export class FileUpdatedAtIdCursorDto {
 }
 
 export class FileSyncCursorDto extends FileUpdatedAtIdCursorDto {
-  @IsIn(Object.values(FileQueryStatus))
-  status: FileQueryStatus;
+  @IsOptional()
+  @IsIn(Object.values(FileStatus))
+  status?: FileStatus;
 }
 
 export function encodeCursor<T>(cursor: T): string {


### PR DESCRIPTION
The GET 'files/' EP is too expensive when synching data of users with a lot of files. More than half of the query time is being used by windows/linux/macos.

## Changes
- Added a files sync endpoint with cursor pagination

## Benchmark
Listing files for a user with 2M rows. The benchmark consists of an OFFSET 1M LIMIT 1000 query and its cursor equivalent.

### OFFSET 1000000 LIMIT 1000

No Status filter
```sql
Limit  (cost=996376.76..1006340.50 rows=10000 width=188) (actual time=3993.632..4027.311 rows=10000 loops=1)
  Output: uuid, id, file_id, plain_name, type, size, bucket, folder_id, folder_uuid, encrypt_version, user_id, creation_time, modification_time, created_at, updated_at, removed, removed_at, deleted, deleted_at, status
  ->  Incremental Sort  (cost=2.36..2346484.99 rows=2355021 width=188) (actual time=31.579..3666.590 rows=1010000 loops=1)
        Output: uuid, id, file_id, plain_name, type, size, bucket, folder_id, folder_uuid, encrypt_version, user_id, creation_time, modification_time, created_at, updated_at, removed, removed_at, deleted, deleted_at, status
        Sort Key: "FileModel".updated_at, "FileModel".uuid
        Presorted Key: "FileModel".updated_at
        Full-sort Groups: 28496  Sort Method: quicksort  Average Memory: 33kB  Peak Memory: 33kB
        ->  Index Scan using idx_user_updated_at_status on public.files "FileModel"  (cost=0.57..2278100.10 rows=2355021 width=188) (actual time=28.218..2542.474 rows=1010001 loops=1)
              Output: uuid, id, file_id, plain_name, type, size, bucket, folder_id, folder_uuid, encrypt_version, user_id, creation_time, modification_time, created_at, updated_at, removed, removed_at, deleted, deleted_at, status
              Index Cond: (("FileModel".user_id = 211491) AND ("FileModel".updated_at > '2022-08-13 12:49:10.704'::timestamp without time zone))
Query Identifier: -7549579982700785369
Planning Time: 0.843 ms
JIT:
  Functions: 6
  Options: Inlining true, Optimization true, Expressions true, Deforming true
  Timing: Generation 6.943 ms (Deform 4.056 ms), Inlining 10.502 ms, Optimization 195.732 ms, Emission 101.998 ms, Total 315.175 ms
Execution Time: 4037.456 ms
```

Using status = 'EXISTS'
```sql
Limit  (cost=1018440.04..1019458.48 rows=1000 width=188) (actual time=6545.296..6546.498 rows=1000 loops=1)
  Output: uuid, id, file_id, plain_name, type, size, bucket, folder_id, folder_uuid, encrypt_version, user_id, creation_time, modification_time, created_at, updated_at, removed, removed_at, deleted, deleted_at, status
  Buffers: shared hit=391835 read=71599 written=12
  ->  Incremental Sort  (cost=2.14..1741672.51 rows=1710139 width=188) (actual time=21.132..5736.745 rows=1001000 loops=1)
        Output: uuid, id, file_id, plain_name, type, size, bucket, folder_id, folder_uuid, encrypt_version, user_id, creation_time, modification_time, created_at, updated_at, removed, removed_at, deleted, deleted_at, status
        Sort Key: "FileModel".updated_at, "FileModel".uuid
        Presorted Key: "FileModel".updated_at
        Full-sort Groups: 28244  Sort Method: quicksort  Average Memory: 33kB  Peak Memory: 33kB
        Buffers: shared hit=391835 read=71599 written=12
        ->  Index Scan using idx_user_updated_at_status on public.files "FileModel"  (cost=0.57..1686678.86 rows=1710139 width=188) (actual time=7.031..4543.810 rows=1001006 loops=1)
              Output: uuid, id, file_id, plain_name, type, size, bucket, folder_id, folder_uuid, encrypt_version, user_id, creation_time, modification_time, created_at, updated_at, removed, removed_at, deleted, deleted_at, status
              Index Cond: (("FileModel".user_id = 211491) AND ("FileModel".updated_at >= '2022-11-15 06:05:06'::timestamp without time zone) AND ("FileModel".status = 'EXISTS'::enum_files_status))
              Buffers: shared hit=391835 read=71599 written=12
Query Identifier: 1495482723408476982
Planning:
  Buffers: shared hit=24
Planning Time: 3.508 ms
JIT:
  Functions: 6
  Options: Inlining true, Optimization true, Expressions true, Deforming true
  Timing: Generation 12.947 ms (Deform 11.589 ms), Inlining 38.222 ms, Optimization 274.100 ms, Emission 420.174 ms, Total 745.442 ms
Execution Time: 6559.720 ms
```

### Cursor

No Status filter
```sql
Limit  (cost=2.33..10036.01 rows=10000 width=188) (actual time=9.536..59.563 rows=10000 loops=1)
  Output: uuid, id, file_id, plain_name, type, size, bucket, folder_id, folder_uuid, encrypt_version, user_id, creation_time, modification_time, created_at, updated_at, removed, removed_at, deleted, deleted_at, status
  ->  Incremental Sort  (cost=2.33..2260053.70 rows=2252465 width=188) (actual time=9.534..58.365 rows=10000 loops=1)
        Output: uuid, id, file_id, plain_name, type, size, bucket, folder_id, folder_uuid, encrypt_version, user_id, creation_time, modification_time, created_at, updated_at, removed, removed_at, deleted, deleted_at, status
        Sort Key: "FileModel".updated_at, "FileModel".uuid
        Presorted Key: "FileModel".updated_at
        Full-sort Groups: 281  Sort Method: quicksort  Average Memory: 34kB  Peak Memory: 34kB
        ->  Index Scan using idx_user_updated_at_status on public.files "FileModel"  (cost=0.57..2193631.42 rows=2252465 width=188) (actual time=4.737..45.685 rows=10008 loops=1)
              Output: uuid, id, file_id, plain_name, type, size, bucket, folder_id, folder_uuid, encrypt_version, user_id, creation_time, modification_time, created_at, updated_at, removed, removed_at, deleted, deleted_at, status
              Index Cond: (("FileModel".user_id = 211491) AND ("FileModel".updated_at >= '2023-10-16 10:59:04'::timestamp without time zone))
              Filter: (ROW("FileModel".updated_at, "FileModel".uuid) > ROW('2023-10-16 10:59:04'::timestamp without time zone, '8c99ef1a-d33c-4704-b5c0-a451f27c5170'::uuid))
              Rows Removed by Filter: 4
Query Identifier: -4160511577164285942
Planning Time: 0.413 ms
Execution Time: 60.001 ms
```

Using status = 'EXISTS'
```sql
Limit  (cost=2.12..1027.22 rows=1000 width=188) (actual time=11.196..14.721 rows=1000 loops=1)
  Output: uuid, id, file_id, plain_name, type, size, bucket, folder_id, folder_uuid, encrypt_version, user_id, creation_time, modification_time, created_at, updated_at, removed, removed_at, deleted, deleted_at, status
  Buffers: shared hit=400 read=56
  ->  Incremental Sort  (cost=2.12..1677826.56 rows=1636747 width=188) (actual time=11.194..14.633 rows=1000 loops=1)
        Output: uuid, id, file_id, plain_name, type, size, bucket, folder_id, folder_uuid, encrypt_version, user_id, creation_time, modification_time, created_at, updated_at, removed, removed_at, deleted, deleted_at, status
        Sort Key: "FileModel".updated_at, "FileModel".uuid
        Presorted Key: "FileModel".updated_at
        Full-sort Groups: 29  Sort Method: quicksort  Average Memory: 34kB  Peak Memory: 34kB
        Buffers: shared hit=400 read=56
        ->  Index Scan using idx_user_updated_at_status on public.files "FileModel"  (cost=0.57..1624535.46 rows=1636747 width=188) (actual time=2.980..13.948 rows=1006 loops=1)
              Output: uuid, id, file_id, plain_name, type, size, bucket, folder_id, folder_uuid, encrypt_version, user_id, creation_time, modification_time, created_at, updated_at, removed, removed_at, deleted, deleted_at, status
              Index Cond: (("FileModel".user_id = 211491) AND ("FileModel".updated_at >= '2023-10-16 10:59:04'::timestamp without time zone) AND ("FileModel".status = 'EXISTS'::enum_files_status))
              Filter: (ROW("FileModel".updated_at, "FileModel".uuid) >= ROW('2023-10-16 10:59:04'::timestamp without time zone, '8c99ef1a-d33c-4704-b5c0-a451f27c5170'::uuid))
              Rows Removed by Filter: 3
              Buffers: shared hit=400 read=56
Query Identifier: 7853669427554763825
Planning:
  Buffers: shared hit=4
Planning Time: 0.366 ms
Execution Time: 15.978 ms
```