### PR TITLE
[BR-2298]: stabilize listing pagination with a uuid sort tiebreaker

### DIFF
--- a/src/lib/sort.ts
+++ b/src/lib/sort.ts
@@ -1,0 +1,43 @@
+import { Sequelize } from 'sequelize';
+import type { Model, ModelStatic } from 'sequelize';
+import type { Literal } from 'sequelize/types/utils';
+
+const UNIQUE_SORT_FIELDS = new Set(['uuid', 'id']);
+
+/**
+ * Applies the custom numeric collation to plainName sorts and appends a
+ * unique tiebreaker column so paginated listings keep a stable total order.
+ * Without it, rows tied on the sort field can shift between LIMIT/OFFSET
+ * pages, returning duplicated and missing items across pages.
+ */
+export function applyCollateAndTiebreakerToSort<Field extends string>(
+  model: ModelStatic<Model>,
+  order: Array<[Field, string]>,
+): Array<[Field, string] | Literal> {
+  if (order.length === 0) {
+    return order;
+  }
+
+  const newOrder: Array<[Field, string] | Literal> = structuredClone(order);
+
+  const plainNameIndex = order.findIndex(([field]) => field === 'plainName');
+  const isPlainNameSort = plainNameIndex !== -1;
+
+  if (isPlainNameSort) {
+    const [, orderDirection] = order[plainNameIndex];
+    newOrder[plainNameIndex] = Sequelize.literal(
+      `"${model.name}"."plain_name" COLLATE "custom_numeric" ${
+        orderDirection === 'ASC' ? 'ASC' : 'DESC'
+      }`,
+    );
+  }
+
+  const hasUniqueSortField = order.some(([field]) =>
+    UNIQUE_SORT_FIELDS.has(field),
+  );
+  if (!hasUniqueSortField) {
+    newOrder.push(['uuid' as Field, 'ASC']);
+  }
+
+  return newOrder;
+}

--- a/src/modules/file/file.repository.spec.ts
+++ b/src/modules/file/file.repository.spec.ts
@@ -723,6 +723,48 @@ describe('FileRepository', () => {
     });
   });
 
