### PR TITLE
[_] feat(uuid): allow other uuid versions

### DIFF
--- a/src/modules/file/dto/create-file.dto.ts
+++ b/src/modules/file/dto/create-file.dto.ts
@@ -39,7 +39,7 @@ export class CreateFileDto {
     format: 'uuid',
     example: '550e8400-e29b-41d4-a716-446655440000',
   })
-  @IsUUID('4')
+  @IsUUID()
   folderUuid: string;
 
   @ApiProperty({

--- a/src/modules/folder/dto/create-folder.dto.ts
+++ b/src/modules/folder/dto/create-folder.dto.ts
@@ -46,7 +46,7 @@ export class CreateFolderDto {
     description: 'Uuid of the parent folder',
   })
   @IsNotEmpty()
-  @IsUUID('4')
+  @IsUUID()
   parentFolderUuid: string;
 
   @ApiProperty({

--- a/src/modules/workspaces/dto/create-workspace-folder.dto.ts
+++ b/src/modules/workspaces/dto/create-workspace-folder.dto.ts
@@ -14,6 +14,6 @@ export class CreateWorkspaceFolderDto {
     description: 'Uuid of the parent folder',
   })
   @IsNotEmpty()
-  @IsUUID('4')
+  @IsUUID()
   parentFolderUuid: string;
 }


### PR DESCRIPTION
We'll move to UUIDV7 eventually. I want to make sure no client breaks with the change, but I need these DTO to only validate UUID formats and not versions to run some tests.

Changes
- Validate UUID format instead of version (we do not require to validate versions anyway)