### PR TITLE
fix: do not delete file content when replace re-declares the same file id

### DIFF
--- a/src/modules/file/file.usecase.spec.ts
+++ b/src/modules/file/file.usecase.spec.ts
@@ -3201,6 +3201,14 @@ describe('FileUseCases', () => {
         expect(fileRepository.getZeroSizeFilesCountByUser).toHaveBeenCalledWith(
           userMocked.id,
         );
+        // Truncating to empty still supersedes the old content, so it must be
+        // freed. This is the legitimate cleanup nearest to the same-id guard
+        // above, and the one most easily broken by widening it.
+        expect(bridgeService.deleteFile).toHaveBeenCalledWith(
+          userMocked,
+          mockFile.bucket,
+          'old-file-id',
+        );
       });
 
       it('When replacing with empty file and limit is reached, then it should throw', async () => {

--- a/src/modules/file/file.usecase.spec.ts
+++ b/src/modules/file/file.usecase.spec.ts
@@ -2945,6 +2945,38 @@ describe('FileUseCases', () => {
       });
     });
 
+    it('When the new file id matches the current one, then it should not delete the content from the network', async () => {
+      const mockFile = newFile({
+        attributes: {
+          fileId: 'unchanged-file-id',
+          bucket: 'test-bucket',
+          type: 'bin',
+        },
+      });
+      const replaceData = {
+        fileId: 'unchanged-file-id',
+        size: mockFile.size,
+        modificationTime: new Date(),
+      };
+
+      jest.spyOn(fileRepository, 'findByUuid').mockResolvedValue(mockFile);
+      jest.spyOn(fileRepository, 'updateByUuidAndUserId').mockResolvedValue();
+      jest.spyOn(bridgeService, 'deleteFile').mockResolvedValue();
+
+      await service.replaceFile(userMocked, mockFile.uuid, replaceData);
+
+      expect(fileRepository.updateByUuidAndUserId).toHaveBeenCalledWith(
+        mockFile.uuid,
+        userMocked.id,
+        {
+          fileId: replaceData.fileId,
+          size: replaceData.size,
+          modificationTime: replaceData.modificationTime,
+        },
+      );
+      expect(bridgeService.deleteFile).not.toHaveBeenCalled();
+    });
+
     it('When file exists and modificationTime was passed, then it should replace file data with modificationTime', async () => {
       const mockFile = newFile({
         attributes: { fileId: 'old-file-id-string', bucket: 'test-bucket' },

--- a/src/modules/file/file.usecase.ts
+++ b/src/modules/file/file.usecase.ts
@@ -1077,7 +1077,11 @@ export class FileUseCases {
       });
     });
 
-    if (oldFileId) {
+    // Only drop the previous content when it has actually been superseded. A
+    // client may call replace to update metadata (a modification time, say)
+    // while re-declaring the file id it already has; deleting here would
+    // destroy the content the row still points at.
+    if (oldFileId && oldFileId !== newFileId) {
       try {
         await this.network.deleteFile(user, bucket, oldFileId);
       } catch (error) {


### PR DESCRIPTION
## What is changed

`FileUseCases.replaceFile` ends by removing the previous content from the storage bucket. The guard on that delete is currently:

```ts
if (oldFileId) {
  await this.network.deleteFile(user, bucket, oldFileId);
}
```

This PR makes it fire only when the content has actually been superseded:

```ts
if (oldFileId && oldFileId !== newFileId) {
```

plus one new test, and one assertion added to an existing test.

## Why

`oldFileId` is the file's contents id as it was before the update. `newFileId` is what the caller sent (`isFileEmpty ? null : newFileData.fileId`). Nothing compares the two.

So a client that calls `PUT /files/{uuid}` to update metadata while re-declaring the contents id the file already has gets this sequence:

1. the row is updated to that same contents id, which changes nothing;
2. that contents id is then deleted from the bucket via `BridgeService.deleteFile`, i.e. `DELETE /buckets/{bucket}/files/{id}`.

The row survives pointing at content that no longer exists. The delete runs after the row update and its failure is only logged, so there is no rollback, and the endpoint answers `200`.

`ReplaceFileDto` accepts an optional `modificationTime`, which is the natural reason a client would call this endpoint without new content. That is how we found it: we were looking at implementing `Utimens` in the Linux client, so that `cp -p` and `rsync -a` stop failing against the drive.

`deleteFile` takes only `(bucket, fileId)`, so it cannot distinguish a superseded object from the current one when the two ids are equal, and we found no reference-counting contract in the code that would make the current behaviour safe.

### Why versioning does not already cover it

The `shouldVersion` branch preserves the old content instead of deleting it, but `isFileVersionable` requires all of: the type is in `VERSIONABLE_FILE_EXTENSIONS` (`pdf`, `docx`, `xlsx`, `csv`); the user's tier has versioning enabled; and the file is under `maxFileSize`. Every other file type takes the deleting path.

## What this PR does NOT fix, stated explicitly

We had this change reviewed by three independent reviewers alongside the client code that motivated it. **They were clear that this guard closes one specific hole and does not make `PUT /files/{uuid}` safe as a metadata endpoint.** We would rather say so here than have it inferred:

1. **The versioned branch is untouched, and is worse than we first thought.** A same-id call on a `pdf`/`docx`/`xlsx`/`csv` never reaches this guard. It runs `applyRetentionPolicy` (which can mark a genuine historical version `DELETED` to make room) and then writes a version row whose `networkFileId` aliases the live file's. **And because `getUserUsedStorage` adds `fileVersionRepository.sumExistingSizesByUser` to the file usage, that spurious version bills the user for the file's full size while storing no new bytes.** A repeated metadata update on a document would inflate quota and evict real history.
2. **A stale contents id defeats this guard.** A client sends the id it has cached. If the server has meanwhile replaced A with B and deleted A, a late request re-declaring A makes this code see `old=B, new=A` - unequal, so it deletes **B**, the live content. Safe metadata updates need an atomic precondition ("update only if the current contents id is X"), which no current endpoint offers.
3. **Same id with a different `size` is still accepted**, which preserves the content while letting the row misreport its size.
4. **A metadata-only call still does upload work**: `enforceMaxUploadFileSize` runs, so a file that is legitimately stored but larger than the user's *current* limit (after a plan change) makes a bare metadata update return `402`; and `addFileReplacementDelta` takes a Redis lock per call even though it correctly writes no usage row for a zero delta.

## What we think the right fix is

**A dedicated metadata route.** All three reviewers reached this independently, and `updateFileMetaData` / `UpdateFileMetaDto` already exists as the natural home - it currently carries only `plainName` and `type`. Accepting `modificationTime` there, doing no quota, usage, versioning, retention or storage work, would resolve every point above at once, and its presence would give clients a capability check they do not currently have.

**We are not proposing that here**, because it is your architectural call and because this guard is worth having on its own. We would be glad to open it if you want it, and we are happy to be told a different shape is preferable.

**The Linux `Utimens` work that led us here is parked**, precisely because of points 1 to 3. We are not asking you to merge this to unblock us.

## Blast radius of this change

Deliberately minimal. Normal replacements are untouched: a real upload sends a new contents id, so `oldFileId !== newFileId` holds and the old content is freed exactly as before. Truncation to zero sends `null`, which also differs. The only behaviour that changes is the equal-ids case, where the current code destroys the content it was asked to keep.

## Evidence

- The new test fails without the guard, on `Expected number of calls: 0 / Received number of calls: 1` against `bridgeService.deleteFile`, and passes with it.
- The assertion added to the empty-file test was verified by control: widening the guard to `oldFileId && newFileId && oldFileId !== newFileId` - the plausible mistake - fails that test and only that test. Without the assertion the same mistake left the suite green.
- `file.usecase.spec.ts` and `file.controller.spec.ts` are green at 192 tests together; eslint reports 0 errors on both changed files.
- **We have not reproduced this against a running server.** The finding is from the source and the unit tests. If your integration environment can confirm it end to end, that seems worth doing before merge.

## Two unrelated things we noticed and deliberately did not touch

- In `applyRetentionPolicy`, when `maxVersions` is `0`, `versionsToKeep.length === maxVersions` is true for the empty array, so `versionsToKeep.at(-1)` returns `undefined`, is pushed into `versionsToDelete`, and `v.id` then throws.
- In `replaceFile`, `fileUuid` is typed `File['fileId']` while being used as a UUID; it looks like it should be `File['uuid']`.

Both look like separate cleanups rather than part of a behavioural fix, so we left them alone.