+  describe('findAllCursor sort tiebreaker', () => {
+    const where = { status: FileStatus.EXISTS };
+    const limit = 10;
+    const offset = 0;
+
+    it('When sorting by a non-unique field, then a uuid tiebreaker is appended to keep pagination stable', async () => {
+      jest.spyOn(fileModel, 'findAll').mockResolvedValue([]);
+
+      await repository.findAllCursor(where, limit, offset, [
+        ['updatedAt', 'ASC'],
+      ]);
+
+      const { order } = (fileModel.findAll as jest.Mock).mock.calls[0][0];
+      expect(order).toEqual([
+        ['updatedAt', 'ASC'],
+        ['uuid', 'ASC'],
+      ]);
+    });
+
+    it('When sorting by plainName, then the collated sort is followed by the uuid tiebreaker', async () => {
+      jest.spyOn(fileModel, 'findAll').mockResolvedValue([]);
+
+      await repository.findAllCursor(where, limit, offset, [
+        ['plainName', 'DESC'],
+      ]);
+
+      const { order } = (fileModel.findAll as jest.Mock).mock.calls[0][0];
+      expect(order).toHaveLength(2);
+      expect(order[0].val).toContain('COLLATE "custom_numeric" DESC');
+      expect(order[1]).toEqual(['uuid', 'ASC']);
+    });
+
+    it('When the sort already includes a unique field, then no tiebreaker is appended', async () => {
+      jest.spyOn(fileModel, 'findAll').mockResolvedValue([]);
+
+      await repository.findAllCursor(where, limit, offset, [['uuid', 'DESC']]);
+
+      const { order } = (fileModel.findAll as jest.Mock).mock.calls[0][0];
+      expect(order).toEqual([['uuid', 'DESC']]);
+    });
+  });
+
   describe('findAllCursor isFavorite enrichment', () => {
     const userUuid = v4();
     const where = { status: FileStatus.EXISTS };

--- a/src/modules/file/file.repository.ts
+++ b/src/modules/file/file.repository.ts
@@ -460,23 +460,33 @@ export class SequelizeFileRepository implements FileRepository {
   private applyCollateToPlainNameSort(
     order: Array<[keyof FileModel, string]>,
   ): Array<[keyof FileModel, string] | Literal> {
-    const plainNameIndex = order.findIndex(
-      ([field, _]) => field === 'plainName',
-    );
-    const isPlainNameSort = plainNameIndex !== -1;
-
-    if (!isPlainNameSort) {
+    if (order.length === 0) {
       return order;
     }
 
     const newOrder: Array<[keyof FileModel, string] | Literal> =
       structuredClone(order);
-    const [, orderDirection] = order[plainNameIndex];
-    newOrder[plainNameIndex] = Sequelize.literal(
-      `"FileModel"."plain_name" COLLATE "custom_numeric" ${
-        orderDirection === 'ASC' ? 'ASC' : 'DESC'
-      }`,
+
+    const plainNameIndex = order.findIndex(
+      ([field, _]) => field === 'plainName',
     );
+    const isPlainNameSort = plainNameIndex !== -1;
+
+    if (isPlainNameSort) {
+      const [, orderDirection] = order[plainNameIndex];
+      newOrder[plainNameIndex] = Sequelize.literal(
+        `"FileModel"."plain_name" COLLATE "custom_numeric" ${
+          orderDirection === 'ASC' ? 'ASC' : 'DESC'
+        }`,
+      );
+    }
+
+    const hasUniqueSortField = order.some(
+      ([field, _]) => field === 'uuid' || field === 'id',
+    );
+    if (!hasUniqueSortField) {
+      newOrder.push(['uuid', 'ASC']);
+    }
 
     return newOrder;
   }

--- a/src/modules/file/file.repository.ts
+++ b/src/modules/file/file.repository.ts
@@ -38,6 +38,7 @@ import {
   FavoriteItemType,
   type FavoriteAttributes,
 } from '../favorite/favorite.domain';
+import { applyCollateAndTiebreakerToSort } from '../../lib/sort';
 
 export interface FileRepository {
   create(file: Omit<FileAttributes, 'id'>): Promise<File | null>;
@@ -460,35 +461,7 @@ export class SequelizeFileRepository implements FileRepository {
   private applyCollateToPlainNameSort(
     order: Array<[keyof FileModel, string]>,
   ): Array<[keyof FileModel, string] | Literal> {
-    if (order.length === 0) {
-      return order;
-    }
-
-    const newOrder: Array<[keyof FileModel, string] | Literal> =
-      structuredClone(order);
-
-    const plainNameIndex = order.findIndex(
-      ([field, _]) => field === 'plainName',
-    );
-    const isPlainNameSort = plainNameIndex !== -1;
-
-    if (isPlainNameSort) {
-      const [, orderDirection] = order[plainNameIndex];
-      newOrder[plainNameIndex] = Sequelize.literal(
-        `"FileModel"."plain_name" COLLATE "custom_numeric" ${
-          orderDirection === 'ASC' ? 'ASC' : 'DESC'
-        }`,
-      );
-    }
-
-    const hasUniqueSortField = order.some(
-      ([field, _]) => field === 'uuid' || field === 'id',
-    );
-    if (!hasUniqueSortField) {
-      newOrder.push(['uuid', 'ASC']);
-    }
-
-    return newOrder;
+    return applyCollateAndTiebreakerToSort(FileModel, order);
   }
 
   async findAllCursor(

--- a/src/modules/folder/folder.repository.spec.ts
+++ b/src/modules/folder/folder.repository.spec.ts
@@ -332,7 +332,7 @@ describe('SequelizeFolderRepository', () => {
         offset,
         where: whereClause,
         subQuery: false,
-        order,
+        order: [...order, ['uuid', 'ASC']],
       });
     });
 
@@ -403,7 +403,7 @@ describe('SequelizeFolderRepository', () => {
           parentUuid: { [Op.not]: null },
         },
         subQuery: false,
-        order,
+        order: [...order, ['uuid', 'ASC']],
       });
     });
 
@@ -761,6 +761,50 @@ describe('SequelizeFolderRepository', () => {
     });
   });
 
+  describe('findAllCursor sort tiebreaker', () => {
+    const whereClause = { deleted: false, removed: false };
+    const limit = 10;
+    const offset = 0;
+
+    it('When sorting by a non-unique field, then a uuid tiebreaker is appended to keep pagination stable', async () => {
+      jest.spyOn(folderModel, 'findAll').mockResolvedValueOnce([]);
+
+      await repository.findAllCursor(whereClause, limit, offset, [
+        ['updatedAt', 'ASC'],
+      ]);
+
+      const { order } = (folderModel.findAll as jest.Mock).mock.calls[0][0];
+      expect(order).toEqual([
+        ['updatedAt', 'ASC'],
+        ['uuid', 'ASC'],
+      ]);
+    });
+
+    it('When sorting by plainName, then the collated sort is followed by the uuid tiebreaker', async () => {
+      jest.spyOn(folderModel, 'findAll').mockResolvedValueOnce([]);
+
+      await repository.findAllCursor(whereClause, limit, offset, [
+        ['plainName', 'DESC'],
+      ]);
+
+      const { order } = (folderModel.findAll as jest.Mock).mock.calls[0][0];
+      expect(order).toHaveLength(2);
+      expect(order[0].val).toContain('COLLATE "custom_numeric" DESC');
+      expect(order[1]).toEqual(['uuid', 'ASC']);
+    });
+
+    it('When the sort already includes a unique field, then no tiebreaker is appended', async () => {
+      jest.spyOn(folderModel, 'findAll').mockResolvedValueOnce([]);
+
+      await repository.findAllCursor(whereClause, limit, offset, [
+        ['uuid', 'DESC'],
+      ]);
+
+      const { order } = (folderModel.findAll as jest.Mock).mock.calls[0][0];
+      expect(order).toEqual([['uuid', 'DESC']]);
+    });
+  });
+
   describe('findAllCursor', () => {
     const whereClause = { deleted: false, removed: false };
     const limit = 10;
@@ -783,7 +827,7 @@ describe('SequelizeFolderRepository', () => {
         offset,
         where: whereClause,
         subQuery: false,
-        order,
+        order: [...order, ['uuid', 'ASC']],
         include: [
           {
             separate: true,

--- a/src/modules/folder/folder.repository.ts
+++ b/src/modules/folder/folder.repository.ts
@@ -31,6 +31,7 @@ import {
   FavoriteItemType,
   type FavoriteAttributes,
 } from '../favorite/favorite.domain';
+import { applyCollateAndTiebreakerToSort } from '../../lib/sort';
 
 function mapSnakeCaseToCamelCase(data) {
   const camelCasedObject = {};
@@ -188,35 +189,7 @@ export class SequelizeFolderRepository implements FolderRepository {
   private applyCollateToPlainNameSort(
     order: Array<[keyof FolderModel, string]>,
   ): Array<[keyof FolderModel, string] | Literal> {
-    if (order.length === 0) {
-      return order;
-    }
-
-    const newOrder: Array<[keyof FolderModel, string] | Literal> =
-      structuredClone(order);
-
-    const plainNameIndex = order.findIndex(
-      ([field, _]) => field === 'plainName',
-    );
-    const isPlainNameSort = plainNameIndex !== -1;
-
-    if (isPlainNameSort) {
-      const [, orderDirection] = order[plainNameIndex];
-      newOrder[plainNameIndex] = Sequelize.literal(
-        `"FolderModel"."plain_name" COLLATE "custom_numeric" ${
-          orderDirection === 'ASC' ? 'ASC' : 'DESC'
-        }`,
-      );
-    }
-
-    const hasUniqueSortField = order.some(
-      ([field, _]) => field === 'uuid' || field === 'id',
-    );
-    if (!hasUniqueSortField) {
-      newOrder.push(['uuid', 'ASC']);
-    }
-
-    return newOrder;
+    return applyCollateAndTiebreakerToSort(FolderModel, order);
   }
 
   async findByParentUuid(

--- a/src/modules/folder/folder.repository.ts
+++ b/src/modules/folder/folder.repository.ts
@@ -27,7 +27,10 @@ import { UserModel } from '../user/user.model';
 import { User } from '../user/user.domain';
 import { type UserAttributes } from '../user/user.attributes';
 import { FavoriteModel } from '../favorite/favorite.model';
-import { FavoriteItemType, type FavoriteAttributes } from '../favorite/favorite.domain';
+import {
+  FavoriteItemType,
+  type FavoriteAttributes,
+} from '../favorite/favorite.domain';
 
 function mapSnakeCaseToCamelCase(data) {
   const camelCasedObject = {};
@@ -185,23 +188,33 @@ export class SequelizeFolderRepository implements FolderRepository {
   private applyCollateToPlainNameSort(
     order: Array<[keyof FolderModel, string]>,
   ): Array<[keyof FolderModel, string] | Literal> {
-    const plainNameIndex = order.findIndex(
-      ([field, _]) => field === 'plainName',
-    );
-    const isPlainNameSort = plainNameIndex !== -1;
-
-    if (!isPlainNameSort) {
+    if (order.length === 0) {
       return order;
     }
 
     const newOrder: Array<[keyof FolderModel, string] | Literal> =
       structuredClone(order);
-    const [, orderDirection] = order[plainNameIndex];
-    newOrder[plainNameIndex] = Sequelize.literal(
-      `"FolderModel"."plain_name" COLLATE "custom_numeric" ${
-        orderDirection === 'ASC' ? 'ASC' : 'DESC'
-      }`,
+
+    const plainNameIndex = order.findIndex(
+      ([field, _]) => field === 'plainName',
     );
+    const isPlainNameSort = plainNameIndex !== -1;
+
+    if (isPlainNameSort) {
+      const [, orderDirection] = order[plainNameIndex];
+      newOrder[plainNameIndex] = Sequelize.literal(
+        `"FolderModel"."plain_name" COLLATE "custom_numeric" ${
+          orderDirection === 'ASC' ? 'ASC' : 'DESC'
+        }`,
+      );
+    }
+
+    const hasUniqueSortField = order.some(
+      ([field, _]) => field === 'uuid' || field === 'id',
+    );
+    if (!hasUniqueSortField) {
+      newOrder.push(['uuid', 'ASC']);
+    }
 
     return newOrder;
   }


### PR DESCRIPTION
## Problem
A user reported that `rclone ls` / `lsf` / `lsjson` return duplicated filenames and omit other files, while the same folder looks correct in the Drive web app. Reproducible on every listing.

Cause: Folder listings are paged (`limit=50` + `offset`) with no tiebreaker in the sort. Files tied on the sort field (`photo.jpg` / `photo.json` → same `plain_name`; bulk uploads → same `updatedAt`) have no deterministic order, so ties can shift between page queries. When a tie group straddles a page boundary, one file is returned twice and another is never returned.

rclone shows this raw (duplicate + missing files, as reported); the web app hides it by de-duplicating on uuid — but the missing files are absent there too.

## Solution

Append `uuid ASC` as a final sort key in the file and folder repositories when the requested sort has no unique field:

```sql
ORDER BY plain_name COLLATE "custom_numeric" ASC, uuid ASC

Ties become impossible, so pages tile together exactly once per file. 