### PR TITLE
[_]: feat/get mail usage

### DIFF
--- a/src/externals/mail/mail.service.spec.ts
+++ b/src/externals/mail/mail.service.spec.ts
@@ -101,4 +101,69 @@ describe('MailService', () => {
       );
     });
   });
+
+  describe('getUserMailUsage', () => {
+    const baseUrl = 'https://mail.test';
+    const userUuid = 'drive-user-uuid';
+
+    beforeEach(() => {
+      jest.spyOn(configService, 'get').mockImplementation((key: string) => {
+        if (key === 'apis.mail.url') return baseUrl;
+        if (key === 'isDevelopment') return false;
+        if (key === 'secrets.gateway') return 'ZHVtbXk=';
+        return undefined;
+      });
+    });
+
+    it('When the gateway returns a usage, then it returns that usage in bytes', async () => {
+      jest
+        .spyOn(httpClient, 'get')
+        .mockResolvedValueOnce(
+          emptyAxiosResponse({ userId: userUuid, usage: 12345 }),
+        );
+
+      const result = await service.getUserMailUsage(userUuid);
+
+      expect(result).toBe(12345);
+      expect(httpClient.get).toHaveBeenCalledWith(
+        `${baseUrl}/gateway/accounts/${encodeURIComponent(userUuid)}/usage`,
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            Authorization: 'Bearer mock-gateway-jwt',
+            'Content-Type': 'application/json',
+          }),
+          timeout: expect.any(Number),
+        }),
+      );
+    });
+
+    it('When the user has no mail account, then the reported zero usage is returned as is', async () => {
+      jest
+        .spyOn(httpClient, 'get')
+        .mockResolvedValueOnce(
+          emptyAxiosResponse({ userId: userUuid, usage: 0 }),
+        );
+
+      const result = await service.getUserMailUsage(userUuid);
+
+      expect(result).toBe(0);
+    });
+
+    it('When the gateway returns a malformed payload, then it throws instead of reporting zero', async () => {
+      jest
+        .spyOn(httpClient, 'get')
+        .mockResolvedValueOnce(emptyAxiosResponse({ userId: userUuid }));
+
+      await expect(service.getUserMailUsage(userUuid)).rejects.toThrow(
+        /malformed usage payload/,
+      );
+    });
+
+    it('When the gateway fails, then it propagates the error', async () => {
+      const err = new Error('upstream');
+      jest.spyOn(httpClient, 'get').mockRejectedValueOnce(err);
+
+      await expect(service.getUserMailUsage(userUuid)).rejects.toThrow(err);
+    });
+  });
 });

--- a/src/externals/mail/mail.service.ts
+++ b/src/externals/mail/mail.service.ts
@@ -3,6 +3,8 @@ import { signWithExpiry } from '../../middlewares/passport';
 import { ConfigService } from '@nestjs/config';
 import { HttpClient } from '../http/http.service';
 
+const MAIL_USAGE_REQUEST_TIMEOUT_MS = 3000;
+
 function signToken(duration: string, secret: string, isDevelopment?: boolean) {
   return signWithExpiry({}, Buffer.from(secret, 'base64').toString('utf8'), {
     algorithm: 'RS256',
@@ -51,5 +53,24 @@ export class MailService {
       }
       throw error;
     }
+  }
+  async getUserMailUsage(userUuid: string): Promise<number> {
+    const baseUrl = this.configService.get('apis.mail.url');
+    const headers = this.getAuthHeaders();
+
+    const res = await this.httpClient.get(
+      `${baseUrl}/gateway/accounts/${encodeURIComponent(userUuid)}/usage`,
+      { headers, timeout: MAIL_USAGE_REQUEST_TIMEOUT_MS },
+    );
+
+    const usage = res.data?.usage;
+
+    if (typeof usage !== 'number' || !Number.isFinite(usage)) {
+      throw new Error(
+        `Mail gateway returned a malformed usage payload for user ${userUuid}`,
+      );
+    }
+
+    return usage;
   }
 }

--- a/src/modules/cache-manager/cache-manager.service.spec.ts
+++ b/src/modules/cache-manager/cache-manager.service.spec.ts
@@ -50,6 +50,77 @@ describe('CacheManagerService', () => {
     });
   });
 
