### PR TITLE
[PB-6630] refactor: remove the deprecated GET fuzzy search endpoints

### DIFF
--- a/src/modules/fuzzy-search/fuzzy-search.controller.ts
+++ b/src/modules/fuzzy-search/fuzzy-search.controller.ts
@@ -1,14 +1,4 @@
-import {
-  Body,
-  Controller,
-  DefaultValuePipe,
-  Get,
-  HttpCode,
-  Param,
-  ParseIntPipe,
-  Post,
-  Query,
-} from '@nestjs/common';
+import { Body, Controller, HttpCode, Param, Post } from '@nestjs/common';
 import { FuzzySearchUseCases } from './fuzzy-search.usecase';
 import { ApiOkResponse, ApiOperation, ApiTags } from '@nestjs/swagger';
 import { User } from '../user/user.domain';
@@ -21,10 +11,9 @@ import { FuzzySearchQueryDto } from './dto/fuzzy-search-query.dto';
 export class FuzzySearchController {
   constructor(private readonly usecases: FuzzySearchUseCases) {}
 
-  @Get('/:search')
+  @Post('/:search')
   @ApiOperation({
     summary: 'Search for items from a part of the name',
-    deprecated: true,
   })
   @HttpCode(200)
   @ApiOkResponse({
@@ -34,32 +23,9 @@ export class FuzzySearchController {
   async fuzzySearch(
     @UserDecorator() user: User,
     @Param('search') search: string,
-    @Query('offset', new DefaultValuePipe(0), ParseIntPipe) offset: number,
-  ): Promise<FuzzySearchResults> {
-    const data = await this.usecases.fuzzySearch(user.uuid, search, offset);
-
-    return { data };
-  }
-
-  @Post('/:search')
-  @ApiOperation({
-    summary: 'Search for items from a part of the name applying filters',
-  })
-  @HttpCode(200)
-  @ApiOkResponse({
-    description: 'Elements found',
-    type: FuzzySearchResults,
-  })
-  async fuzzySearchWithFilters(
-    @UserDecorator() user: User,
-    @Param('search') search: string,
     @Body() query: FuzzySearchQueryDto,
   ): Promise<FuzzySearchResults> {
-    const data = await this.usecases.fuzzySearchWithFilters(
-      user.uuid,
-      search,
-      query,
-    );
+    const data = await this.usecases.fuzzySearch(user.uuid, search, query);
 
     return { data };
   }

--- a/src/modules/fuzzy-search/fuzzy-search.usecase.spec.ts
+++ b/src/modules/fuzzy-search/fuzzy-search.usecase.spec.ts
@@ -30,7 +30,7 @@ describe('FuzzySearchUseCases', () => {
   });
 
   describe('workspaceFuzzySearch', () => {
-    it('should call repository.workspaceSearch', async () => {
+    test('When filters are passed, then they should be forwarded to the repository', async () => {
       const user = newUser();
       const workspace = newWorkspace();
       const search = 'search';
@@ -38,53 +38,11 @@ describe('FuzzySearchUseCases', () => {
         .spyOn(fuzzySearchRepository, 'workspaceSearch')
         .mockResolvedValueOnce([]);
 
-      await service.workspaceFuzzySearch(user.uuid, workspace, search);
+      await service.workspaceFuzzySearch(user.uuid, workspace, search, {
+        type: ['pdf'],
+      });
 
       expect(fuzzySearchRepository.workspaceSearch).toHaveBeenCalledWith(
-        user.uuid,
-        workspace.workspaceUserId,
-        workspace.id,
-        search,
-        0,
-      );
-    });
-  });
-
-  describe('fuzzySearch', () => {
-    test('When an offset is passed, then it should be forwarded to the repository', async () => {
-      const user = newUser();
-      const search = 'search';
-      jest.spyOn(fuzzySearchRepository, 'search').mockResolvedValueOnce([]);
-
-      await service.fuzzySearch(user.uuid, search, 20);
-
-      expect(fuzzySearchRepository.search).toHaveBeenCalledWith(
-        user.uuid,
-        search,
-        20,
-      );
-    });
-  });
-
-  describe('workspaceFuzzySearchWithFilters', () => {
-    test('When filters are passed, then they should be forwarded to the repository', async () => {
-      const user = newUser();
-      const workspace = newWorkspace();
-      const search = 'search';
-      jest
-        .spyOn(fuzzySearchRepository, 'workspaceSearchWithFilters')
-        .mockResolvedValueOnce([]);
-
-      await service.workspaceFuzzySearchWithFilters(
-        user.uuid,
-        workspace,
-        search,
-        { type: ['pdf'] },
-      );
-
-      expect(
-        fuzzySearchRepository.workspaceSearchWithFilters,
-      ).toHaveBeenCalledWith(
         user.uuid,
         workspace.workspaceUserId,
         workspace.id,
@@ -94,20 +52,18 @@ describe('FuzzySearchUseCases', () => {
     });
   });
 
-  describe('fuzzySearchWithFilters', () => {
+  describe('fuzzySearch', () => {
     const user = newUser();
     const search = 'search';
 
     beforeEach(() => {
-      jest
-        .spyOn(fuzzySearchRepository, 'searchWithFilters')
-        .mockResolvedValue([]);
+      jest.spyOn(fuzzySearchRepository, 'search').mockResolvedValue([]);
     });
 
     test('When no query is passed, then it should search without filters', async () => {
-      await service.fuzzySearchWithFilters(user.uuid, search);
+      await service.fuzzySearch(user.uuid, search);
 
-      expect(fuzzySearchRepository.searchWithFilters).toHaveBeenCalledWith(
+      expect(fuzzySearchRepository.search).toHaveBeenCalledWith(
         user.uuid,
         search,
         { offset: 0 },
@@ -115,11 +71,11 @@ describe('FuzzySearchUseCases', () => {
     });
 
     test('When file extensions are passed, then it should forward them and only include files', async () => {
-      await service.fuzzySearchWithFilters(user.uuid, search, {
+      await service.fuzzySearch(user.uuid, search, {
         type: ['pdf'],
       });
 
-      expect(fuzzySearchRepository.searchWithFilters).toHaveBeenCalledWith(
+      expect(fuzzySearchRepository.search).toHaveBeenCalledWith(
         user.uuid,
         search,
         expect.objectContaining({
@@ -130,26 +86,26 @@ describe('FuzzySearchUseCases', () => {
     });
 
     test('When the folder type is passed alone, then it should only include folders without extensions', async () => {
-      await service.fuzzySearchWithFilters(user.uuid, search, {
+      await service.fuzzySearch(user.uuid, search, {
         type: ['folder'],
       });
 
-      expect(fuzzySearchRepository.searchWithFilters).toHaveBeenCalledWith(
+      expect(fuzzySearchRepository.search).toHaveBeenCalledWith(
         user.uuid,
         search,
         expect.objectContaining({ itemTypes: ['folder'] }),
       );
-      const filters = (fuzzySearchRepository.searchWithFilters as jest.Mock)
-        .mock.calls[0][2];
+      const filters = (fuzzySearchRepository.search as jest.Mock).mock
+        .calls[0][2];
       expect(filters.extensions).toBeUndefined();
     });
 
     test('When the folder type and file extensions are combined, then it should include both item types', async () => {
-      await service.fuzzySearchWithFilters(user.uuid, search, {
+      await service.fuzzySearch(user.uuid, search, {
         type: ['folder', 'jpg', 'png'],
       });
 
-      expect(fuzzySearchRepository.searchWithFilters).toHaveBeenCalledWith(
+      expect(fuzzySearchRepository.search).toHaveBeenCalledWith(
         user.uuid,
         search,
         expect.objectContaining({
@@ -160,17 +116,17 @@ describe('FuzzySearchUseCases', () => {
     });
 
     test('When duplicated extensions are passed, then they should be deduplicated', async () => {
-      await service.fuzzySearchWithFilters(user.uuid, search, {
+      await service.fuzzySearch(user.uuid, search, {
         type: ['ogg', 'mp3', 'ogg'],
       });
 
-      const filters = (fuzzySearchRepository.searchWithFilters as jest.Mock)
-        .mock.calls[0][2];
+      const filters = (fuzzySearchRepository.search as jest.Mock).mock
+        .calls[0][2];
       expect(filters.extensions).toEqual(['ogg', 'mp3']);
     });
 
     test('When size and date filters are passed, then they should be forwarded to the repository', async () => {
-      await service.fuzzySearchWithFilters(user.uuid, search, {
+      await service.fuzzySearch(user.uuid, search, {
         offset: 20,
         minSize: 1024,
         maxSize: 5242880,
@@ -178,7 +134,7 @@ describe('FuzzySearchUseCases', () => {
         modifiedBefore: '2026-06-30T23:59:59.999Z',
       });
 
-      expect(fuzzySearchRepository.searchWithFilters).toHaveBeenCalledWith(
+      expect(fuzzySearchRepository.search).toHaveBeenCalledWith(
         user.uuid,
         search,
         {

--- a/src/modules/fuzzy-search/fuzzy-search.usecase.ts
+++ b/src/modules/fuzzy-search/fuzzy-search.usecase.ts
@@ -21,45 +21,18 @@ export class FuzzySearchUseCases {
   fuzzySearch(
     userUuid: UserAttributes['uuid'],
     text: string,
-    offset = 0,
+    query: FuzzySearchQueryDto = {},
   ): Promise<Array<FuzzySearchResult>> {
-    return this.repository.search(userUuid, text, offset);
+    return this.repository.search(userUuid, text, this.toFilters(query));
   }
 
   workspaceFuzzySearch(
     userUuid: string,
     workspace: Workspace,
     text: string,
-    offset = 0,
+    query: FuzzySearchQueryDto = {},
   ): Promise<Array<FuzzySearchResult>> {
     return this.repository.workspaceSearch(
-      userUuid,
-      workspace.workspaceUserId,
-      workspace.id,
-      text,
-      offset,
-    );
-  }
-
-  fuzzySearchWithFilters(
-    userUuid: UserAttributes['uuid'],
-    text: string,
-    query: FuzzySearchQueryDto = {},
-  ): Promise<Array<FuzzySearchResult>> {
-    return this.repository.searchWithFilters(
-      userUuid,
-      text,
-      this.toFilters(query),
-    );
-  }
-
-  workspaceFuzzySearchWithFilters(
-    userUuid: string,
-    workspace: Workspace,
-    text: string,
-    query: FuzzySearchQueryDto = {},
-  ): Promise<Array<FuzzySearchResult>> {
-    return this.repository.workspaceSearchWithFilters(
       userUuid,
       workspace.workspaceUserId,
       workspace.id,

--- a/src/modules/fuzzy-search/look-up.repository.spec.ts
+++ b/src/modules/fuzzy-search/look-up.repository.spec.ts
@@ -23,47 +23,8 @@ describe('SequelizeLookUpRepository', () => {
   });
 
   describe('search', () => {
-    test('When a search is requested, then it should query files and folders with the given offset', async () => {
-      await repository.search(userUuid, partialName, 10);
-
-      const [sql, options] = sequelize.query.mock.calls[0];
-      expect(sql).toContain('FROM files');
-      expect(sql).toContain('FROM folders');
-      expect(sql).toContain('UNION ALL');
-      expect(options.replacements).toEqual({
-        userUuid,
-        partialName,
-        offset: 10,
-      });
-    });
-  });
-
-  describe('workspaceSearch', () => {
-    test('When a search is requested, then it should query both branches with workspace replacements', async () => {
-      await repository.workspaceSearch(
-        userUuid,
-        workspaceUserUuid,
-        workspaceId,
-        partialName,
-      );
-
-      const [sql, options] = sequelize.query.mock.calls[0];
-      expect(sql).toContain('FROM files');
-      expect(sql).toContain('FROM folders');
-      expect(sql).toContain('wiu.workspace_id = :workspaceId');
-      expect(options.replacements).toEqual({
-        userUuid,
-        workspaceUserUuid,
-        workspaceId,
-        partialName,
-        offset: 0,
-      });
-    });
-  });
-
-  describe('searchWithFilters', () => {
     test('When no filters are passed, then it should query files and folders without filter clauses', async () => {
-      await repository.searchWithFilters(userUuid, partialName);
+      await repository.search(userUuid, partialName);
 
       const [sql, options] = sequelize.query.mock.calls[0];
       expect(sql).toContain('FROM files');
@@ -80,7 +41,7 @@ describe('SequelizeLookUpRepository', () => {
     });
 
     test('When extensions are passed, then it should filter files by type', async () => {
-      await repository.searchWithFilters(userUuid, partialName, {
+      await repository.search(userUuid, partialName, {
         itemTypes: ['file'],
         extensions: ['pdf'],
       });
@@ -92,7 +53,7 @@ describe('SequelizeLookUpRepository', () => {
     });
 
     test('When only folders are requested, then it should not query files', async () => {
-      await repository.searchWithFilters(userUuid, partialName, {
+      await repository.search(userUuid, partialName, {
         itemTypes: ['folder'],
       });
 
@@ -103,7 +64,7 @@ describe('SequelizeLookUpRepository', () => {
     });
 
     test('When a size filter is passed, then it should exclude folders', async () => {
-      await repository.searchWithFilters(userUuid, partialName, {
+      await repository.search(userUuid, partialName, {
         minSize: 1024,
       });
 
@@ -114,7 +75,7 @@ describe('SequelizeLookUpRepository', () => {
     });
 
     test('When the min size is zero, then it should not filter files nor exclude folders', async () => {
-      await repository.searchWithFilters(userUuid, partialName, { minSize: 0 });
+      await repository.search(userUuid, partialName, { minSize: 0 });
 
       const [sql, options] = sequelize.query.mock.calls[0];
       expect(sql).toContain('FROM folders');
@@ -123,7 +84,7 @@ describe('SequelizeLookUpRepository', () => {
     });
 
     test('When the max size is zero, then it should filter files and exclude folders', async () => {
-      await repository.searchWithFilters(userUuid, partialName, { maxSize: 0 });
+      await repository.search(userUuid, partialName, { maxSize: 0 });
 
       const [sql, options] = sequelize.query.mock.calls[0];
       expect(sql).toContain('f."size" <= :maxSize');
@@ -132,7 +93,7 @@ describe('SequelizeLookUpRepository', () => {
     });
 
     test('When a size filter is combined with folders only, then it should return empty without querying', async () => {
-      const result = await repository.searchWithFilters(userUuid, partialName, {
+      const result = await repository.search(userUuid, partialName, {
         itemTypes: ['folder'],
         minSize: 1024,
       });
@@ -142,7 +103,7 @@ describe('SequelizeLookUpRepository', () => {
     });
 
     test('When date filters are passed, then they should apply to files and folders', async () => {
-      await repository.searchWithFilters(userUuid, partialName, {
+      await repository.search(userUuid, partialName, {
         modifiedAfter: '2026-01-01T00:00:00.000Z',
         modifiedBefore: '2026-06-30T23:59:59.999Z',
       });
@@ -161,7 +122,7 @@ describe('SequelizeLookUpRepository', () => {
     });
 
     test('When combined filters are passed, then all clauses should apply together', async () => {
-      await repository.searchWithFilters(userUuid, partialName, {
+      await repository.search(userUuid, partialName, {
         offset: 10,
         itemTypes: ['file'],
         extensions: ['jpg', 'png'],
@@ -204,7 +165,7 @@ describe('SequelizeLookUpRepository', () => {
         },
       ]);
 
-      const result = await repository.searchWithFilters(userUuid, partialName);
+      const result = await repository.search(userUuid, partialName);
 
       expect(result).toEqual([
         {
@@ -228,9 +189,9 @@ describe('SequelizeLookUpRepository', () => {
     });
   });
 
-  describe('workspaceSearchWithFilters', () => {
+  describe('workspaceSearch', () => {
     test('When no filters are passed, then it should query both branches with workspace replacements', async () => {
-      await repository.workspaceSearchWithFilters(
+      await repository.workspaceSearch(
         userUuid,
         workspaceUserUuid,
         workspaceId,
@@ -251,7 +212,7 @@ describe('SequelizeLookUpRepository', () => {
     });
 
     test('When filters are passed, then the same clauses should apply as in the personal search', async () => {
-      await repository.workspaceSearchWithFilters(
+      await repository.workspaceSearch(
         userUuid,
         workspaceUserUuid,
         workspaceId,

--- a/src/modules/fuzzy-search/look-up.repository.ts
+++ b/src/modules/fuzzy-search/look-up.repository.ts
@@ -30,21 +30,9 @@ export interface LookUpRepository {
   search(
     userUuid: UserAttributes['uuid'],
     partialName: string,
-    offset: number,
-  ): Promise<LookUpResult>;
-  workspaceSearch(
-    userUuid: UserAttributes['uuid'],
-    workspaceUserUuid: WorkspaceAttributes['workspaceUserId'],
-    workspaceId: WorkspaceAttributes['id'],
-    partialName: string,
-    offset: number,
-  ): Promise<LookUpResult>;
-  searchWithFilters(
-    userUuid: UserAttributes['uuid'],
-    partialName: string,
     filters?: FuzzySearchFilters,
   ): Promise<LookUpResult>;
-  workspaceSearchWithFilters(
+  workspaceSearch(
     userUuid: UserAttributes['uuid'],
     workspaceUserUuid: WorkspaceAttributes['workspaceUserId'],
     workspaceId: WorkspaceAttributes['id'],
@@ -173,150 +161,6 @@ export class SequelizeLookUpRepository implements LookUpRepository {
   async search(
     userUuid: UserAttributes['uuid'],
     partialName: string,
-    offset = 0,
-  ): Promise<LookUpResult> {
-    const rows = await this.sequelize.query<Record<string, unknown>>(
-      `
-      SELECT
-          f."uuid"                                                              AS "id",
-          f."uuid"                                                              AS "itemId",
-          'file'                                                                AS "itemType",
-          :userUuid                                                             AS "userId",
-          f."plain_name"                                                        AS "name",
-          NULL                                                                  AS "rank",
-          similarity(f."plain_name", :partialName)                             AS "similarity",
-          CASE WHEN f."plain_name" = :partialName THEN 1 ELSE 0 END            AS "exactMatch",
-          f."type"        AS "file.type",
-          f."id"          AS "file.id",
-          f."size"        AS "file.size",
-          f."bucket"      AS "file.bucket",
-          f."file_id"     AS "file.fileId",
-          f."plain_name"  AS "file.plainName",
-          NULL            AS "folder.id"
-      FROM files f
-      WHERE f."user_id" = (SELECT id FROM users WHERE uuid = :userUuid)
-        AND f."status" = 'EXISTS'
-        AND (f."plain_name" % :partialName OR similarity(f."plain_name", :partialName) > 0.0)
-
-      UNION ALL
-
-      SELECT
-          fo."uuid"                                                             AS "id",
-          fo."uuid"                                                             AS "itemId",
-          'folder'                                                              AS "itemType",
-          :userUuid                                                             AS "userId",
-          fo."plain_name"                                                       AS "name",
-          NULL                                                                  AS "rank",
-          similarity(fo."plain_name", :partialName)                            AS "similarity",
-          CASE WHEN fo."plain_name" = :partialName THEN 1 ELSE 0 END           AS "exactMatch",
-          NULL AS "file.type",
-          NULL AS "file.id",
-          NULL AS "file.size",
-          NULL AS "file.bucket",
-          NULL AS "file.fileId",
-          NULL AS "file.plainName",
-          fo."id" AS "folder.id"
-      FROM folders fo
-      WHERE fo."user_id" = (SELECT id FROM users WHERE uuid = :userUuid)
-        AND NOT fo."deleted"
-        AND NOT fo."removed"
-        AND fo."parent_uuid" IS NOT NULL
-        AND (fo."plain_name" % :partialName OR similarity(fo."plain_name", :partialName) > 0.0)
-
-      ORDER BY "exactMatch" DESC, "similarity" DESC
-      LIMIT 10 OFFSET :offset
-      `,
-      {
-        replacements: { userUuid, partialName, offset },
-        type: QueryTypes.SELECT,
-      },
-    );
-
-    return toResult(rows);
-  }
-
-  async workspaceSearch(
-    userUuid: UserAttributes['uuid'],
-    workspaceUserUuid: WorkspaceAttributes['workspaceUserId'],
-    workspaceId: WorkspaceAttributes['id'],
-    partialName: string,
-    offset = 0,
-  ): Promise<LookUpResult> {
-    const rows = await this.sequelize.query<Record<string, unknown>>(
-      `
-      SELECT
-          f."uuid"                                                              AS "id",
-          f."uuid"                                                              AS "itemId",
-          'file'                                                                AS "itemType",
-          :userUuid                                                             AS "userId",
-          f."plain_name"                                                        AS "name",
-          NULL                                                                  AS "rank",
-          similarity(f."plain_name", :partialName)                             AS "similarity",
-          CASE WHEN f."plain_name" = :partialName THEN 1 ELSE 0 END            AS "exactMatch",
-          f."type"        AS "file.type",
-          f."id"          AS "file.id",
-          f."size"        AS "file.size",
-          f."bucket"      AS "file.bucket",
-          f."file_id"     AS "file.fileId",
-          f."plain_name"  AS "file.plainName",
-          NULL            AS "folder.id"
-      FROM files f
-      INNER JOIN workspace_items_users wiu ON wiu.item_id = f.uuid
-      WHERE f."user_id" = (SELECT id FROM users WHERE uuid = :workspaceUserUuid)
-        AND f."status" = 'EXISTS'
-        AND wiu.created_by = :userUuid
-        AND wiu.workspace_id = :workspaceId
-        AND (f."plain_name" % :partialName OR similarity(f."plain_name", :partialName) > 0.0)
-
-      UNION ALL
-
-      SELECT
-          fo."uuid"                                                             AS "id",
-          fo."uuid"                                                             AS "itemId",
-          'folder'                                                              AS "itemType",
-          :userUuid                                                             AS "userId",
-          fo."plain_name"                                                       AS "name",
-          NULL                                                                  AS "rank",
-          similarity(fo."plain_name", :partialName)                            AS "similarity",
-          CASE WHEN fo."plain_name" = :partialName THEN 1 ELSE 0 END           AS "exactMatch",
-          NULL AS "file.type",
-          NULL AS "file.id",
-          NULL AS "file.size",
-          NULL AS "file.bucket",
-          NULL AS "file.fileId",
-          NULL AS "file.plainName",
-          fo."id" AS "folder.id"
-      FROM folders fo
-      INNER JOIN workspace_items_users wiu ON wiu.item_id = fo.uuid
-      WHERE fo."user_id" = (SELECT id FROM users WHERE uuid = :workspaceUserUuid)
-        AND NOT fo."deleted"
-        AND NOT fo."removed"
-        AND fo."parent_uuid" IS NOT NULL
-        AND wiu.created_by = :userUuid
-        AND wiu.workspace_id = :workspaceId
-        AND (fo."plain_name" % :partialName OR similarity(fo."plain_name", :partialName) > 0.0)
-
-      ORDER BY "exactMatch" DESC, "similarity" DESC
-      LIMIT 10 OFFSET :offset
-      `,
-      {
-        replacements: {
-          userUuid,
-          workspaceUserUuid,
-          workspaceId,
-          partialName,
-          offset,
-        },
-        type: QueryTypes.SELECT,
-      },
-    );
-
-    return toResult(rows);
-  }
-
-  async searchWithFilters(
-    userUuid: UserAttributes['uuid'],
-    partialName: string,
     filters: FuzzySearchFilters = {},
   ): Promise<LookUpResult> {
     const clauses = buildFilterClauses(filters);
@@ -348,7 +192,7 @@ export class SequelizeLookUpRepository implements LookUpRepository {
     });
   }
 
-  async workspaceSearchWithFilters(
+  async workspaceSearch(
     userUuid: UserAttributes['uuid'],
     workspaceUserUuid: WorkspaceAttributes['workspaceUserId'],
     workspaceId: WorkspaceAttributes['id'],

--- a/src/modules/workspaces/workspaces.controller.spec.ts
+++ b/src/modules/workspaces/workspaces.controller.spec.ts
@@ -814,40 +814,26 @@ describe('Workspace Controller', () => {
     });
   });
 
-  describe('GET /:workspaceId/fuzzy/:search', () => {
-    it('When a fuzzy search is requested, then it should call the service with the respective arguments', async () => {
-      const user = newUser();
-      const workspaceId = v4();
-      const search = 'search';
-
-      await workspacesController.searchWorkspace(workspaceId, user, search, 0);
-
-      expect(workspacesUsecases.searchWorkspaceContent).toHaveBeenCalledWith(
-        user,
-        workspaceId,
-        search,
-        0,
-      );
-    });
-  });
-
   describe('POST /:workspaceId/fuzzy/:search', () => {
-    it('When a fuzzy search with filters is requested, then it should call the service with the respective arguments', async () => {
+    it('When a fuzzy search is requested, then it should call the service with the respective arguments', async () => {
       const user = newUser();
       const workspaceId = v4();
       const search = 'search';
       const query = { offset: 0, type: ['pdf'] };
 
-      await workspacesController.searchWorkspaceWithFilters(
+      await workspacesController.searchWorkspace(
         workspaceId,
         user,
         search,
         query,
       );
 
-      expect(
-        workspacesUsecases.searchWorkspaceContentWithFilters,
-      ).toHaveBeenCalledWith(user, workspaceId, search, query);
+      expect(workspacesUsecases.searchWorkspaceContent).toHaveBeenCalledWith(
+        user,
+        workspaceId,
+        search,
+        query,
+      );
     });
   });
 

--- a/src/modules/workspaces/workspaces.controller.ts
+++ b/src/modules/workspaces/workspaces.controller.ts
@@ -15,8 +15,6 @@ import {
   InternalServerErrorException,
   ForbiddenException,
   NotFoundException,
-  DefaultValuePipe,
-  ParseIntPipe,
 } from '@nestjs/common';
 import {
   ApiBearerAuth,
@@ -1210,14 +1208,14 @@ export class WorkspacesController {
     });
   }
 
-  @Get(':workspaceId/fuzzy/:search')
+  @Post(':workspaceId/fuzzy/:search')
   @ApiBearerAuth()
   @ApiOperation({
     summary: 'Search by name inside workspace',
-    deprecated: true,
   })
   @ApiParam({ name: 'workspaceId', type: String, required: true })
   @ApiParam({ name: 'search', type: String, required: true })
+  @HttpCode(200)
   @ApiOkResponse({
     description: 'Search results',
   })
@@ -1228,37 +1226,9 @@ export class WorkspacesController {
     workspaceId: WorkspaceAttributes['id'],
     @UserDecorator() user: User,
     @Param('search') search: string,
-    @Query('offset', new DefaultValuePipe(0), ParseIntPipe) offset: number,
-  ) {
-    return this.workspaceUseCases.searchWorkspaceContent(
-      user,
-      workspaceId,
-      search,
-      offset,
-    );
-  }
-
-  @Post(':workspaceId/fuzzy/:search')
-  @ApiBearerAuth()
-  @ApiOperation({
-    summary: 'Search by name inside workspace applying filters',
-  })
-  @ApiParam({ name: 'workspaceId', type: String, required: true })
-  @ApiParam({ name: 'search', type: String, required: true })
-  @HttpCode(200)
-  @ApiOkResponse({
-    description: 'Search results',
-  })
-  @UseGuards(WorkspaceGuard)
-  @WorkspaceRequiredAccess(AccessContext.WORKSPACE, WorkspaceRole.MEMBER)
-  async searchWorkspaceWithFilters(
-    @Param('workspaceId', ValidateUUIDPipe)
-    workspaceId: WorkspaceAttributes['id'],
-    @UserDecorator() user: User,
-    @Param('search') search: string,
     @Body() query: FuzzySearchQueryDto,
   ) {
-    return this.workspaceUseCases.searchWorkspaceContentWithFilters(
+    return this.workspaceUseCases.searchWorkspaceContent(
       user,
       workspaceId,
       search,

--- a/src/modules/workspaces/workspaces.usecase.spec.ts
+++ b/src/modules/workspaces/workspaces.usecase.spec.ts
@@ -6120,56 +6120,7 @@ describe('WorkspacesUsecases', () => {
       jest.spyOn(workspaceRepository, 'findById').mockResolvedValue(null);
 
       await expect(
-        service.searchWorkspaceContent(user, workspaceId, query, 0),
-      ).rejects.toThrow(NotFoundException);
-    });
-
-    it('When workspace is found, then it should search for content', async () => {
-      const user = newUser();
-      const workspace = newWorkspace({ owner: user });
-      const query = 'query';
-      const files = [newFile()];
-
-      const searchResult: FuzzySearchResult[] = [
-        {
-          id: v4(),
-          itemId: files[0].uuid,
-          itemType: WorkspaceItemType.File,
-          name: files[0].name,
-          similarity: 0.8,
-          rank: 1,
-        },
-      ];
-
-      jest.spyOn(workspaceRepository, 'findById').mockResolvedValue(workspace);
-      jest
-        .spyOn(fuzzySearchUseCases, 'workspaceFuzzySearch')
-        .mockResolvedValue(searchResult);
-
-      const result = await service.searchWorkspaceContent(
-        user,
-        workspace.id,
-        query,
-        0,
-      );
-
-      expect(result[0]).toMatchObject({
-        name: files[0].name,
-        similarity: 0.8,
-      });
-    });
-  });
-
-  describe('searchWorkspaceContentWithFilters', () => {
-    it('when workspace is not found, then it should throw', async () => {
-      const user = newUser();
-      const workspaceId = v4();
-      const query = 'query';
-
-      jest.spyOn(workspaceRepository, 'findById').mockResolvedValue(null);
-
-      await expect(
-        service.searchWorkspaceContentWithFilters(user, workspaceId, query, {
+        service.searchWorkspaceContent(user, workspaceId, query, {
           offset: 0,
         }),
       ).rejects.toThrow(NotFoundException);
@@ -6195,19 +6146,22 @@ describe('WorkspacesUsecases', () => {
 
       jest.spyOn(workspaceRepository, 'findById').mockResolvedValue(workspace);
       jest
-        .spyOn(fuzzySearchUseCases, 'workspaceFuzzySearchWithFilters')
+        .spyOn(fuzzySearchUseCases, 'workspaceFuzzySearch')
         .mockResolvedValue(searchResult);
 
-      const result = await service.searchWorkspaceContentWithFilters(
+      const result = await service.searchWorkspaceContent(
         user,
         workspace.id,
         query,
         filters,
       );
 
-      expect(
-        fuzzySearchUseCases.workspaceFuzzySearchWithFilters,
-      ).toHaveBeenCalledWith(user.uuid, workspace, query, filters);
+      expect(fuzzySearchUseCases.workspaceFuzzySearch).toHaveBeenCalledWith(
+        user.uuid,
+        workspace,
+        query,
+        filters,
+      );
       expect(result[0]).toMatchObject({
         name: files[0].name,
         similarity: 0.8,

--- a/src/modules/workspaces/workspaces.usecase.ts
+++ b/src/modules/workspaces/workspaces.usecase.ts
@@ -2969,7 +2969,7 @@ export class WorkspacesUsecases {
     user: User,
     workspaceId: Workspace['id'],
     search: string,
-    offset: number,
+    query: FuzzySearchQueryDto,
   ) {
     const workspace = await this.workspaceRepository.findById(workspaceId);
 
@@ -2981,31 +2981,8 @@ export class WorkspacesUsecases {
       user.uuid,
       workspace,
       search,
-      offset,
+      query,
     );
-
-    return searchResults;
-  }
-
-  async searchWorkspaceContentWithFilters(
-    user: User,
-    workspaceId: Workspace['id'],
-    search: string,
-    query: FuzzySearchQueryDto,
-  ) {
-    const workspace = await this.workspaceRepository.findById(workspaceId);
-
-    if (!workspace) {
-      throw new NotFoundException('Workspace not found');
-    }
-
-    const searchResults =
-      await this.fuzzySearchUseCases.workspaceFuzzySearchWithFilters(
-        user.uuid,
-        workspace,
-        search,
-        query,
-      );
 
     return searchResults;
   }


### PR DESCRIPTION
## What

Final cleanup of **[PB-6630] advanced search filters**. The GET fuzzy search endpoints (`GET /fuzzy/:search` and `GET /workspaces/:workspaceId/fuzzy/:search`) were kept temporarily in #1107 so older clients wouldn't break while the POST endpoints rolled out. Now that every client consumes the POST variants through SDK ≥1.20.0, this PR removes them:

- **`fuzzy-search.controller.ts` / `workspaces.controller.ts`**: the deprecated GET handlers are gone; the POST handlers drop the `deprecated` flag and recover the plain names (`fuzzySearch`, `searchWorkspace`).
- **`fuzzy-search.usecase.ts` / `workspaces.usecase.ts`**: the old offset-based methods are deleted; the `*WithFilters` variants are renamed to take their place (`searchWorkspaceContent(user, workspaceId, search, query)`).
- **`look-up.repository.ts`**: the legacy inline-SQL `search`/`workspaceSearch` (~160 lines) are removed; `searchWithFilters`/`workspaceSearchWithFilters` are renamed to `search`/`workspaceSearch`. `buildFilterClauses` and the shared query builder are untouched.

No behavior changes for the POST endpoints — this is a deletion + rename, net **−413 lines**.

## Testing

- The 4 affected specs updated symmetrically: legacy offset describes deleted, renamed methods covered, filter-forwarding asserted (338 tests green across the 5 suites).
- `npx tsc --noEmit` clean; no remaining references to `WithFilters` in `src/`.

## Related Pull Requests

- #1106 — `[PB-6630] feat: add fuzzy search filters query contract`
- #1107 — `[PB-6630] feat: apply search filters in fuzzy search endpoints` (re-added the GETs as deprecated during the transition)

[PB-6630]: https://inxt.atlassian.net/browse/PB-6630
