### PR TITLE
[_] fix: use folder uuid instead of folder id for looking file existence

### DIFF
--- a/src/modules/file/file.repository.spec.ts
+++ b/src/modules/file/file.repository.spec.ts
@@ -343,7 +343,7 @@ describe('FileRepository', () => {
         mockFile.userId,
         mockFile.plainName,
         mockFile.type,
-        mockFile.folderId,
+        mockFile.folderUuid,
         mockFile.status,
       );
 
@@ -352,7 +352,7 @@ describe('FileRepository', () => {
           userId: { [Op.eq]: mockFile.userId },
           plainName: { [Op.eq]: mockFile.plainName },
           type: { [Op.or]: [{ [Op.is]: null }, { [Op.eq]: '' }] },
-          folderId: { [Op.eq]: mockFile.folderId },
+          folderUuid: { [Op.eq]: mockFile.folderUuid },
           status: { [Op.eq]: mockFile.status },
         }),
       });
@@ -374,7 +374,7 @@ describe('FileRepository', () => {
         mockFile.userId,
         mockFile.plainName,
         mockFile.type,
-        mockFile.folderId,
+        mockFile.folderUuid,
         mockFile.status,
       );
 
@@ -383,7 +383,7 @@ describe('FileRepository', () => {
           userId: { [Op.eq]: mockFile.userId },
           plainName: { [Op.eq]: mockFile.plainName },
           type: { [Op.or]: [{ [Op.is]: null }, { [Op.eq]: '' }] },
-          folderId: { [Op.eq]: mockFile.folderId },
+          folderUuid: { [Op.eq]: mockFile.folderUuid },
           status: { [Op.eq]: mockFile.status },
         }),
       });
@@ -405,7 +405,7 @@ describe('FileRepository', () => {
         mockFile.userId,
         mockFile.plainName,
         mockFile.type,
-        mockFile.folderId,
+        mockFile.folderUuid,
         mockFile.status,
       );
 
@@ -414,7 +414,7 @@ describe('FileRepository', () => {
           userId: { [Op.eq]: mockFile.userId },
           plainName: { [Op.eq]: mockFile.plainName },
           type: { [Op.eq]: mockFile.type },
-          folderId: { [Op.eq]: mockFile.folderId },
+          folderUuid: { [Op.eq]: mockFile.folderUuid },
           status: { [Op.eq]: mockFile.status },
         }),
       });
@@ -1550,89 +1550,6 @@ describe('FileRepository', () => {
         },
       });
       expect(result).toBe(count);
-    });
-  });
-
-  describe('deleteFilesByUuid', () => {
-    it('When file UUIDs are provided, then it should mark them as removed and deleted', async () => {
-      const fileUuids = [v4(), v4(), v4()];
-      const updatedCount = 3;
-
-      jest
-        .spyOn(fileModel, 'update')
-        .mockResolvedValueOnce([updatedCount] as any);
-
-      const result = await repository.deleteFilesByUuid(fileUuids);
-
-      expect(fileModel.update).toHaveBeenCalledWith(
-        expect.objectContaining({
-          removed: true,
-          status: FileStatus.DELETED,
-        }),
-        expect.objectContaining({
-          where: {
-            uuid: { [Op.in]: fileUuids },
-            status: { [Op.not]: FileStatus.DELETED },
-          },
-        }),
-      );
-      expect(result).toBe(updatedCount);
-    });
-
-    it('When single file UUID is provided, then it should process it', async () => {
-      const fileUuid = v4();
-      const updatedCount = 1;
-
-      jest
-        .spyOn(fileModel, 'update')
-        .mockResolvedValueOnce([updatedCount] as any);
-
-      const result = await repository.deleteFilesByUuid([fileUuid]);
-
-      expect(fileModel.update).toHaveBeenCalledWith(
-        expect.objectContaining({
-          removed: true,
-          status: FileStatus.DELETED,
-        }),
-        expect.objectContaining({
-          where: {
-            uuid: { [Op.in]: [fileUuid] },
-            status: { [Op.not]: FileStatus.DELETED },
-          },
-        }),
-      );
-      expect(result).toBe(1);
-    });
-
-    it('When no files match the UUIDs, then it should return zero', async () => {
-      const fileUuids = [v4(), v4()];
-      const updatedCount = 0;
-
-      jest
-        .spyOn(fileModel, 'update')
-        .mockResolvedValueOnce([updatedCount] as any);
-
-      const result = await repository.deleteFilesByUuid(fileUuids);
-
-      expect(result).toBe(0);
-    });
-
-    it('When files already deleted, then it should not update them', async () => {
-      const fileUuids = [v4(), v4()];
-
-      jest.spyOn(fileModel, 'update').mockResolvedValueOnce([0] as any);
-
-      const result = await repository.deleteFilesByUuid(fileUuids);
-
-      expect(fileModel.update).toHaveBeenCalledWith(
-        expect.any(Object),
-        expect.objectContaining({
-          where: expect.objectContaining({
-            status: { [Op.not]: FileStatus.DELETED },
-          }),
-        }),
-      );
-      expect(result).toBe(0);
     });
   });
 

