### PR TITLE
[_] feat(uuid): move to uuid v7

### DIFF
--- a/src/modules/file/file.usecase.ts
+++ b/src/modules/file/file.usecase.ts
@@ -30,7 +30,7 @@ import { type ReplaceFileDto } from './dto/replace-file.dto';
 import { type FileDto } from './dto/file.dto';
 import { SharingService } from '../sharing/sharing.service';
 import { SharingItemType } from '../sharing/sharing.domain';
-import { v4 } from 'uuid';
+import { v7 } from 'uuid';
 import { type CreateFileDto } from './dto/create-file.dto';
 import { type UpdateFileMetaDto } from './dto/update-file-meta.dto';
 import { type WorkspaceAttributes } from '../workspaces/attributes/workspace.attributes';
@@ -357,7 +357,7 @@ export class FileUseCases {
     const newFileId = isFileEmpty ? null : newFileDto.fileId;
 
     const newFile = await this.fileRepository.create({
-      uuid: v4(),
+      uuid: v7(),
       name: cryptoFileName,
       plainName: newFileDto.plainName,
       type: newFileDto.type,

--- a/src/modules/folder/folder.repository.ts
+++ b/src/modules/folder/folder.repository.ts
@@ -8,7 +8,7 @@ import {
   Sequelize,
   type WhereOptions,
 } from 'sequelize';
-import { v4 } from 'uuid';
+import { v7 } from 'uuid';
 
 import { Folder } from './folder.domain';
 import { type FolderAttributes } from './folder.attributes';
@@ -27,7 +27,10 @@ import { UserModel } from '../user/user.model';
 import { User } from '../user/user.domain';
 import { type UserAttributes } from '../user/user.attributes';
 import { FavoriteModel } from '../favorite/favorite.model';
-import { FavoriteItemType, type FavoriteAttributes } from '../favorite/favorite.domain';
+import {
+  FavoriteItemType,
+  type FavoriteAttributes,
+} from '../favorite/favorite.domain';
 
 function mapSnakeCaseToCamelCase(data) {
   const camelCasedObject = {};
@@ -679,7 +682,7 @@ export class SequelizeFolderRepository implements FolderRepository {
       bucket,
       parentId,
       encryptVersion,
-      uuid: v4(),
+      uuid: v7(),
       parentUuid,
     });
 

--- a/src/modules/folder/folder.usecase.ts
+++ b/src/modules/folder/folder.usecase.ts
@@ -25,7 +25,7 @@ import { SequelizeFolderRepository } from './folder.repository';
 import { SharingService } from '../sharing/sharing.service';
 import { SharingItemType } from '../sharing/sharing.domain';
 import { type WorkspaceItemUserAttributes } from '../workspaces/attributes/workspace-items-users.attributes';
-import { v4 } from 'uuid';
+import { v7 } from 'uuid';
 import { type UpdateFolderMetaDto } from './dto/update-folder-meta.dto';
 import { type FolderStatsDto } from './dto/responses/folder-stats.dto';
 import { type WorkspaceAttributes } from '../workspaces/attributes/workspace.attributes';
@@ -393,7 +393,7 @@ export class FolderUseCases {
     );
 
     const folder = await this.folderRepository.createWithAttributes({
-      uuid: v4(),
+      uuid: v7(),
       userId: user.id,
       name: encryptedFolderName,
       plainName: newFolderDto.plainName,
@@ -460,7 +460,7 @@ export class FolderUseCases {
 
     const now = new Date();
     const foldersToCreate = folders.map((item) => ({
-      uuid: v4(),
+      uuid: v7(),
       userId: user.id,
       name: this.cryptoService.encryptName(item.plainName, parentFolder.id),
       plainName: item.plainName,
@@ -849,7 +849,7 @@ export class FolderUseCases {
       Logger.error(
         `User with id: ${user.id} tried to delete a folder that does not own.`,
       );
-      throw new ForbiddenException(`You are not owner of this share`);
+      throw new ForbiddenException('You are not owner of this share');
     }
 
     await this.folderRepository.deleteById(folder.id);


### PR DESCRIPTION
### What 
Migrate to UUIDV7

### Why
UUIDv4 is random, which causes more index bloat, slower inserts (random page access), and slower lookups.

UUIDv7 is sequential, so index growth is more predictable, inserts are faster, and there's less fragmentation.

5M insert comparison on a 20M-row table populated with UUIDv4 (same scenario as prod):

<img width="1520" height="340" alt="image" src="https://github.com/user-attachments/assets/3302568b-765b-42be-9507-a12b3d933bf9" />
