### PR TITLE
[_] fix(db-search): use collate in where clause

### DIFF
--- a/migrations/20260907111433-create-unique-index-files-folder-user-name-type.js
+++ b/migrations/20260907111433-create-unique-index-files-folder-user-name-type.js
@@ -1,5 +1,6 @@
 'use strict';
 
+// NOTE: if this collation changes, update matching queries in file.repository.ts
 /** @type {import('sequelize-cli').Migration} */
 module.exports = {
   async up(queryInterface) {

--- a/src/modules/file/file.repository.spec.ts
+++ b/src/modules/file/file.repository.spec.ts
@@ -294,14 +294,18 @@ describe('FileRepository', () => {
           folderUuid,
           status: FileStatus.EXISTS,
           [Op.or]: [
-            {
-              plainName: 'Report',
+            expect.objectContaining({
+              [Op.and]: expect.objectContaining({
+                val: expect.stringContaining('COLLATE "custom_numeric"'),
+              }),
               type: 'pdf',
-            },
-            {
-              plainName: 'Summary',
+            }),
+            expect.objectContaining({
+              [Op.and]: expect.objectContaining({
+                val: expect.stringContaining('COLLATE "custom_numeric"'),
+              }),
               type: 'doc',
-            },
+            }),
           ],
         }),
       });
@@ -317,9 +321,11 @@ describe('FileRepository', () => {
           folderUuid,
           status: FileStatus.EXISTS,
           [Op.or]: [
-            {
-              plainName: 'Report',
-            },
+            expect.objectContaining({
+              [Op.and]: expect.objectContaining({
+                val: expect.stringContaining('COLLATE "custom_numeric"'),
+              }),
+            }),
           ],
         }),
       });
@@ -350,11 +356,14 @@ describe('FileRepository', () => {
       expect(fileModel.findOne).toHaveBeenCalledWith({
         where: expect.objectContaining({
           userId: { [Op.eq]: mockFile.userId },
-          plainName: { [Op.eq]: mockFile.plainName },
+          [Op.and]: expect.objectContaining({
+            val: expect.stringContaining('COLLATE "custom_numeric"'),
+          }),
           type: { [Op.or]: [{ [Op.is]: null }, { [Op.eq]: '' }] },
           folderUuid: { [Op.eq]: mockFile.folderUuid },
           status: { [Op.eq]: mockFile.status },
         }),
+        replacements: { plainName: mockFile.plainName },
       });
     });
 
@@ -381,11 +390,14 @@ describe('FileRepository', () => {
       expect(fileModel.findOne).toHaveBeenCalledWith({
         where: expect.objectContaining({
           userId: { [Op.eq]: mockFile.userId },
-          plainName: { [Op.eq]: mockFile.plainName },
+          [Op.and]: expect.objectContaining({
+            val: expect.stringContaining('COLLATE "custom_numeric"'),
+          }),
           type: { [Op.or]: [{ [Op.is]: null }, { [Op.eq]: '' }] },
           folderUuid: { [Op.eq]: mockFile.folderUuid },
           status: { [Op.eq]: mockFile.status },
         }),
+        replacements: { plainName: mockFile.plainName },
       });
     });
 
@@ -412,11 +424,14 @@ describe('FileRepository', () => {
       expect(fileModel.findOne).toHaveBeenCalledWith({
         where: expect.objectContaining({
           userId: { [Op.eq]: mockFile.userId },
-          plainName: { [Op.eq]: mockFile.plainName },
+          [Op.and]: expect.objectContaining({
+            val: expect.stringContaining('COLLATE "custom_numeric"'),
+          }),
           type: { [Op.eq]: mockFile.type },
           folderUuid: { [Op.eq]: mockFile.folderUuid },
           status: { [Op.eq]: mockFile.status },
         }),
+        replacements: { plainName: mockFile.plainName },
       });
     });
   });

--- a/src/modules/file/file.repository.ts
+++ b/src/modules/file/file.repository.ts
@@ -343,11 +343,15 @@ export class SequelizeFileRepository implements FileRepository {
     const file = await this.fileModel.findOne({
       where: {
         userId: { [Op.eq]: userId },
-        plainName: { [Op.eq]: plainName },
+        // NOTE: collate needed to use the plain_name numeric-collation index
+        [Op.and]: Sequelize.literal(
+          '"FileModel"."plain_name" COLLATE "custom_numeric" = :plainName COLLATE "custom_numeric"',
+        ),
         type: typeCondition,
         folderUuid: { [Op.eq]: folderUuid },
         status: { [Op.eq]: status },
       },
+      replacements: { plainName },
     });
     return file ? this.toDomain(file) : null;
   }
@@ -460,6 +464,7 @@ export class SequelizeFileRepository implements FileRepository {
     const newOrder: Array<[keyof FileModel, string] | Literal> =
       structuredClone(order);
     const [, orderDirection] = order[plainNameIndex];
+    // NOTE: collate needed to use the plain_name numeric-collation index
     newOrder[plainNameIndex] = Sequelize.literal(
       `"FileModel"."plain_name" COLLATE "custom_numeric" ${
         orderDirection === 'ASC' ? 'ASC' : 'DESC'
@@ -980,7 +985,12 @@ export class SequelizeFileRepository implements FileRepository {
 
     if (searchFilter.length) {
       where[Op.or] = searchFilter.map((criteria) => ({
-        plainName: criteria.plainName,
+        // NOTE: collate needed to use the plain_name numeric-collation index
+        [Op.and]: Sequelize.literal(
+          `"FileModel"."plain_name" COLLATE "custom_numeric" = ${this.fileModel.sequelize.escape(
+            criteria.plainName,
+          )} COLLATE "custom_numeric"`,
+        ),
         ...(criteria.type ? { type: criteria.type } : {}),
       }));
     }


### PR DESCRIPTION
## What
As we added an index with a custom collate instead of running ALTER TABLE... to set the default collate on plain_name, we need to also specify the collate in the WHERE clauses so they take advantage of the index.

## Why
Users with a lot of items in the folders have troubles to create, moving and updating files metadata, as an example, a file lookup to check if a file with the same name exists in the folder can take 4 minutes:

```
Index Scan using idx_files_folder_user_name_type_unique_numeric on public.files "FileModel"  (cost=0.70..5330.19 rows=1 width=189) (actual time=30335.779..260624.159 rows=1 loops=1)
  Output: uuid, id, file_id, plain_name, type, size, bucket, folder_id, folder_uuid, encrypt_version, user_id, creation_time, modification_time, created_at, updated_at, removed, removed_at, deleted, deleted_at, status
  Index Cond: (("FileModel".folder_uuid = 'd727a126-a234-4815-9a29-4dd32392b7bc'::uuid) AND (("FileModel".type)::text = 'eml'::text))
  Filter: (("FileModel".plain_name)::text = '1772355878.M157996P921Q16696.624d7bf6515e'::text)
  Rows Removed by Filter: 78549
  Buffers: shared hit=5355 read=75216 written=29
Query Identifier: 407500847225719756
Planning:
  Buffers: shared hit=382
Planning Time: 4.635 ms
Execution Time: 260624.391 ms
```