+  describe('mail usage', () => {
+    const TTL_1_HOUR = 60 * 60 * 1000;
+
+    it('When the cached entry is within the freshness window, then it is reported as fresh', async () => {
+      const userUuid = v4();
+
+      jest
+        .spyOn(cacheManager, 'get')
+        .mockResolvedValue({ usage: 1024, cachedAt: Date.now() });
+
+      const result = await cacheManagerService.getUserMailUsage(userUuid);
+
+      expect(cacheManager.get).toHaveBeenCalledWith(`mail-usage:${userUuid}`);
+      expect(result).toEqual({ usage: 1024, isFresh: true });
+    });
+
+    it('When the cached entry is older than the freshness window, then it is reported as stale but still returned', async () => {
+      const userUuid = v4();
+      const elevenMinutesAgo = Date.now() - 11 * 60 * 1000;
+
+      jest
+        .spyOn(cacheManager, 'get')
+        .mockResolvedValue({ usage: 1024, cachedAt: elevenMinutesAgo });
+
+      const result = await cacheManagerService.getUserMailUsage(userUuid);
+
+      expect(result).toEqual({ usage: 1024, isFresh: false });
+    });
+
+    it('When there is no cached entry, then it returns null', async () => {
+      jest.spyOn(cacheManager, 'get').mockResolvedValue(null);
+
+      const result = await cacheManagerService.getUserMailUsage(v4());
+
+      expect(result).toBeNull();
+    });
+
+    it('When setting mail usage, then it stores a timestamped entry retained for an hour', async () => {
+      const userUuid = v4();
+      const usage = 2048;
+
+      await cacheManagerService.setUserMailUsage(userUuid, usage);
+
+      expect(cacheManager.set).toHaveBeenCalledWith(
+        `mail-usage:${userUuid}`,
+        expect.objectContaining({ usage, cachedAt: expect.any(Number) }),
+        TTL_1_HOUR,
+      );
+    });
+
+    it('When setting mail usage, then it does not overload the drive usage key', async () => {
+      const userUuid = v4();
+
+      await cacheManagerService.setUserMailUsage(userUuid, 1);
+
+      expect(cacheManager.set).not.toHaveBeenCalledWith(
+        `usage:${userUuid}`,
+        expect.anything(),
+        expect.anything(),
+      );
+    });
+
+    it('When expiring mail usage, then it deletes the mail entry', async () => {
+      const userUuid = v4();
+
+      await cacheManagerService.expireUserMailUsage(userUuid);
+
+      expect(cacheManager.del).toHaveBeenCalledWith(`mail-usage:${userUuid}`);
+    });
+  });
+
   describe('setUserUsage', () => {
     it('When setting user usage, then it should store the usage with correct key and expiration', async () => {
       const userUuid = v4();

--- a/src/modules/cache-manager/cache-manager.service.ts
+++ b/src/modules/cache-manager/cache-manager.service.ts
@@ -5,11 +5,14 @@ import { type Cache } from 'cache-manager';
 @Injectable()
 export class CacheManagerService {
   private readonly USAGE_KEY_PREFIX = 'usage:';
+  private readonly MAIL_USAGE_KEY_PREFIX = 'mail-usage:';
   private readonly LIMIT_KEY_PREFIX = 'limit:';
   private readonly JWT_KEY_PREFIX = 'jwt:';
   private readonly AVATAR_KEY_PREFIX = 'avatar:';
   private readonly TTL_10_MINUTES = 10 * 60 * 1000;
   private readonly TTL_24_HOURS = 24 * 60 * 60 * 1000;
+  private readonly TTL_1_HOUR = 60 * 60 * 1000;
+  private readonly MAIL_USAGE_FRESH_MS = 10 * 60 * 1000;
 
   constructor(@Inject(CACHE_MANAGER) private readonly cacheManager: Cache) {}
 
@@ -39,6 +42,34 @@ export class CacheManagerService {
 
   async expireUserUsage(userUuid: string): Promise<void> {
     await this.cacheManager.del(`${this.USAGE_KEY_PREFIX}${userUuid}`);
+  }
+
+  async getUserMailUsage(userUuid: string) {
+    const cachedUsage = await this.cacheManager.get<{
+      usage: number;
+      cachedAt: number;
+    }>(`${this.MAIL_USAGE_KEY_PREFIX}${userUuid}`);
+
+    if (!cachedUsage) {
+      return null;
+    }
+
+    return {
+      usage: cachedUsage.usage,
+      isFresh: Date.now() - cachedUsage.cachedAt < this.MAIL_USAGE_FRESH_MS,
+    };
+  }
+
+  async setUserMailUsage(userUuid: string, usage: number) {
+    return this.cacheManager.set(
+      `${this.MAIL_USAGE_KEY_PREFIX}${userUuid}`,
+      { usage, cachedAt: Date.now() },
+      this.TTL_1_HOUR,
+    );
+  }
+
+  async expireUserMailUsage(userUuid: string): Promise<void> {
+    await this.cacheManager.del(`${this.MAIL_USAGE_KEY_PREFIX}${userUuid}`);
   }
 
   async expireLimit(userUuid: string): Promise<void> {

--- a/src/modules/user/dto/responses/get-user-usage.dto.ts
+++ b/src/modules/user/dto/responses/get-user-usage.dto.ts
@@ -9,17 +9,14 @@ export class GetUserUsageDto {
 
   @ApiProperty({
     type: Number,
-    nullable: true,
     description:
-      'Mail storage charged to the shared plan counter, in bytes. Null when the mail service could not be reached and no cached value is available; clients should show the total as unavailable rather than treating it as zero.',
+      'Mail storage charged to the shared plan counter, in bytes. Falls back to the last known cached value, or 0 if none is available, when the mail service cannot be reached.',
   })
-  mail: number | null;
+  mail: number;
 
   @ApiProperty({
     type: Number,
-    nullable: true,
-    description:
-      'Sum of drive, backup and mail usage. Null whenever mail usage is null, since a total that omits mail understates the space the user is gated on.',
+    description: 'Sum of drive, backup and mail usage.',
   })
-  total: number | null;
+  total: number;
 }

--- a/src/modules/user/dto/responses/get-user-usage.dto.ts
+++ b/src/modules/user/dto/responses/get-user-usage.dto.ts
@@ -7,6 +7,19 @@ export class GetUserUsageDto {
   @ApiProperty()
   backup: number;
 
-  @ApiProperty()
-  total: number;
+  @ApiProperty({
+    type: Number,
+    nullable: true,
+    description:
+      'Mail storage charged to the shared plan counter, in bytes. Null when the mail service could not be reached and no cached value is available; clients should show the total as unavailable rather than treating it as zero.',
+  })
+  mail: number | null;
+
+  @ApiProperty({
+    type: Number,
+    nullable: true,
+    description:
+      'Sum of drive, backup and mail usage. Null whenever mail usage is null, since a total that omits mail understates the space the user is gated on.',
+  })
+  total: number | null;
 }

--- a/src/modules/user/user.controller.spec.ts
+++ b/src/modules/user/user.controller.spec.ts
@@ -1201,10 +1201,12 @@ describe('User Controller', () => {
     it('When storage usage is requested, then it should return the user usage data', async () => {
       const driveUsage = 1024000;
       const backupUsage = 2048000;
-      const totalUsage = driveUsage + backupUsage;
+      const mailUsage = 512000;
+      const totalUsage = driveUsage + backupUsage + mailUsage;
       const mockUsage = {
         drive: driveUsage,
         backup: backupUsage,
+        mail: mailUsage,
         total: totalUsage,
       };
 

--- a/src/modules/user/user.module.ts
+++ b/src/modules/user/user.module.ts
@@ -46,6 +46,7 @@ import { WorkspacesModule } from '../workspaces/workspaces.module';
 import { SequelizeWorkspaceRepository } from '../workspaces/repositories/workspaces.repository';
 import { UserNotificationTokensModel } from './user-notification-tokens.model';
 import { BackupModule } from '../backups/backup.module';
+import { MailServiceModule } from '../../externals/mail/mail.module';
 import { CacheManagerModule } from '../cache-manager/cache-manager.module';
 import { AsymmetricEncryptionModule } from '../../externals/asymmetric-encryption/asymmetric-encryption.module';
 import { AuditLogsModule } from '../../common/audit-logs/audit-logs.module';
@@ -83,6 +84,7 @@ import { CaptchaService } from '../../externals/captcha/captcha.service';
     AsymmetricEncryptionModule,
     AuditLogsModule,
     KlaviyoModule,
+    MailServiceModule,
   ],
   controllers: [UserController],
   providers: [

--- a/src/modules/user/user.usecase.spec.ts
+++ b/src/modules/user/user.usecase.spec.ts
@@ -2391,7 +2391,7 @@ describe('User use cases', () => {
       expect(result.total).toBe(1024 + 1024 + lastKnownMailUsage);
     });
 
-    it('When the mail service fails and there is no cached value, then it does not throw and does not report zero mail usage', async () => {
+    it('When the mail service fails and there is no cached value, then it does not throw and defaults mail usage to 0', async () => {
       jest
         .spyOn(mailService, 'getUserMailUsage')
         .mockRejectedValue(new Error('mail gateway down'));
@@ -2400,11 +2400,37 @@ describe('User use cases', () => {
         .mockResolvedValue(null);
       const result = await userUseCases.getUserUsage(user);
 
-      expect(result.mail).toBeNull();
-      expect(result.mail).not.toBe(0);
-      expect(result.total).toBeNull();
+      expect(result.mail).toBe(0);
+      expect(result.total).toBe(1024 + 1024 + 0);
+      expect(cacheManagerService.setUserMailUsage).toHaveBeenCalledWith(
+        user.uuid,
+        0,
+      );
       expect(result.drive).toBe(1024);
       expect(result.backup).toBe(1024);
+    });
+
+    it('When the mail usage cache read fails, then it does not throw and falls back to fetching live', async () => {
+      jest
+        .spyOn(cacheManagerService, 'getUserMailUsage')
+        .mockRejectedValue(new Error('redis unreachable'));
+
+      const result = await userUseCases.getUserUsage(user);
+
+      expect(mailService.getUserMailUsage).toHaveBeenCalledWith(user.uuid);
+      expect(result.mail).toBe(mailUsage);
+      expect(result.total).toBe(1024 + 1024 + mailUsage);
+    });
+
+    it('When caching a freshly fetched mail usage fails, then it still returns the fetched value', async () => {
+      jest
+        .spyOn(cacheManagerService, 'setUserMailUsage')
+        .mockRejectedValue(new Error('redis unreachable'));
+
+      const result = await userUseCases.getUserUsage(user);
+
+      expect(result.mail).toBe(mailUsage);
+      expect(result.total).toBe(1024 + 1024 + mailUsage);
     });
 
     it('When cached mail usage is stale, then it refreshes it from the mail service', async () => {

--- a/src/modules/user/user.usecase.spec.ts
+++ b/src/modules/user/user.usecase.spec.ts
@@ -76,6 +76,7 @@ import { AppSumoUseCase } from '../app-sumo/app-sumo.usecase';
 import { BackupUseCase } from '../backups/backup.usecase';
 import { convertSizeToBytes } from '../../lib/convert-size-to-bytes';
 import { CacheManagerService } from '../cache-manager/cache-manager.service';
+import { MailService } from '../../externals/mail/mail.service';
 import { AsymmetricEncryptionService } from '../../externals/asymmetric-encryption/asymmetric-encryption.service';
 import { KyberProvider } from '../../externals/asymmetric-encryption/providers/kyber.provider';
 import { SequelizeSharingRepository } from '../sharing/sharing.repository';
@@ -132,6 +133,7 @@ describe('User use cases', () => {
   let appSumoUseCases: AppSumoUseCase;
   let backupUseCases: BackupUseCase;
   let cacheManagerService: CacheManagerService;
+  let mailService: MailService;
   let loggerMock: DeepMocked<Logger>;
   let sharingRepository: SequelizeSharingRepository;
   let preCreatedUsersRepository: SequelizePreCreatedUsersRepository;
@@ -224,6 +226,7 @@ describe('User use cases', () => {
     backupUseCases = moduleRef.get<BackupUseCase>(BackupUseCase);
     cacheManagerService =
       moduleRef.get<CacheManagerService>(CacheManagerService);
+    mailService = moduleRef.get<MailService>(MailService);
     sharingRepository = moduleRef.get<SequelizeSharingRepository>(
       SequelizeSharingRepository,
     );
@@ -2272,10 +2275,30 @@ describe('User use cases', () => {
   });
 
   describe('getUserUsage', () => {
+    const mailUsage = 512;
+    const defaultDriveUsage = 1024;
+    const defaultBackupUsage = 1024;
+
+    beforeEach(() => {
+      jest
+        .spyOn(cacheManagerService, 'getUserMailUsage')
+        .mockResolvedValue(null);
+      jest
+        .spyOn(cacheManagerService, 'setUserMailUsage')
+        .mockResolvedValue(undefined);
+      jest.spyOn(mailService, 'getUserMailUsage').mockResolvedValue(mailUsage);
+      jest
+        .spyOn(cacheManagerService, 'getUserUsage')
+        .mockResolvedValue({ usage: defaultDriveUsage });
+      jest
+        .spyOn(backupUseCases, 'sumExistentBackupSizes')
+        .mockResolvedValue(defaultBackupUsage);
+    });
+
     it('When cache has user usage data, then it should return the cached data', async () => {
       const cachedUsage = { usage: 1024 };
       const backupUsage = 1024;
-      const totalUsage = cachedUsage.usage + backupUsage;
+      const totalUsage = cachedUsage.usage + backupUsage + mailUsage;
 
       jest
         .spyOn(cacheManagerService, 'getUserUsage')
@@ -2294,6 +2317,7 @@ describe('User use cases', () => {
       expect(result).toEqual({
         drive: cachedUsage.usage,
         backup: backupUsage,
+        mail: mailUsage,
         total: totalUsage,
       });
     });
@@ -2301,7 +2325,7 @@ describe('User use cases', () => {
     it('When cache does not have user usage data, then it should get data from database and cache it', async () => {
       const driveUsage = 2048;
       const backupUsage = 1024;
-      const totalUsage = driveUsage + backupUsage;
+      const totalUsage = driveUsage + backupUsage + mailUsage;
       jest.spyOn(cacheManagerService, 'getUserUsage').mockResolvedValue(null);
       jest
         .spyOn(fileUseCases, 'getUserUsedStorage')
@@ -2324,8 +2348,82 @@ describe('User use cases', () => {
       expect(result).toEqual({
         drive: driveUsage,
         backup: backupUsage,
+        mail: mailUsage,
         total: totalUsage,
       });
+    });
+
+    it('When mail usage is not cached, then it is fetched and cached', async () => {
+      const result = await userUseCases.getUserUsage(user);
+
+      expect(mailService.getUserMailUsage).toHaveBeenCalledWith(user.uuid);
+      expect(cacheManagerService.setUserMailUsage).toHaveBeenCalledWith(
+        user.uuid,
+        mailUsage,
+      );
+      expect(result.mail).toBe(mailUsage);
+    });
+
+    it('When cached mail usage is still fresh, then the mail service is not called again', async () => {
+      const cachedMailUsage = 999;
+      jest
+        .spyOn(cacheManagerService, 'getUserMailUsage')
+        .mockResolvedValue({ usage: cachedMailUsage, isFresh: true });
+      const result = await userUseCases.getUserUsage(user);
+
+      expect(mailService.getUserMailUsage).not.toHaveBeenCalled();
+      expect(cacheManagerService.setUserMailUsage).not.toHaveBeenCalled();
+      expect(result.mail).toBe(cachedMailUsage);
+      expect(result.total).toBe(1024 + 1024 + cachedMailUsage);
+    });
+
+    it('When the mail service fails and a stale value exists, then it serves that value', async () => {
+      const lastKnownMailUsage = 777;
+      jest
+        .spyOn(mailService, 'getUserMailUsage')
+        .mockRejectedValue(new Error('mail gateway down'));
+      jest
+        .spyOn(cacheManagerService, 'getUserMailUsage')
+        .mockResolvedValue({ usage: lastKnownMailUsage, isFresh: false });
+      const result = await userUseCases.getUserUsage(user);
+
+      expect(result.mail).toBe(lastKnownMailUsage);
+      expect(result.total).toBe(1024 + 1024 + lastKnownMailUsage);
+    });
+
+    it('When the mail service fails and there is no cached value, then it does not throw and does not report zero mail usage', async () => {
+      jest
+        .spyOn(mailService, 'getUserMailUsage')
+        .mockRejectedValue(new Error('mail gateway down'));
+      jest
+        .spyOn(cacheManagerService, 'getUserMailUsage')
+        .mockResolvedValue(null);
+      const result = await userUseCases.getUserUsage(user);
+
+      expect(result.mail).toBeNull();
+      expect(result.mail).not.toBe(0);
+      expect(result.total).toBeNull();
+      expect(result.drive).toBe(1024);
+      expect(result.backup).toBe(1024);
+    });
+
+    it('When cached mail usage is stale, then it refreshes it from the mail service', async () => {
+      jest
+        .spyOn(cacheManagerService, 'getUserMailUsage')
+        .mockResolvedValue({ usage: 111, isFresh: false });
+      const result = await userUseCases.getUserUsage(user);
+
+      expect(mailService.getUserMailUsage).toHaveBeenCalledWith(user.uuid);
+      expect(result.mail).toBe(mailUsage);
+    });
+
+    it('When usage is requested, then mail usage is resolved alongside the backup query', async () => {
+      await userUseCases.getUserUsage(user);
+
+      expect(backupUseCases.sumExistentBackupSizes).toHaveBeenCalledWith(
+        user.id,
+      );
+      expect(mailService.getUserMailUsage).toHaveBeenCalledWith(user.uuid);
     });
   });
 

--- a/src/modules/user/user.usecase.ts
+++ b/src/modules/user/user.usecase.ts
@@ -82,6 +82,7 @@ import { AppSumoUseCase } from '../app-sumo/app-sumo.usecase';
 import { BackupUseCase } from '../backups/backup.usecase';
 import { convertSizeToBytes } from '../../lib/convert-size-to-bytes';
 import { CacheManagerService } from '../cache-manager/cache-manager.service';
+import { MailService } from '../../externals/mail/mail.service';
 import { type SharingInvite } from '../sharing/sharing.domain';
 import { AsymmetricEncryptionService } from '../../externals/asymmetric-encryption/asymmetric-encryption.service';
 import { WorkspacesUsecases } from '../workspaces/workspaces.usecase';
@@ -167,6 +168,7 @@ export class UserUseCases {
     private readonly backupUseCases: BackupUseCase,
     private readonly cacheManager: CacheManagerService,
     private readonly asymmetricEncryptionService: AsymmetricEncryptionService,
+    private readonly mailService: MailService,
   ) {}
 
   async getCachedAvatar(user: User): Promise<string | null> {
@@ -1897,28 +1899,61 @@ export class UserUseCases {
     );
   }
 
-  async getUserUsage(
-    user: User,
-  ): Promise<{ drive: number; backup: number; total: number }> {
-    let totalDriveUsage = 0;
-    const cachedUsage = await this.cacheManager.getUserUsage(user.uuid);
+  private async calculateAndCacheDriveUsage(user: User): Promise<number> {
+    const driveUsage = await this.fileUseCases.getUserUsedStorage(user);
+    await this.cacheManager.setUserUsage(user.uuid, driveUsage);
 
-    if (cachedUsage) {
-      totalDriveUsage = cachedUsage.usage;
-    } else {
-      const driveUsage = await this.fileUseCases.getUserUsedStorage(user);
-      await this.cacheManager.setUserUsage(user.uuid, driveUsage);
-      totalDriveUsage = driveUsage;
+    return driveUsage;
+  }
+
+  private async getMailUsage(user: User): Promise<number | null> {
+    const cachedMailUsage = await this.cacheManager.getUserMailUsage(user.uuid);
+
+    if (cachedMailUsage?.isFresh) {
+      return cachedMailUsage.usage;
     }
 
-    const backupUsage = await this.backupUseCases.sumExistentBackupSizes(
-      user.id,
-    );
+    try {
+      const mailUsage = await this.mailService.getUserMailUsage(user.uuid);
+      await this.cacheManager.setUserMailUsage(user.uuid, mailUsage);
+
+      return mailUsage;
+    } catch (error) {
+      const lastKnownUsage = cachedMailUsage?.usage ?? null;
+
+      Logger.error(
+        `[USER/MAIL_USAGE] Failed to get mail usage for user ${user.uuid}: ${error.message}. ` +
+          (lastKnownUsage !== null
+            ? 'Serving the last known value.'
+            : 'No cached value available, reporting mail usage as unknown.'),
+      );
+
+      return lastKnownUsage;
+    }
+  }
+
+  async getUserUsage(user: User): Promise<{
+    drive: number;
+    backup: number;
+    mail: number | null;
+    total: number | null;
+  }> {
+    const [cachedUsage, backupUsage, mailUsage] = await Promise.all([
+      this.cacheManager.getUserUsage(user.uuid),
+      this.backupUseCases.sumExistentBackupSizes(user.id),
+      this.getMailUsage(user),
+    ]);
+
+    const totalDriveUsage = cachedUsage
+      ? cachedUsage.usage
+      : await this.calculateAndCacheDriveUsage(user);
 
     return {
       drive: totalDriveUsage,
       backup: backupUsage,
-      total: totalDriveUsage + backupUsage,
+      mail: mailUsage,
+      total:
+        mailUsage === null ? null : totalDriveUsage + backupUsage + mailUsage,
     };
   }
 
@@ -2050,11 +2085,15 @@ export class UserUseCases {
 
   async checkAndNotifyStorageThreshold(
     user: User,
-    usage: { drive: number; backup: number; total: number },
+    usage: { drive: number; backup: number; total: number | null },
   ): Promise<void> {
     const NOTIFY_THRESHOLD = 80;
     const COOLDOWN_DAYS = 14;
     const MAX_EMAILS_PER_MONTH = 2;
+
+    if (usage.total === null) {
+      return;
+    }
 
     try {
       const limit = await this.getSpaceLimit(user);

--- a/src/modules/user/user.usecase.ts
+++ b/src/modules/user/user.usecase.ts
@@ -1906,37 +1906,52 @@ export class UserUseCases {
     return driveUsage;
   }
 
-  private async getMailUsage(user: User): Promise<number | null> {
-    const cachedMailUsage = await this.cacheManager.getUserMailUsage(user.uuid);
+  private async getMailUsage(user: User): Promise<number> {
+    let cachedMailUsage: { usage: number; isFresh: boolean } | null = null;
+
+    try {
+      cachedMailUsage = await this.cacheManager.getUserMailUsage(user.uuid);
+    } catch (error: any) {
+      Logger.error(
+        `[USER/MAIL_USAGE] Failed to read mail usage cache for user ${user.uuid}: ${error.message}`,
+      );
+    }
 
     if (cachedMailUsage?.isFresh) {
       return cachedMailUsage.usage;
     }
 
-    try {
-      const mailUsage = await this.mailService.getUserMailUsage(user.uuid);
-      await this.cacheManager.setUserMailUsage(user.uuid, mailUsage);
+    let mailUsage: number;
 
-      return mailUsage;
-    } catch (error) {
-      const lastKnownUsage = cachedMailUsage?.usage ?? null;
+    try {
+      mailUsage = await this.mailService.getUserMailUsage(user.uuid);
+    } catch (error: any) {
+      mailUsage = cachedMailUsage?.usage ?? 0;
 
       Logger.error(
         `[USER/MAIL_USAGE] Failed to get mail usage for user ${user.uuid}: ${error.message}. ` +
-          (lastKnownUsage !== null
+          (cachedMailUsage
             ? 'Serving the last known value.'
-            : 'No cached value available, reporting mail usage as unknown.'),
+            : 'No cached value available, defaulting mail usage to 0.'),
       );
-
-      return lastKnownUsage;
     }
+
+    try {
+      await this.cacheManager.setUserMailUsage(user.uuid, mailUsage);
+    } catch (error: any) {
+      Logger.error(
+        `[USER/MAIL_USAGE] Failed to cache mail usage for user ${user.uuid}: ${error.message}`,
+      );
+    }
+
+    return mailUsage;
   }
 
   async getUserUsage(user: User): Promise<{
     drive: number;
     backup: number;
-    mail: number | null;
-    total: number | null;
+    mail: number;
+    total: number;
   }> {
     const [cachedUsage, backupUsage, mailUsage] = await Promise.all([
       this.cacheManager.getUserUsage(user.uuid),
@@ -1952,8 +1967,7 @@ export class UserUseCases {
       drive: totalDriveUsage,
       backup: backupUsage,
       mail: mailUsage,
-      total:
-        mailUsage === null ? null : totalDriveUsage + backupUsage + mailUsage,
+      total: totalDriveUsage + backupUsage + mailUsage,
     };
   }
 


### PR DESCRIPTION
- Adds mail storage usage to GET /users/usage, alongside existing drive and backup usage.
- Fetches usage from the mail gateway (MailService.getUserMailUsage), with Redis caching (CacheManagerService) to reduce load on the mail service: cached for 1 hour, considered "fresh" for 10 minutes.
- If the mail service call fails, falls back to the last cached value (even if stale); if no cached value exists either, defaults to 0 rather than throwing.
- GetUserUsageDto gains a mail field; total is now drive + backup + mail.