### PR TITLE
[_] chore: create index for folder navigation

### DIFF
--- a/migrations/20260907111433-create-unique-index-files-folder-user-name-type.js
+++ b/migrations/20260907111433-create-unique-index-files-folder-user-name-type.js
@@ -1,0 +1,37 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface) {
+    // Enforce uniqueness and matches the collation used in the navigation queries
+    await queryInterface.sequelize.query(`
+      CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS idx_files_folder_user_name_type_unique_numeric
+      ON files (folder_uuid, user_id, plain_name COLLATE "custom_numeric", type)
+      WHERE status = 'EXISTS';
+    `);
+
+    // These indexes are redundant now
+    await queryInterface.sequelize.query(
+      'DROP INDEX CONCURRENTLY IF EXISTS idx_files_folder_user_exists;',
+    );
+    await queryInterface.sequelize.query(
+      'DROP INDEX CONCURRENTLY IF EXISTS files_plainname_type_folderid_exists_unique;',
+    );
+  },
+
+  async down(queryInterface) {
+    await queryInterface.sequelize.query(`
+      CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_files_folder_user_exists
+      ON files (folder_uuid, user_id)
+      WHERE status = 'EXISTS';
+    `);
+    await queryInterface.sequelize.query(`
+      CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS files_plainname_type_folderid_exists_unique
+      ON files USING btree (plain_name, type, folder_id)
+      WHERE (status = 'EXISTS');
+    `);
+    await queryInterface.sequelize.query(
+      'DROP INDEX CONCURRENTLY IF EXISTS idx_files_folder_user_name_type_unique_numeric;',
+    );
+  },
+};