--- a/src/modules/file/file.repository.ts
+++ b/src/modules/file/file.repository.ts
@@ -3,12 +3,7 @@ import { withQueryTimeout } from '../../lib/query-timeout';
 import { Time } from '../../lib/time';
 import { type FileUpdatedAtIdCursorDto } from './utils/file-cursor.util';
 import { InjectModel } from '@nestjs/sequelize';
-import {
-  File,
-  type FileAttributes,
-  type FileOptions,
-  FileStatus,
-} from './file.domain';
+import { File, type FileAttributes, FileStatus } from './file.domain';
 import {
   type FindOptions,
   type Includeable,
@@ -23,7 +18,6 @@ import { User } from '../user/user.domain';
 import { UserModel } from './../user/user.model';
 import { Folder } from '../folder/folder.domain';
 import { FolderModel } from '../folder/folder.model';
-import { Pagination } from '../../lib/pagination';
 import { ThumbnailModel } from '../thumbnail/thumbnail.model';
 import { FileModel } from './file.model';
 import { SharingModel } from '../sharing/models';
@@ -44,11 +38,6 @@ export interface FileRepository {
   deleteFilesByUser(user: User, files: File[]): Promise<void>;
   destroyFile(where: Partial<FileModel>): Promise<void>;
   findAll(): Promise<Array<File> | []>;
-  findAllByFolderIdAndUserId(
-    folderUuid: FileAttributes['folderUuid'],
-    userId: FileAttributes['userId'],
-    options: FileOptions,
-  ): Promise<Array<File> | []>;
   findAllCursor(
     where: Partial<Record<keyof FileAttributes, any>>,
     limit: number,
@@ -896,26 +885,6 @@ export class SequelizeFileRepository implements FileRepository {
     });
 
     return files.map(this.toDomain.bind(this));
-  }
-
-  async findAllByFolderIdAndUserId(
-    folderUuid: FileAttributes['folderUuid'],
-    userId: FileAttributes['userId'],
-    { deleted, page, perPage }: FileOptions,
-  ): Promise<Array<File> | []> {
-    const { offset, limit } = Pagination.calculatePagination(page, perPage);
-    const query: FindOptions = {
-      where: { folderUuid, userId, deleted },
-      order: [['id', 'ASC']],
-    };
-    if (page && perPage) {
-      query.offset = offset;
-      query.limit = limit;
-    }
-    const files = await this.fileModel.findAll(query);
-    return files.map((file) => {
-      return this.toDomain(file);
-    });
   }
 
   async getFilesByFolderUuid(

--- a/src/modules/file/file.repository.ts
+++ b/src/modules/file/file.repository.ts
@@ -45,7 +45,7 @@ export interface FileRepository {
   destroyFile(where: Partial<FileModel>): Promise<void>;
   findAll(): Promise<Array<File> | []>;
   findAllByFolderIdAndUserId(
-    folderId: FileAttributes['folderId'],
+    folderUuid: FileAttributes['folderUuid'],
     userId: FileAttributes['userId'],
     options: FileOptions,
   ): Promise<Array<File> | []>;
@@ -117,7 +117,7 @@ export interface FileRepository {
     userId: File['userId'],
     plainName: FileAttributes['plainName'],
     type: FileAttributes['type'],
-    folderId: FileAttributes['folderId'],
+    folderUuid: FileAttributes['folderUuid'],
     status: FileAttributes['status'],
   ): Promise<File | null>;
   getSumSizeOfFilesInWorkspaceByStatuses(
@@ -167,7 +167,6 @@ export interface FileRepository {
     order?: [keyof FileModel, 'ASC' | 'DESC'][],
   ): Promise<File[]>;
   deleteUserTrashedFilesBatch(userId: number, limit: number): Promise<number>;
-  deleteFilesByUuid(fileUuids: string[]): Promise<number>;
   deleteExpiredTrashFilesByTier(
     tierId: string,
     cutoffDate: Date,
@@ -344,7 +343,7 @@ export class SequelizeFileRepository implements FileRepository {
     userId: FileAttributes['userId'],
     plainName: FileAttributes['plainName'],
     type: FileAttributes['type'],
-    folderId: FileAttributes['folderId'],
+    folderUuid: FileAttributes['folderUuid'],
     status: FileAttributes['status'],
   ): Promise<File | null> {
     const typeCondition =
@@ -357,7 +356,7 @@ export class SequelizeFileRepository implements FileRepository {
         userId: { [Op.eq]: userId },
         plainName: { [Op.eq]: plainName },
         type: typeCondition,
-        folderId: { [Op.eq]: folderId },
+        folderUuid: { [Op.eq]: folderUuid },
         status: { [Op.eq]: status },
       },
     });
@@ -888,14 +887,6 @@ export class SequelizeFileRepository implements FileRepository {
     return files.map(this.toDomain.bind(this));
   }
 
-  async findByUuidNotDeleted(uuid: FileAttributes['uuid']): Promise<File> {
-    const file = await this.fileModel.findOne({
-      where: { uuid, deleted: false },
-    });
-
-    return file ? this.toDomain(file) : null;
-  }
-
   async findByIds(
     userId: FileAttributes['userId'],
     ids: FileAttributes['id'][],
@@ -908,13 +899,13 @@ export class SequelizeFileRepository implements FileRepository {
   }
 
   async findAllByFolderIdAndUserId(
-    folderId: FileAttributes['folderId'],
+    folderUuid: FileAttributes['folderUuid'],
     userId: FileAttributes['userId'],
     { deleted, page, perPage }: FileOptions,
   ): Promise<Array<File> | []> {
     const { offset, limit } = Pagination.calculatePagination(page, perPage);
     const query: FindOptions = {
-      where: { folderId, userId, deleted },
+      where: { folderUuid, userId, deleted },
       order: [['id', 'ASC']],
     };
     if (page && perPage) {
@@ -1000,26 +991,6 @@ export class SequelizeFileRepository implements FileRepository {
     const page = hasMore ? rows.slice(0, pageSize) : rows;
 
     return { files: page.map(this.toDomain.bind(this)), hasMore };
-  }
-
-  async findAllByUserIdExceptFolderIds(
-    userId: FileAttributes['userId'],
-    exceptFolderIds: FileAttributes['folderId'][],
-    { deleted, page, perPage }: FileOptions,
-  ): Promise<Array<File> | []> {
-    const { offset, limit } = Pagination.calculatePagination(page, perPage);
-    const query: FindOptions = {
-      where: { userId, deleted, folderId: { [Op.notIn]: exceptFolderIds } },
-      order: [['id', 'ASC']],
-    };
-    if (page && perPage) {
-      query.offset = offset;
-      query.limit = limit;
-    }
-    const files = await this.fileModel.findAll(query);
-    return files.map((file) => {
-      return this.toDomain(file);
-    });
   }
 
   async findOneBy(where: Partial<FileAttributes>): Promise<File | null> {
@@ -1199,26 +1170,6 @@ export class SequelizeFileRepository implements FileRepository {
     );
 
     return { updatedCount };
-  }
-
-  async deleteFilesByUuid(fileUuids: string[]): Promise<number> {
-    const deletedDate = new Date();
-    const [updatedCount] = await this.fileModel.update(
-      {
-        removed: true,
-        removedAt: deletedDate,
-        status: FileStatus.DELETED,
-        updatedAt: deletedDate,
-      },
-      {
-        where: {
-          uuid: { [Op.in]: fileUuids },
-          status: { [Op.not]: FileStatus.DELETED },
-        },
-      },
-    );
-
-    return updatedCount;
   }
 
   async deleteExpiredTrashFilesByTier(

--- a/src/modules/file/file.usecase.spec.ts
+++ b/src/modules/file/file.usecase.spec.ts
@@ -1761,7 +1761,7 @@ describe('FileUseCases', () => {
         mockFile.userId,
         newFileMeta.plainName,
         mockFile.type,
-        mockFile.folderId,
+        mockFile.folderUuid,
         FileStatus.EXISTS,
       );
       expect(fileRepository.updateByUuidAndUserId).toHaveBeenCalledWith(
@@ -1822,7 +1822,7 @@ describe('FileUseCases', () => {
         mockFile.userId,
         mockFile.plainName,
         newTypeFileMeta.type,
-        mockFile.folderId,
+        mockFile.folderUuid,
         FileStatus.EXISTS,
       );
       expect(fileRepository.updateByUuidAndUserId).toHaveBeenCalledWith(
@@ -2358,9 +2358,7 @@ describe('FileUseCases', () => {
 
       expect(
         fileRepository.findFilesWithCursorWhereUpdatedAfter,
-      ).toHaveBeenCalledWith(
-        expect.objectContaining({ cursor: cursorData }),
-      );
+      ).toHaveBeenCalledWith(expect.objectContaining({ cursor: cursorData }));
     });
 
     it('When the cursor status does not match the requested status, then it should throw', async () => {

--- a/src/modules/file/file.usecase.spec.ts
+++ b/src/modules/file/file.usecase.spec.ts
@@ -65,7 +65,6 @@ import { type FileInfo } from '@internxt/inxt-js/build/api';
 import { FavoriteUseCases } from '../favorite/favorite.usecase';
 import { FavoriteItemType } from '../favorite/favorite.domain';
 
-const userId = 1;
 const folderId = 4;
 
 describe('FileUseCases', () => {
@@ -221,72 +220,6 @@ describe('FileUseCases', () => {
         userMocked,
         [...fileUuids, ...files.map((file) => file.uuid)],
         FavoriteItemType.File,
-      );
-    });
-  });
-
-  describe('get folder by folderId and User Id', () => {
-    it('calls getByFolderAndUser and return empty files', async () => {
-      const mockFile = [];
-      jest
-        .spyOn(fileRepository, 'findAllByFolderIdAndUserId')
-        .mockResolvedValue([]);
-
-      const options = { deleted: false };
-      const result = await service.getByFolderAndUser(
-        folderId,
-        userId,
-        options,
-      );
-      expect(result).toEqual(mockFile);
-      expect(fileRepository.findAllByFolderIdAndUserId).toHaveBeenNthCalledWith(
-        1,
-        folderId,
-        userId,
-        options,
-      );
-    });
-
-    it('calls getByFolderAndUser and return files', async () => {
-      const mockFile = File.build({
-        id: 1,
-        fileId: '',
-        name: '',
-        type: 'jpg',
-        size: null,
-        bucket: '',
-        folderId: 4,
-        encryptVersion: '',
-        deleted: false,
-        deletedAt: new Date(),
-        userId: 1,
-        creationTime: new Date(),
-        modificationTime: new Date(),
-        createdAt: new Date(),
-        updatedAt: new Date(),
-        uuid: '',
-        folderUuid: '',
-        removed: false,
-        removedAt: undefined,
-        plainName: 'test',
-        status: FileStatus.EXISTS,
-      });
-      jest
-        .spyOn(fileRepository, 'findAllByFolderIdAndUserId')
-        .mockResolvedValue([mockFile]);
-
-      const options = { deleted: false };
-      const result = await service.getByFolderAndUser(
-        folderId,
-        userId,
-        options,
-      );
-      expect(result).toEqual([mockFile]);
-      expect(fileRepository.findAllByFolderIdAndUserId).toHaveBeenNthCalledWith(
-        1,
-        folderId,
-        userId,
-        options,
       );
     });
   });

--- a/src/modules/file/file.usecase.ts
+++ b/src/modules/file/file.usecase.ts
@@ -14,13 +14,11 @@ import {
 } from '@nestjs/common';
 import { CryptoService } from '../../externals/crypto/crypto.service';
 import { BridgeService } from '../../externals/bridge/bridge.service';
-import { type FolderAttributes } from '../folder/folder.attributes';
 import { type User } from '../user/user.domain';
 import { type UserAttributes } from '../user/user.attributes';
 import {
   File,
   type FileAttributes,
-  type FileOptions,
   FileStatus,
   type SortableFileAttributes,
 } from './file.domain';
@@ -899,20 +897,6 @@ export class FileUseCases {
       pagination.limit,
       pagination.offset,
       order,
-    );
-
-    return files.map((file) => file.toJSON());
-  }
-
-  async getByFolderAndUser(
-    folderUuid: FolderAttributes['uuid'],
-    userId: FolderAttributes['userId'],
-    options: FileOptions,
-  ) {
-    const files = await this.fileRepository.findAllByFolderIdAndUserId(
-      folderUuid,
-      userId,
-      options,
     );
 
     return files.map((file) => file.toJSON());

--- a/src/modules/file/file.usecase.ts
+++ b/src/modules/file/file.usecase.ts
@@ -329,7 +329,7 @@ export class FileUseCases {
       user.id,
       newFileDto.plainName,
       newFileDto.type,
-      folder.id,
+      folder.uuid,
       FileStatus.EXISTS,
     );
     if (exists) {
@@ -486,7 +486,7 @@ export class FileUseCases {
       updatedFile.userId,
       updatedFile.plainName,
       updatedFile.type,
-      updatedFile.folderId,
+      updatedFile.folderUuid,
     );
     if (fileWithSameNameExists) {
       throw new ConflictException(
@@ -905,12 +905,12 @@ export class FileUseCases {
   }
 
   async getByFolderAndUser(
-    folderId: FolderAttributes['id'],
+    folderUuid: FolderAttributes['uuid'],
     userId: FolderAttributes['userId'],
     options: FileOptions,
   ) {
     const files = await this.fileRepository.findAllByFolderIdAndUserId(
-      folderId,
+      folderUuid,
       userId,
       options,
     );
@@ -1178,7 +1178,7 @@ export class FileUseCases {
       file.userId,
       file.plainName,
       file.type,
-      destinationFolder.id,
+      destinationFolder.uuid,
       FileStatus.EXISTS,
     );
 
@@ -1276,13 +1276,13 @@ export class FileUseCases {
     userId: FileAttributes['userId'],
     plainName: FileAttributes['plainName'],
     type: FileAttributes['type'],
-    folderId: FileAttributes['folderId'],
+    folderUuid: FileAttributes['folderUuid'],
   ): Promise<File | null> {
     return this.fileRepository.findByPlainNameAndFolderId(
       userId,
       plainName,
       type,
-      folderId,
+      folderUuid,
       FileStatus.EXISTS,
     );
   }
@@ -1305,7 +1305,7 @@ export class FileUseCases {
       user.id,
       path.fileName,
       path.fileType,
-      folder.id,
+      folder.uuid,
     );
     return file;
   }


### PR DESCRIPTION
Queries that looks for files existence in a folder do not support folderId anymore, we need to migrate to folderUuid as the speed is being compromised.

## Changes
- Removed some dead methods
- Migrate to folderUuid