--- a/src/common/filters/unique-constraint.filter.spec.ts
+++ b/src/common/filters/unique-constraint.filter.spec.ts
@@ -26,7 +26,7 @@ describe('UniqueConstraintFilter', () => {
   });
 
   it('When a file unique constraint is violated, it should throw 409 with the file message', () => {
-    const error = makeError('files_plainname_type_folderid_exists_unique');
+    const error = makeError('idx_files_folder_user_name_type_unique_numeric');
 
     expect(() => filter.catch(error, mockHost)).toThrow(
       new ConflictException(

--- a/src/common/filters/unique-constraint.filter.ts
+++ b/src/common/filters/unique-constraint.filter.ts
@@ -13,7 +13,7 @@ interface DatabaseErrorWithConstraint extends Error {
 @Catch(UniqueConstraintError)
 export class UniqueConstraintFilter implements ExceptionFilter {
   private readonly constraintMessages: Record<string, string> = {
-    files_plainname_type_folderid_exists_unique:
+    idx_files_folder_user_name_type_unique_numeric:
       'A file with this name already exists in this location',
     folders_plainname_parentid_key:
       'A folder with this name already exists in this location',


### PR DESCRIPTION
We have a throughput of 3k/minute on the EP that uses this query, but the indexes we have currently are not optimized for it.

This PR creates a new index that covers both the uniqueness guarantee index and the folder_uuid + user_id lookup used for navigation between files in a folder. It's built with the collation we use for correct ordering (taking into account numeric values), so all queries using that collation get faster too.

### Prod
Folder with ~8.5k files, order performed in memory, this is an example of how bad the query perfoms on prod: 

```
Limit  (cost=2.60..2.61 rows=1 width=705) (actual time=52085.247..52085.258 rows=50 loops=1)
  Output: uuid, id, file_id, plain_name, type, size, bucket, folder_id, folder_uuid, encrypt_version, user_id, creation_time, modification_time, created_at, updated_at, removed, removed_at, deleted, deleted_at, status, ((plain_name)::character varying(650))
  Buffers: shared hit=245 read=8164 written=546
  ->  Sort  (cost=2.60..2.61 rows=1 width=705) (actual time=52085.242..52085.249 rows=50 loops=1)
        Output: uuid, id, file_id, plain_name, type, size, bucket, folder_id, folder_uuid, encrypt_version, user_id, creation_time, modification_time, created_at, updated_at, removed, removed_at, deleted, deleted_at, status, ((plain_name)::character varying(650))
        Sort Key: "FileModel".plain_name COLLATE custom_numeric
        Sort Method: top-N heapsort  Memory: 44kB
        Buffers: shared hit=245 read=8164 written=546
        ->  Index Scan using idx_files_folder_user_exists on public.files "FileModel"  (cost=0.57..2.59 rows=1 width=705) (actual time=32.194..52008.604 rows=8471 loops=1)
              Output: uuid, id, file_id, plain_name, type, size, bucket, folder_id, folder_uuid, encrypt_version, user_id, creation_time, modification_time, created_at, updated_at, removed, removed_at, deleted, deleted_at, status, plain_name
              Index Cond: (("FileModel".folder_uuid = '612a32d6-cda9-4531-bb05-ac4932836c11'::uuid) AND ("FileModel".user_id = 5940910))
              Buffers: shared hit=245 read=8164 written=546
Query Identifier: -1559311482312742605
Planning:
  Buffers: shared hit=6
Planning Time: 1.073 ms
Execution Time: 52085.363 ms
```

## Benchmark
Let's try to mimic the same behaviour locally:

User with 700K files with random statuses in the same folder.

Query:

```
EXPLAIN (ANALYZE)
SELECT uuid, id, file_id, plain_name, type, size, bucket, folder_id, folder_uuid,
       encrypt_version, user_id, creation_time, modification_time, created_at,
       updated_at, removed, removed_at, deleted, deleted_at, status
FROM files
WHERE folder_uuid = FOLDER_UUID
  AND user_id = USER_ID
  AND status = 'EXISTS'
ORDER BY
    files.plain_name COLLATE "custom_numeric" ASC
LIMIT 50;
```

### Before
The query uses idx_files_folder_user_exists.

```
Limit  (cost=42898.70..42904.53 rows=50 width=700) (actual time=30.293..32.951 rows=50.00 loops=1)
  Buffers: shared hit=1733
  ->  Gather Merge  (cost=42898.70..56486.15 rows=116664 width=700) (actual time=30.290..32.939 rows=50.00 loops=1)
        Workers Planned: 2
        Workers Launched: 2
        Buffers: shared hit=1733
        ->  Sort  (cost=41898.68..42020.21 rows=48610 width=700) (actual time=25.016..25.021 rows=50.00 loops=3)
              Sort Key: plain_name COLLATE custom_numeric
              Sort Method: top-N heapsort  Memory: 38kB
              Buffers: shared hit=1733
              Worker 0:  Sort Method: top-N heapsort  Memory: 37kB
              Worker 1:  Sort Method: top-N heapsort  Memory: 37kB
              ->  Parallel Bitmap Heap Scan on files  (cost=1600.22..40283.89 rows=48610 width=700) (actual time=1.298..7.658 rows=20000.67 loops=3)
                    Recheck Cond: ((folder_uuid = '48204e02-0420-4a47-9a2a-6ab7df4793dd'::uuid) AND (user_id = 1) AND (status = 'EXISTS'::enum_files_status))
                    Heap Blocks: exact=833
                    Buffers: shared hit=1675
                    Worker 0:  Heap Blocks: exact=377
                    Worker 1:  Heap Blocks: exact=371
                    ->  Bitmap Index Scan on idx_files_folder_user_exists  (cost=0.00..1571.06 rows=116663 width=0) (actual time=3.224..3.224 rows=60002.00 loops=1)
                          Index Cond: ((folder_uuid = '48204e02-0420-4a47-9a2a-6ab7df4793dd'::uuid) AND (user_id = 1))
                          Index Searches: 1
                          Buffers: shared hit=54
Planning:
  Buffers: shared hit=1
Planning Time: 0.533 ms
Execution Time: 33.042 ms
```

After
```
Limit  (cost=0.43..68.55 rows=50 width=701) (actual time=0.036..0.065 rows=50.00 loops=1)
  Output: uuid, id, file_id, plain_name, type, size, bucket, folder_id, folder_uuid, encrypt_version, user_id, creation_time, modification_time, created_at, updated_at, removed, removed_at, deleted, deleted_at, status, ((plain_name)::character varying(650))
  Buffers: shared hit=5
  ->  Index Scan using idx_files_folder_user_name_type_numeric on public.files "FileModel"  (cost=0.43..29759.14 rows=21842 width=701) (actual time=0.035..0.057 rows=50.00 loops=1)
        Output: uuid, id, file_id, plain_name, type, size, bucket, folder_id, folder_uuid, encrypt_version, user_id, creation_time, modification_time, created_at, updated_at, removed, removed_at, deleted, deleted_at, status, plain_name
        Index Cond: (("FileModel".folder_uuid = '48204e02-0420-4a47-9a2a-6ab7df4793dd'::uuid) AND ("FileModel".user_id = 1))
        Index Searches: 1
        Buffers: shared hit=5
Query Identifier: -5781742296691481127
Planning:
  Buffers: shared hit=3
Planning Time: 0.252 ms
Execution Time: 0.098 ms
```