### PR TITLE
[PB-6828] feat/folders in folder with cursor based pagination

### DIFF
--- a/migrations/20260910111639-create-unique-index-folders-parentuuid-plainname-numeric.js
+++ b/migrations/20260910111639-create-unique-index-folders-parentuuid-plainname-numeric.js
@@ -1,0 +1,28 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  up: async (queryInterface) => {
+    await queryInterface.sequelize.query(`
+      CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS folders_parentuuid_plainname_numeric_unique
+      ON folders (parent_uuid, plain_name COLLATE "custom_numeric")
+      WHERE deleted = false and removed = false;
+    `);
+
+    await queryInterface.sequelize.query(`
+      DROP INDEX CONCURRENTLY IF EXISTS folders_parentuuid_plainname_unique;
+    `);
+  },
+
+  down: async (queryInterface) => {
+    await queryInterface.sequelize.query(`
+      CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS folders_parentuuid_plainname_unique
+      ON folders (parent_uuid, plain_name)
+      WHERE deleted = false and removed = false;
+    `);
+
+    await queryInterface.sequelize.query(`
+      DROP INDEX CONCURRENTLY IF EXISTS folders_parentuuid_plainname_numeric_unique;
+    `);
+  },
+};

--- a/src/common/dto/cursor-pagination.dto.ts
+++ b/src/common/dto/cursor-pagination.dto.ts
@@ -1,0 +1,57 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import {
+  IsEnum,
+  IsInt,
+  IsOptional,
+  IsString,
+  IsUUID,
+  Max,
+  MaxLength,
+  Min,
+} from 'class-validator';
+import { SortOrder } from '../order.type';
+
+export class CursorPaginationDto {
+  @ApiProperty({
+    description: 'Sort direction',
+    enum: SortOrder,
+    default: SortOrder.ASC,
+    required: false,
+  })
+  @IsOptional()
+  @IsEnum(SortOrder)
+  order: SortOrder = SortOrder.ASC;
+
+  @ApiProperty({
+    description: 'Cursor from a previous response to fetch the next page',
+    required: false,
+  })
+  @IsOptional()
+  @IsString()
+  @MaxLength(256)
+  cursor?: string;
+
+  @ApiProperty({
+    description: 'Page size',
+    default: 100,
+    required: false,
+  })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(50)
+  @Max(1000)
+  limit: number = 100;
+}
+
+export class CursorPageTokenDto {
+  @IsUUID()
+  lastUuid: string;
+
+  @IsEnum(SortOrder)
+  order: SortOrder;
+
+  @IsString()
+  lastValue: string;
+}

--- a/src/modules/file/file.repository.ts
+++ b/src/modules/file/file.repository.ts
@@ -461,6 +461,7 @@ export class SequelizeFileRepository implements FileRepository {
   }): Promise<{ files: File[]; hasMore: boolean }> {
     const sortColumn = '"FileModel"."plain_name" COLLATE "custom_numeric"';
     const comparator = order === SortOrder.DESC ? '<' : '>';
+    const orderDirection = order === SortOrder.DESC ? 'DESC' : 'ASC';
 
     const whereCondition: WhereOptions<FileAttributes> = {
       folderUuid,
@@ -509,9 +510,9 @@ export class SequelizeFileRepository implements FileRepository {
       subQuery: false,
       order: [
         Sequelize.literal(
-          `"FileModel"."plain_name" COLLATE "custom_numeric" ${order}`,
+          `"FileModel"."plain_name" COLLATE "custom_numeric" ${orderDirection}`,
         ),
-        ['uuid', order],
+        ['uuid', orderDirection],
       ],
       limit: pageSize + 1,
     });

--- a/src/modules/folder/dto/get-folder-content-files-cursor.dto.ts
+++ b/src/modules/folder/dto/get-folder-content-files-cursor.dto.ts
@@ -1,50 +1,12 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { Transform, Type } from 'class-transformer';
+import { Transform } from 'class-transformer';
+import { IsBoolean, IsOptional } from 'class-validator';
 import {
-  IsBoolean,
-  IsEnum,
-  IsInt,
-  IsOptional,
-  IsString,
-  IsUUID,
-  Max,
-  MaxLength,
-  Min,
-} from 'class-validator';
-import { SortOrder } from '../../../common/order.type';
+  CursorPaginationDto,
+  CursorPageTokenDto,
+} from '../../../common/dto/cursor-pagination.dto';
 
-export class GetFolderContentFilesCursorDto {
-  @ApiProperty({
-    description: 'Sort direction',
-    enum: SortOrder,
-    default: SortOrder.ASC,
-    required: false,
-  })
-  @IsOptional()
-  @IsEnum(SortOrder)
-  order: SortOrder = SortOrder.ASC;
-
-  @ApiProperty({
-    description: 'Cursor from a previous response to fetch the next page',
-    required: false,
-  })
-  @IsOptional()
-  @IsString()
-  @MaxLength(256)
-  cursor?: string;
-
-  @ApiProperty({
-    description: 'Page size',
-    default: 100,
-    required: false,
-  })
-  @IsOptional()
-  @Type(() => Number)
-  @IsInt()
-  @Min(50)
-  @Max(1000)
-  limit: number = 100;
-
+export class GetFolderContentFilesCursorDto extends CursorPaginationDto {
   @ApiProperty({
     description: 'Whether to include each file favorite status',
     default: false,
@@ -76,13 +38,4 @@ export class GetFolderContentFilesCursorDto {
   withSharings?: boolean;
 }
 
-export class FolderFilesCursorDto {
-  @IsUUID()
-  lastUuid: string;
-
-  @IsEnum(SortOrder)
-  order: SortOrder;
-
-  @IsString()
-  lastValue: string;
-}
+export class FolderFilesCursorDto extends CursorPageTokenDto {}

--- a/src/modules/folder/dto/get-folder-content-folders-cursor.dto.ts
+++ b/src/modules/folder/dto/get-folder-content-folders-cursor.dto.ts
@@ -1,0 +1,78 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Transform, Type } from 'class-transformer';
+import {
+  IsBoolean,
+  IsEnum,
+  IsInt,
+  IsOptional,
+  IsString,
+  IsUUID,
+  Max,
+  MaxLength,
+  Min,
+} from 'class-validator';
+import { SortOrder } from '../../../common/order.type';
+
+export class GetFolderContentFoldersCursorDto {
+  @ApiProperty({
+    description: 'Sort direction',
+    enum: SortOrder,
+    default: SortOrder.ASC,
+    required: false,
+  })
+  @IsOptional()
+  @IsEnum(SortOrder)
+  order: SortOrder = SortOrder.ASC;
+
+  @ApiProperty({
+    description: 'Cursor from a previous response to fetch the next page',
+    required: false,
+  })
+  @IsOptional()
+  @IsString()
+  @MaxLength(256)
+  cursor?: string;
+
+  @ApiProperty({
+    description: 'Page size',
+    default: 100,
+    required: false,
+  })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(50)
+  @Max(1000)
+  limit: number = 100;
+
+  @ApiProperty({
+    description: 'Whether to include each folder favorite status',
+    default: false,
+    required: false,
+  })
+  @IsOptional()
+  @Transform(({ value }) => value === 'true')
+  @IsBoolean()
+  withFavorites?: boolean;
+
+  @ApiProperty({
+    description: 'Whether to include each folder sharing info',
+    default: false,
+    required: false,
+  })
+  @IsOptional()
+  @Transform(({ value }) => value === 'true')
+  @IsBoolean()
+  withSharings?: boolean;
+}
+
+export class FolderFoldersCursorDto {
+  @IsUUID()
+  lastUuid: string;
+
+  @IsEnum(SortOrder)
+  order: SortOrder;
+
+  @IsString()
+  lastValue: string;
+}

--- a/src/modules/folder/dto/get-folder-content-folders-cursor.dto.ts
+++ b/src/modules/folder/dto/get-folder-content-folders-cursor.dto.ts
@@ -1,50 +1,12 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { Transform, Type } from 'class-transformer';
+import { Transform } from 'class-transformer';
+import { IsBoolean, IsOptional } from 'class-validator';
 import {
-  IsBoolean,
-  IsEnum,
-  IsInt,
-  IsOptional,
-  IsString,
-  IsUUID,
-  Max,
-  MaxLength,
-  Min,
-} from 'class-validator';
-import { SortOrder } from '../../../common/order.type';
+  CursorPaginationDto,
+  CursorPageTokenDto,
+} from '../../../common/dto/cursor-pagination.dto';
 
-export class GetFolderContentFoldersCursorDto {
-  @ApiProperty({
-    description: 'Sort direction',
-    enum: SortOrder,
-    default: SortOrder.ASC,
-    required: false,
-  })
-  @IsOptional()
-  @IsEnum(SortOrder)
-  order: SortOrder = SortOrder.ASC;
-
-  @ApiProperty({
-    description: 'Cursor from a previous response to fetch the next page',
-    required: false,
-  })
-  @IsOptional()
-  @IsString()
-  @MaxLength(256)
-  cursor?: string;
-
-  @ApiProperty({
-    description: 'Page size',
-    default: 100,
-    required: false,
-  })
-  @IsOptional()
-  @Type(() => Number)
-  @IsInt()
-  @Min(50)
-  @Max(1000)
-  limit: number = 100;
-
+export class GetFolderContentFoldersCursorDto extends CursorPaginationDto {
   @ApiProperty({
     description: 'Whether to include each folder favorite status',
     default: false,
@@ -66,13 +28,4 @@ export class GetFolderContentFoldersCursorDto {
   withSharings?: boolean;
 }
 
-export class FolderFoldersCursorDto {
-  @IsUUID()
-  lastUuid: string;
-
-  @IsEnum(SortOrder)
-  order: SortOrder;
-
-  @IsString()
-  lastValue: string;
-}
+export class FolderFoldersCursorDto extends CursorPageTokenDto {}

--- a/src/modules/folder/dto/responses/get-folder-content-folders-v2.dto.ts
+++ b/src/modules/folder/dto/responses/get-folder-content-folders-v2.dto.ts
@@ -1,0 +1,10 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { FolderDto } from './folder.dto';
+
+export class GetFolderContentFoldersV2ResponseDto {
+  @ApiProperty({ type: FolderDto, isArray: true })
+  folders: FolderDto[];
+
+  @ApiProperty({ type: String, nullable: true })
+  nextCursor: string | null;
+}

--- a/src/modules/folder/folder.controller.spec.ts
+++ b/src/modules/folder/folder.controller.spec.ts
@@ -126,85 +126,124 @@ describe('FolderController', () => {
   });
 
   describe('get folder content', () => {
-    it('When get folder subfiles are requested by folder uuid, then the child files are returned', async () => {
-      const expectedSubfiles = [
-        newFile({ attributes: { id: 1, folderUuid: folder.uuid } }),
-        newFile({ attributes: { id: 2, folderUuid: folder.uuid } }),
-        newFile({ attributes: { id: 3, folderUuid: folder.uuid } }),
-      ];
-      jest.spyOn(fileUseCases, 'getFiles').mockResolvedValue(expectedSubfiles);
+    describe('getFolderContentFiles (deprecated)', () => {
+      it('When get folder subfiles are requested by folder uuid, then the child files are returned', async () => {
+        const expectedSubfiles = [
+          newFile({ attributes: { id: 1, folderUuid: folder.uuid } }),
+          newFile({ attributes: { id: 2, folderUuid: folder.uuid } }),
+          newFile({ attributes: { id: 3, folderUuid: folder.uuid } }),
+        ];
+        jest
+          .spyOn(fileUseCases, 'getFiles')
+          .mockResolvedValue(expectedSubfiles);
 
-      const result = await folderController.getFolderContentFiles(
-        userMocked,
-        folder.uuid,
-        { limit: 50, offset: 0, sort: 'id', order: SortOrder.ASC },
-      );
-      expect(result).toEqual({ files: expectedSubfiles });
-      expect(fileUseCases.getFiles).toHaveBeenCalledWith(
-        userMocked.id,
-        expect.objectContaining({ folderUuid: folder.uuid }),
-        expect.objectContaining({ favoriteUserUuid: userMocked.uuid }),
-      );
-    });
-
-    it('When get folder subfiles v2 (keyset pagination) is requested, then it delegates to getFolderFilesWithCursor and returns files + nextCursor', async () => {
-      const expectedSubfiles = [
-        newFile({ attributes: { id: 1, folderUuid: folder.uuid } }),
-      ];
-      const nextCursor = 'encoded-cursor';
-      jest
-        .spyOn(fileUseCases, 'getFolderFilesWithCursor')
-        .mockResolvedValue({ files: expectedSubfiles, nextCursor });
-
-      const query = { sortBy: undefined, order: undefined };
-      const result = await folderController.getFolderContentFilesV2(
-        userMocked,
-        folder.uuid,
-        query as any,
-      );
-
-      expect(result).toEqual({ files: expectedSubfiles, nextCursor });
-      expect(fileUseCases.getFolderFilesWithCursor).toHaveBeenCalledWith(
-        userMocked,
-        folder.uuid,
-        query,
-      );
-    });
-
-    it('When get folder subfolders are requested by folder uuid, then the child folders are returned', async () => {
-      const expectedSubfolders = [
-        newFolder({ attributes: { id: 1, parentUuid: folder.uuid } }),
-        newFolder({ attributes: { id: 2, parentUuid: folder.uuid } }),
-        newFolder({ attributes: { id: 3, parentUuid: folder.uuid } }),
-      ];
-      const mappedSubfolders = expectedSubfolders.map((f) => {
-        let folderStatus: FileStatus;
-        if (f.removed) {
-          folderStatus = FileStatus.DELETED;
-        } else if (f.deleted) {
-          folderStatus = FileStatus.TRASHED;
-        } else {
-          folderStatus = FileStatus.EXISTS;
-        }
-        return { ...f, status: folderStatus };
+        const result = await folderController.getFolderContentFiles(
+          userMocked,
+          folder.uuid,
+          { limit: 50, offset: 0, sort: 'id', order: SortOrder.ASC },
+        );
+        expect(result).toEqual({ files: expectedSubfiles });
+        expect(fileUseCases.getFiles).toHaveBeenCalledWith(
+          userMocked.id,
+          expect.objectContaining({ folderUuid: folder.uuid }),
+          expect.objectContaining({ favoriteUserUuid: userMocked.uuid }),
+        );
       });
+    });
 
-      jest
-        .spyOn(folderUseCases, 'getFolders')
-        .mockResolvedValue(expectedSubfolders);
+    describe('getFolderContentFilesV2', () => {
+      it('When get folder subfiles v2 (keyset pagination) is requested, then it delegates to getFolderFilesWithCursor and returns files + nextCursor', async () => {
+        const expectedSubfiles = [
+          newFile({ attributes: { id: 1, folderUuid: folder.uuid } }),
+        ];
+        const nextCursor = 'encoded-cursor';
+        jest
+          .spyOn(fileUseCases, 'getFolderFilesWithCursor')
+          .mockResolvedValue({ files: expectedSubfiles, nextCursor });
 
-      const result = await folderController.getFolderContentFolders(
-        userMocked,
-        folder.uuid,
-        { limit: 50, offset: 0, sort: 'id', order: SortOrder.ASC },
-      );
+        const query = { sortBy: undefined, order: undefined };
+        const result = await folderController.getFolderContentFilesV2(
+          userMocked,
+          folder.uuid,
+          query as any,
+        );
 
-      expect(result).toEqual({ folders: mappedSubfolders });
-      expect(folderUseCases.getFolders).toHaveBeenCalledWith(
-        userMocked.id,
-        expect.objectContaining({ parentUuid: folder.uuid }),
-        expect.objectContaining({ favoriteUserUuid: userMocked.uuid }),
-      );
+        expect(result).toEqual({ files: expectedSubfiles, nextCursor });
+        expect(fileUseCases.getFolderFilesWithCursor).toHaveBeenCalledWith(
+          userMocked,
+          folder.uuid,
+          query,
+        );
+      });
+    });
+
+    describe('getFolderContentFolders (deprecated)', () => {
+      it('When get folder subfolders are requested by folder uuid, then the child folders are returned', async () => {
+        const expectedSubfolders = [
+          newFolder({ attributes: { id: 1, parentUuid: folder.uuid } }),
+          newFolder({ attributes: { id: 2, parentUuid: folder.uuid } }),
+          newFolder({ attributes: { id: 3, parentUuid: folder.uuid } }),
+        ];
+        const mappedSubfolders = expectedSubfolders.map((f) => {
+          let folderStatus: FileStatus;
+          if (f.removed) {
+            folderStatus = FileStatus.DELETED;
+          } else if (f.deleted) {
+            folderStatus = FileStatus.TRASHED;
+          } else {
+            folderStatus = FileStatus.EXISTS;
+          }
+          return { ...f, status: folderStatus };
+        });
+
+        jest
+          .spyOn(folderUseCases, 'getFolders')
+          .mockResolvedValue(expectedSubfolders);
+
+        const result = await folderController.getFolderContentFolders(
+          userMocked,
+          folder.uuid,
+          { limit: 50, offset: 0, sort: 'id', order: SortOrder.ASC },
+        );
+
+        expect(result).toEqual({ folders: mappedSubfolders });
+        expect(folderUseCases.getFolders).toHaveBeenCalledWith(
+          userMocked.id,
+          expect.objectContaining({ parentUuid: folder.uuid }),
+          expect.objectContaining({ favoriteUserUuid: userMocked.uuid }),
+        );
+      });
+    });
+
+    describe('getFolderContentFoldersV2', () => {
+      it('When the next page of subfolders is requested, then it returns the folders with the token for the following page', async () => {
+        const expectedSubfolders = [
+          newFolder({ attributes: { id: 1, parentUuid: folder.uuid } }),
+        ];
+        const mappedSubfolders = expectedSubfolders.map((f) => ({
+          ...f,
+          status: f.getFolderStatus(),
+        }));
+        const nextCursor = 'encoded-cursor';
+        jest
+          .spyOn(folderUseCases, 'getFolderSubfoldersWithCursor')
+          .mockResolvedValue({
+            folders: expectedSubfolders,
+            nextCursor,
+          });
+
+        const query = { order: undefined };
+        const result = await folderController.getFolderContentFoldersV2(
+          userMocked,
+          folder.uuid,
+          query as any,
+        );
+
+        expect(result).toEqual({ folders: mappedSubfolders, nextCursor });
+        expect(
+          folderUseCases.getFolderSubfoldersWithCursor,
+        ).toHaveBeenCalledWith(userMocked, folder.uuid, query);
+      });
     });
   });
 

--- a/src/modules/folder/folder.controller.spec.ts
+++ b/src/modules/folder/folder.controller.spec.ts
@@ -220,10 +220,6 @@ describe('FolderController', () => {
         const expectedSubfolders = [
           newFolder({ attributes: { id: 1, parentUuid: folder.uuid } }),
         ];
-        const mappedSubfolders = expectedSubfolders.map((f) => ({
-          ...f,
-          status: f.getFolderStatus(),
-        }));
         const nextCursor = 'encoded-cursor';
         jest
           .spyOn(folderUseCases, 'getFolderSubfoldersWithCursor')
@@ -239,7 +235,7 @@ describe('FolderController', () => {
           query as any,
         );
 
-        expect(result).toEqual({ folders: mappedSubfolders, nextCursor });
+        expect(result).toEqual({ folders: expectedSubfolders, nextCursor });
         expect(
           folderUseCases.getFolderSubfoldersWithCursor,
         ).toHaveBeenCalledWith(userMocked, folder.uuid, query);

--- a/src/modules/folder/folder.controller.ts
+++ b/src/modules/folder/folder.controller.ts
@@ -297,6 +297,7 @@ export class FolderController {
   }
 
   @Get('/content/:uuid/folders')
+  @ApiOperation({ deprecated: true })
   @ApiOkResponse({ type: FoldersDto })
   async getFolderContentFolders(
     @UserDecorator() user: User,

--- a/src/modules/folder/folder.controller.ts
+++ b/src/modules/folder/folder.controller.ts
@@ -343,10 +343,7 @@ export class FolderController {
         query,
       );
 
-    return {
-      folders: folders.map((f) => ({ ...f, status: f.getFolderStatus() })),
-      nextCursor,
-    };
+    return { folders, nextCursor };
   }
 
   @Get('/content/:uuid/folders/existence')

--- a/src/modules/folder/folder.controller.ts
+++ b/src/modules/folder/folder.controller.ts
@@ -72,6 +72,8 @@ import { GetFoldersInFoldersDto } from './dto/get-folders-in-folder.dto';
 import { GetFoldersQueryDto } from './dto/get-folders.dto';
 import { GetFolderContentFilesCursorDto } from './dto/get-folder-content-files-cursor.dto';
 import { GetFolderContentFilesV2ResponseDto } from './dto/responses/get-folder-content-files-v2.dto';
+import { GetFolderContentFoldersCursorDto } from './dto/get-folder-content-folders-cursor.dto';
+import { GetFolderContentFoldersV2ResponseDto } from './dto/responses/get-folder-content-folders-v2.dto';
 
 class BadRequestWrongFolderIdException extends BadRequestException {
   constructor() {
@@ -320,6 +322,29 @@ export class FolderController {
       folders: folders.map((f) => {
         return { ...f, status: f.getFolderStatus() };
       }),
+    };
+  }
+
+  @Get('/v2/content/:uuid/folders')
+  @ApiOperation({
+    summary: 'Get folders in a folder with cursor based pagination',
+  })
+  @ApiOkResponse({ type: GetFolderContentFoldersV2ResponseDto })
+  async getFolderContentFoldersV2(
+    @UserDecorator() user: User,
+    @Param('uuid', ValidateUUIDPipe) folderUuid: string,
+    @Query() query: GetFolderContentFoldersCursorDto,
+  ): Promise<GetFolderContentFoldersV2ResponseDto> {
+    const { folders, nextCursor } =
+      await this.folderUseCases.getFolderSubfoldersWithCursor(
+        user,
+        folderUuid,
+        query,
+      );
+
+    return {
+      folders: folders.map((f) => ({ ...f, status: f.getFolderStatus() })),
+      nextCursor,
     };
   }
 

--- a/src/modules/folder/folder.repository.spec.ts
+++ b/src/modules/folder/folder.repository.spec.ts
@@ -6,7 +6,7 @@ import { Folder } from './folder.domain';
 import { type FolderAttributes } from './folder.attributes';
 import { newFolder, newUser } from '../../../test/fixtures';
 import { FileStatus } from '../file/file.domain';
-import { Op, QueryTypes } from 'sequelize';
+import { Op, QueryTypes, Sequelize } from 'sequelize';
 import { WorkspaceItemUserModel } from '../workspaces/models/workspace-items-users.model';
 import { WorkspaceItemType } from '../workspaces/attributes/workspace-items-users.attributes';
 import { UserModel } from '../user/user.model';
@@ -14,6 +14,7 @@ import { SharingModel } from '../sharing/models';
 import { v4 } from 'uuid';
 import { randomInt } from 'crypto';
 import { Time } from '../../lib/time';
+import { SortOrder } from '../../common/order.type';
 
 jest.mock('../../lib/query-timeout', () => ({
   withQueryTimeout: jest.fn((_sequelize, _timeout, cb) => cb({})),
@@ -125,7 +126,7 @@ describe('SequelizeFolderRepository', () => {
     const parentUuid = v4();
     const plainNames = ['Document', 'Image'];
 
-    it('When folders are searched with names, then it should handle the call with names', async () => {
+    it('When folders are searched with names, then it should filter by the collated plain_name', async () => {
       await repository.findByParentUuid(parentUuid, {
         plainName: plainNames,
         deleted: false,
@@ -135,14 +136,19 @@ describe('SequelizeFolderRepository', () => {
       expect(folderModel.findAll).toHaveBeenCalledWith({
         where: {
           parentUuid,
-          plainName: { [Op.in]: plainNames },
           deleted: false,
           removed: false,
+          [Op.and]: [
+            Sequelize.literal(
+              '"FolderModel"."plain_name" COLLATE "custom_numeric" IN (:plainNames)',
+            ),
+          ],
         },
+        replacements: { plainNames },
       });
     });
 
-    it('When called without specific criteria, then it should handle the call', async () => {
+    it('When called without specific criteria, then it should handle the call without a plain_name condition', async () => {
       await repository.findByParentUuid(parentUuid, {
         plainName: [],
         deleted: false,
@@ -155,6 +161,7 @@ describe('SequelizeFolderRepository', () => {
           deleted: false,
           removed: false,
         },
+        replacements: undefined,
       });
     });
   });
@@ -758,6 +765,146 @@ describe('SequelizeFolderRepository', () => {
       const result = await repository.findUserFoldersByUuid(user, folderUuids);
 
       expect(result).toEqual([]);
+    });
+  });
+
+  describe('findFolderSubfoldersWithCursor', () => {
+    const parentUuid = newFolder().uuid;
+    const userId = newUser().id;
+
+    it('When called without a cursor sorted by plainName ASC, then it filters by parent/user/status and orders with collation', async () => {
+      const subfolder = newFolder();
+
+      jest
+        .spyOn(folderModel, 'findAll')
+        .mockResolvedValueOnce([subfolder] as any);
+
+      const result = await repository.findFolderSubfoldersWithCursor({
+        parentUuid,
+        userId,
+        order: SortOrder.ASC,
+        pageSize: 1000,
+      });
+
+      expect(folderModel.findAll).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: {
+            parentUuid,
+            userId,
+            deleted: false,
+            removed: false,
+          },
+          replacements: undefined,
+          include: [],
+          subQuery: false,
+          order: [
+            Sequelize.literal(
+              '"FolderModel"."plain_name" COLLATE "custom_numeric" ASC',
+            ),
+            ['uuid', 'ASC'],
+          ],
+          limit: 1001,
+        }),
+      );
+      expect(result).toEqual({ folders: expect.any(Array), hasMore: false });
+    });
+
+    it('When sharings are not requested, then it does not include them', async () => {
+      jest.spyOn(folderModel, 'findAll').mockResolvedValueOnce([]);
+
+      await repository.findFolderSubfoldersWithCursor({
+        parentUuid,
+        userId,
+        order: SortOrder.ASC,
+        pageSize: 1000,
+      });
+
+      expect(folderModel.findAll).toHaveBeenCalledWith(
+        expect.objectContaining({ include: [] }),
+      );
+    });
+
+    it('When sharings are requested, then it includes them', async () => {
+      jest.spyOn(folderModel, 'findAll').mockResolvedValueOnce([]);
+
+      await repository.findFolderSubfoldersWithCursor({
+        parentUuid,
+        userId,
+        order: SortOrder.ASC,
+        pageSize: 1000,
+        options: { withSharings: true },
+      });
+
+      expect(folderModel.findAll).toHaveBeenCalledWith(
+        expect.objectContaining({
+          include: [
+            expect.objectContaining({
+              model: SharingModel,
+              attributes: ['type', 'id'],
+            }),
+          ],
+        }),
+      );
+    });
+
+    it('When there is one more row than the page size, then hasMore is true and the extra row is dropped', async () => {
+      const subfolders = [newFolder(), newFolder()];
+
+      jest
+        .spyOn(folderModel, 'findAll')
+        .mockResolvedValueOnce(subfolders as any);
+
+      const result = await repository.findFolderSubfoldersWithCursor({
+        parentUuid,
+        userId,
+        order: SortOrder.ASC,
+        pageSize: 1,
+      });
+
+      expect(result.hasMore).toBe(true);
+      expect(result.folders).toHaveLength(1);
+    });
+
+    it('When a plainName cursor is provided, then it filters by the collated tuple comparator', async () => {
+      const cursorUuid = v4();
+
+      jest.spyOn(folderModel, 'findAll').mockResolvedValueOnce([]);
+
+      await repository.findFolderSubfoldersWithCursor({
+        parentUuid,
+        userId,
+        order: SortOrder.ASC,
+        pageSize: 1000,
+        cursor: {
+          lastUuid: cursorUuid,
+          order: SortOrder.ASC,
+          lastValue: 'folder-b',
+        },
+      });
+
+      expect(folderModel.findAll).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: {
+            parentUuid,
+            userId,
+            deleted: false,
+            removed: false,
+            [Op.and]: [
+              Sequelize.literal(
+                '("FolderModel"."plain_name" COLLATE "custom_numeric", "FolderModel"."uuid") > (:cursorValue, :cursorUuid)',
+              ),
+            ],
+          },
+          replacements: { cursorValue: 'folder-b', cursorUuid },
+          order: [
+            Sequelize.literal(
+              '"FolderModel"."plain_name" COLLATE "custom_numeric" ASC',
+            ),
+            ['uuid', 'ASC'],
+          ],
+          limit: 1001,
+        }),
+      );
     });
   });
 

--- a/src/modules/folder/folder.repository.ts
+++ b/src/modules/folder/folder.repository.ts
@@ -197,6 +197,8 @@ export class SequelizeFolderRepository implements FolderRepository {
     private readonly folderModel: typeof FolderModel,
   ) {}
 
+  // plain_name comparisons/sorts must use COLLATE "custom_numeric" to match
+  // the folders_parentuuid_plainname_numeric_unique index and actually use it.
   private applyCollateToPlainNameSort(
     order: Array<[keyof FolderModel, string]>,
   ): Array<[keyof FolderModel, string] | Literal> {
@@ -235,6 +237,7 @@ export class SequelizeFolderRepository implements FolderRepository {
       deleted: searchBy.deleted,
     };
 
+    // COLLATE "custom_numeric" needed to hit folders_parentuuid_plainname_numeric_unique
     const plainNameCondition =
       searchBy && searchBy.plainName.length > 0
         ? [
@@ -303,6 +306,7 @@ export class SequelizeFolderRepository implements FolderRepository {
       withSharings?: boolean;
     };
   }): Promise<{ folders: Folder[]; hasMore: boolean }> {
+    // COLLATE "custom_numeric" needed to hit folders_parentuuid_plainname_numeric_unique
     const sortColumn = '"FolderModel"."plain_name" COLLATE "custom_numeric"';
     const comparator = order === SortOrder.DESC ? '<' : '>';
 
@@ -642,6 +646,7 @@ export class SequelizeFolderRepository implements FolderRepository {
       where: {
         [Op.or]: [
           { name: { [Op.eq]: name } },
+          // COLLATE "custom_numeric" needed to hit folders_parentuuid_plainname_numeric_unique
           Sequelize.literal(
             '"FolderModel"."plain_name" COLLATE "custom_numeric" = :plainName',
           ),

--- a/src/modules/folder/folder.repository.ts
+++ b/src/modules/folder/folder.repository.ts
@@ -197,8 +197,6 @@ export class SequelizeFolderRepository implements FolderRepository {
     private readonly folderModel: typeof FolderModel,
   ) {}
 
-  // plain_name comparisons/sorts must use COLLATE "custom_numeric" to match
-  // the folders_parentuuid_plainname_numeric_unique index and actually use it.
   private applyCollateToPlainNameSort(
     order: Array<[keyof FolderModel, string]>,
   ): Array<[keyof FolderModel, string] | Literal> {

--- a/src/modules/folder/folder.repository.ts
+++ b/src/modules/folder/folder.repository.ts
@@ -31,6 +31,8 @@ import {
   FavoriteItemType,
   type FavoriteAttributes,
 } from '../favorite/favorite.domain';
+import { SortOrder } from '../../common/order.type';
+import { type FolderFoldersCursorDto } from './dto/get-folder-content-folders-cursor.dto';
 
 function mapSnakeCaseToCamelCase(data) {
   const camelCasedObject = {};
@@ -176,6 +178,16 @@ interface FolderRepository {
     offset: number,
     order?: Array<[keyof FolderModel, 'ASC' | 'DESC']>,
   ): Promise<Folder[]>;
+  findFolderSubfoldersWithCursor(params: {
+    parentUuid: Folder['parentUuid'];
+    userId: User['id'];
+    order: SortOrder;
+    pageSize: number;
+    cursor?: FolderFoldersCursorDto;
+    options?: {
+      withSharings?: boolean;
+    };
+  }): Promise<{ folders: Folder[]; hasMore: boolean }>;
 }
 
 @Injectable()
@@ -223,12 +235,23 @@ export class SequelizeFolderRepository implements FolderRepository {
       deleted: searchBy.deleted,
     };
 
-    if (searchBy && searchBy.plainName.length > 0) {
-      where.plainName = { [Op.in]: searchBy.plainName };
-    }
+    const plainNameCondition =
+      searchBy && searchBy.plainName.length > 0
+        ? [
+            Sequelize.literal(
+              '"FolderModel"."plain_name" COLLATE "custom_numeric" IN (:plainNames)',
+            ),
+          ]
+        : [];
 
     const folders = await this.folderModel.findAll({
-      where,
+      where: {
+        ...where,
+        ...(plainNameCondition.length && { [Op.and]: plainNameCondition }),
+      },
+      replacements: plainNameCondition.length
+        ? { plainNames: searchBy.plainName }
+        : undefined,
     });
 
     return folders.map(this.toDomain.bind(this));
@@ -261,6 +284,78 @@ export class SequelizeFolderRepository implements FolderRepository {
     });
 
     return folders.map(this.toDomain.bind(this));
+  }
+
+  async findFolderSubfoldersWithCursor({
+    parentUuid,
+    userId,
+    order,
+    pageSize,
+    cursor,
+    options,
+  }: {
+    parentUuid: Folder['parentUuid'];
+    userId: User['id'];
+    order: SortOrder;
+    pageSize: number;
+    cursor?: FolderFoldersCursorDto;
+    options?: {
+      withSharings?: boolean;
+    };
+  }): Promise<{ folders: Folder[]; hasMore: boolean }> {
+    const sortColumn = '"FolderModel"."plain_name" COLLATE "custom_numeric"';
+    const comparator = order === SortOrder.DESC ? '<' : '>';
+
+    const whereCondition: WhereOptions<FolderAttributes> = {
+      parentUuid,
+      userId,
+      deleted: false,
+      removed: false,
+      ...(cursor
+        ? {
+            [Op.and]: [
+              Sequelize.literal(
+                `(${sortColumn}, "FolderModel"."uuid") ${comparator} (:cursorValue, :cursorUuid)`,
+              ),
+            ],
+          }
+        : null),
+    };
+
+    const rows = await this.folderModel.findAll({
+      where: whereCondition,
+      replacements: cursor
+        ? {
+            cursorValue: cursor.lastValue,
+            cursorUuid: cursor.lastUuid,
+          }
+        : undefined,
+      include: [
+        ...(options?.withSharings
+          ? [
+              {
+                separate: true,
+                model: SharingModel,
+                attributes: ['type', 'id'],
+                required: false,
+              },
+            ]
+          : []),
+      ],
+      subQuery: false,
+      order: [
+        Sequelize.literal(
+          `"FolderModel"."plain_name" COLLATE "custom_numeric" ${order}`,
+        ),
+        ['uuid', order],
+      ],
+      limit: pageSize + 1,
+    });
+
+    const hasMore = rows.length > pageSize;
+    const page = hasMore ? rows.slice(0, pageSize) : rows;
+
+    return { folders: page.map(this.toDomain.bind(this)), hasMore };
   }
 
   async findTrashedNotExpired(
@@ -547,11 +642,14 @@ export class SequelizeFolderRepository implements FolderRepository {
       where: {
         [Op.or]: [
           { name: { [Op.eq]: name } },
-          { plainName: { [Op.eq]: plainName } },
+          Sequelize.literal(
+            '"FolderModel"."plain_name" COLLATE "custom_numeric" = :plainName',
+          ),
         ],
         parentUuid: { [Op.eq]: parentUuid },
         deleted: { [Op.eq]: deleted },
       },
+      replacements: { plainName },
     });
     return folder ? this.toDomain(folder) : null;
   }

--- a/src/modules/folder/folder.repository.ts
+++ b/src/modules/folder/folder.repository.ts
@@ -307,6 +307,7 @@ export class SequelizeFolderRepository implements FolderRepository {
     // COLLATE "custom_numeric" needed to hit folders_parentuuid_plainname_numeric_unique
     const sortColumn = '"FolderModel"."plain_name" COLLATE "custom_numeric"';
     const comparator = order === SortOrder.DESC ? '<' : '>';
+    const orderDirection = order === SortOrder.DESC ? 'DESC' : 'ASC';
 
     const whereCondition: WhereOptions<FolderAttributes> = {
       parentUuid,
@@ -347,9 +348,9 @@ export class SequelizeFolderRepository implements FolderRepository {
       subQuery: false,
       order: [
         Sequelize.literal(
-          `"FolderModel"."plain_name" COLLATE "custom_numeric" ${order}`,
+          `"FolderModel"."plain_name" COLLATE "custom_numeric" ${orderDirection}`,
         ),
-        ['uuid', order],
+        ['uuid', orderDirection],
       ],
       limit: pageSize + 1,
     });

--- a/src/modules/folder/folder.usecase.spec.ts
+++ b/src/modules/folder/folder.usecase.spec.ts
@@ -31,6 +31,9 @@ import { FileStatus } from '../file/file.domain';
 import { SequelizeFileRepository } from '../file/file.repository';
 import { FavoriteUseCases } from '../favorite/favorite.usecase';
 import { FavoriteItemType } from '../favorite/favorite.domain';
+import { SequelizeFavoriteRepository } from '../favorite/favorite.repository';
+import { type GetFolderContentFoldersCursorDto } from './dto/get-folder-content-folders-cursor.dto';
+import { SortOrder } from '../../common/order.type';
 
 const folderId = 4;
 const user = newUser();
@@ -42,6 +45,7 @@ describe('FolderUseCases', () => {
   let sharingService: SharingService;
   let fileRepository: SequelizeFileRepository;
   let favoriteUseCases: FavoriteUseCases;
+  let favoriteRepository: SequelizeFavoriteRepository;
 
   const userMocked = User.build({
     id: 1,
@@ -91,6 +95,9 @@ describe('FolderUseCases', () => {
       SequelizeFileRepository,
     );
     favoriteUseCases = module.get<FavoriteUseCases>(FavoriteUseCases);
+    favoriteRepository = module.get<SequelizeFavoriteRepository>(
+      SequelizeFavoriteRepository,
+    );
   });
 
   it('should be defined', () => {
@@ -182,10 +189,9 @@ describe('FolderUseCases', () => {
         [mockBackupFolder.uuid, mockFolder.uuid],
         FavoriteItemType.Folder,
       );
-      expect(favoriteUseCases.removeFavoritesInsideFolders).toHaveBeenCalledWith(
-        user,
-        [mockBackupFolder.uuid, mockFolder.uuid],
-      );
+      expect(
+        favoriteUseCases.removeFavoritesInsideFolders,
+      ).toHaveBeenCalledWith(user, [mockBackupFolder.uuid, mockFolder.uuid]);
     });
 
     it('When only ids are passed, then only folders by id should be searched', async () => {
@@ -310,6 +316,200 @@ describe('FolderUseCases', () => {
         undefined,
         user.uuid,
       );
+    });
+  });
+
+  describe('getFolderSubfoldersWithCursor', () => {
+    const userForFolder = newUser();
+    const folderUuid = newFolder().uuid;
+    const mockFolders = [newFolder(), newFolder()];
+
+    const buildQuery = (
+      overrides: Partial<GetFolderContentFoldersCursorDto> = {},
+    ): GetFolderContentFoldersCursorDto => ({
+      order: SortOrder.ASC,
+      limit: 100,
+      ...overrides,
+    });
+
+    it('When a page size and sort direction are given, then it should use them', async () => {
+      jest
+        .spyOn(folderRepository, 'findFolderSubfoldersWithCursor')
+        .mockResolvedValueOnce({ folders: mockFolders, hasMore: false });
+
+      await service.getFolderSubfoldersWithCursor(
+        userForFolder,
+        folderUuid,
+        buildQuery({ order: SortOrder.DESC, limit: 200 }),
+      );
+
+      expect(
+        folderRepository.findFolderSubfoldersWithCursor,
+      ).toHaveBeenCalledWith({
+        parentUuid: folderUuid,
+        userId: userForFolder.id,
+        order: SortOrder.DESC,
+        pageSize: 200,
+        cursor: undefined,
+        options: { withSharings: undefined },
+      });
+    });
+
+    it('When sharing info is requested, then folders should be fetched with it', async () => {
+      jest
+        .spyOn(folderRepository, 'findFolderSubfoldersWithCursor')
+        .mockResolvedValueOnce({ folders: mockFolders, hasMore: false });
+
+      await service.getFolderSubfoldersWithCursor(
+        userForFolder,
+        folderUuid,
+        buildQuery({ withSharings: true }),
+      );
+
+      expect(
+        folderRepository.findFolderSubfoldersWithCursor,
+      ).toHaveBeenCalledWith(
+        expect.objectContaining({ options: { withSharings: true } }),
+      );
+    });
+
+    it('When folders are searched including favorites, then the favorited ones should be marked as such', async () => {
+      jest
+        .spyOn(folderRepository, 'findFolderSubfoldersWithCursor')
+        .mockResolvedValueOnce({ folders: mockFolders, hasMore: false });
+      jest
+        .spyOn(favoriteRepository, 'findFavoritedItemIds')
+        .mockResolvedValueOnce(new Set([mockFolders[0].uuid]));
+
+      const result = await service.getFolderSubfoldersWithCursor(
+        userForFolder,
+        folderUuid,
+        buildQuery({ withFavorites: true }),
+      );
+
+      expect(favoriteRepository.findFavoritedItemIds).toHaveBeenCalledWith(
+        userForFolder.uuid,
+        mockFolders.map((folder) => folder.uuid),
+        FavoriteItemType.Folder,
+      );
+      expect(result.folders[0].isFavorite).toBe(true);
+      expect(result.folders[1].isFavorite).toBe(false);
+    });
+
+    it('When favorites are not requested, then it should not check which folders are favorited', async () => {
+      jest
+        .spyOn(folderRepository, 'findFolderSubfoldersWithCursor')
+        .mockResolvedValueOnce({ folders: mockFolders, hasMore: false });
+      jest.spyOn(favoriteRepository, 'findFavoritedItemIds');
+
+      await service.getFolderSubfoldersWithCursor(
+        userForFolder,
+        folderUuid,
+        buildQuery(),
+      );
+
+      expect(favoriteRepository.findFavoritedItemIds).not.toHaveBeenCalled();
+    });
+
+    it('When continuing from a previous page with the same sort direction, then it should fetch the next folders from there', async () => {
+      const cursorData = {
+        lastUuid: v4(),
+        order: SortOrder.ASC,
+        lastValue: 'folder-a',
+      };
+      const cursorToken = Buffer.from(JSON.stringify(cursorData)).toString(
+        'base64',
+      );
+
+      jest
+        .spyOn(folderRepository, 'findFolderSubfoldersWithCursor')
+        .mockResolvedValueOnce({ folders: mockFolders, hasMore: false });
+
+      await service.getFolderSubfoldersWithCursor(
+        userForFolder,
+        folderUuid,
+        buildQuery({ cursor: cursorToken }),
+      );
+
+      expect(
+        folderRepository.findFolderSubfoldersWithCursor,
+      ).toHaveBeenCalledWith(expect.objectContaining({ cursor: cursorData }));
+    });
+
+    it('When the page token is invalid, then it should throw', async () => {
+      jest.spyOn(folderRepository, 'findFolderSubfoldersWithCursor');
+
+      await expect(
+        service.getFolderSubfoldersWithCursor(
+          userForFolder,
+          folderUuid,
+          buildQuery({ cursor: 'not-a-valid-cursor' }),
+        ),
+      ).rejects.toThrow(BadRequestException);
+      expect(
+        folderRepository.findFolderSubfoldersWithCursor,
+      ).not.toHaveBeenCalled();
+    });
+
+    it('When the page token was requested with a different sort direction, then it should throw', async () => {
+      const cursorData = {
+        lastUuid: v4(),
+        order: SortOrder.ASC,
+        lastValue: 'folder-a',
+      };
+      const cursorToken = Buffer.from(JSON.stringify(cursorData)).toString(
+        'base64',
+      );
+
+      jest.spyOn(folderRepository, 'findFolderSubfoldersWithCursor');
+
+      await expect(
+        service.getFolderSubfoldersWithCursor(
+          userForFolder,
+          folderUuid,
+          buildQuery({ cursor: cursorToken, order: SortOrder.DESC }),
+        ),
+      ).rejects.toThrow(BadRequestException);
+      expect(
+        folderRepository.findFolderSubfoldersWithCursor,
+      ).not.toHaveBeenCalled();
+    });
+
+    it('When there are more folders left, then it should return a token to fetch the next page', async () => {
+      const lastFolder = mockFolders[mockFolders.length - 1];
+      jest
+        .spyOn(folderRepository, 'findFolderSubfoldersWithCursor')
+        .mockResolvedValueOnce({ folders: mockFolders, hasMore: true });
+
+      const result = await service.getFolderSubfoldersWithCursor(
+        userForFolder,
+        folderUuid,
+        buildQuery(),
+      );
+
+      expect(result.nextCursor).not.toBeNull();
+      const decoded = JSON.parse(
+        Buffer.from(result.nextCursor, 'base64').toString('utf-8'),
+      );
+      expect(decoded).toEqual({
+        lastUuid: lastFolder.uuid,
+        order: SortOrder.ASC,
+        lastValue: lastFolder.plainName,
+      });
+    });
+
+    it('When there are no more folders left, then there should be no next page token', async () => {
+      jest
+        .spyOn(folderRepository, 'findFolderSubfoldersWithCursor')
+        .mockResolvedValueOnce({ folders: mockFolders, hasMore: false });
+
+      const result = await service.getFolderSubfoldersWithCursor(
+        userForFolder,
+        folderUuid,
+        buildQuery(),
+      );
+
+      expect(result.nextCursor).toBeNull();
     });
   });
 

--- a/src/modules/folder/folder.usecase.ts
+++ b/src/modules/folder/folder.usecase.ts
@@ -36,6 +36,12 @@ import { type MoveFolderDto } from './dto/move-folder.dto';
 import { SequelizeFileRepository } from '../file/file.repository';
 import { FavoriteUseCases } from '../favorite/favorite.usecase';
 import { FavoriteItemType } from '../favorite/favorite.domain';
+import { SequelizeFavoriteRepository } from '../favorite/favorite.repository';
+import { decodeCursor, encodeCursor } from '../../common/utils/cursor.util';
+import {
+  type GetFolderContentFoldersCursorDto,
+  FolderFoldersCursorDto,
+} from './dto/get-folder-content-folders-cursor.dto';
 
 const invalidName = /[\\/]|^\s*$/;
 
@@ -53,6 +59,7 @@ export class FolderUseCases {
     private readonly fileRepository: SequelizeFileRepository,
     private readonly cryptoService: CryptoService,
     private readonly favoriteUsecases: FavoriteUseCases,
+    private readonly favoriteRepository: SequelizeFavoriteRepository,
   ) {}
 
   getFoldersByIds(user: User, folderIds: FolderAttributes['id'][]) {
@@ -738,6 +745,71 @@ export class FolderUseCases {
     return foldersWithMaybePlainName.map((folder) =>
       folder.plainName ? folder : this.decryptFolderName(folder),
     );
+  }
+
+  async getFolderSubfoldersWithCursor(
+    user: User,
+    folderUuid: Folder['uuid'],
+    query: GetFolderContentFoldersCursorDto,
+  ): Promise<{ folders: Folder[]; nextCursor: string | null }> {
+    const { order, limit: pageSize } = query;
+
+    const cursor = query.cursor
+      ? decodeCursor(FolderFoldersCursorDto, query.cursor)
+      : undefined;
+
+    if (query.cursor && !cursor) {
+      throw new BadRequestException('Invalid cursor');
+    }
+
+    if (cursor && cursor.order !== order) {
+      throw new BadRequestException('Cursor does not match order filter');
+    }
+
+    const { folders, hasMore } =
+      await this.folderRepository.findFolderSubfoldersWithCursor({
+        parentUuid: folderUuid,
+        userId: user.id,
+        order,
+        pageSize,
+        cursor,
+        options: {
+          withSharings: query.withSharings,
+        },
+      });
+
+    const lastFolder = folders.at(-1);
+    const nextCursor =
+      hasMore && lastFolder
+        ? encodeCursor({
+            lastUuid: lastFolder.uuid,
+            order,
+            lastValue: lastFolder.plainName,
+          })
+        : null;
+
+    let foldersWithFavoriteMark = folders;
+    if (query.withFavorites) {
+      const favoritedUuids = await this.favoriteRepository.findFavoritedItemIds(
+        user.uuid,
+        folders.map((folder) => folder.uuid),
+        FavoriteItemType.Folder,
+      );
+      foldersWithFavoriteMark = folders.map(
+        (folder) =>
+          ({
+            ...folder,
+            isFavorite: favoritedUuids.has(folder.uuid),
+          }) as Folder,
+      );
+    }
+
+    return {
+      folders: foldersWithFavoriteMark.map((folder) =>
+        folder.plainName ? folder : this.decryptFolderName(folder),
+      ),
+      nextCursor,
+    };
   }
 
   async getTrashedFolders(


### PR DESCRIPTION
Adds cursor pagination ordering by plain_name for folders in a folder.

⚠️ requires migration 

## Changes

* Added new EP to use keyset pagination for folders in a folder (mirrors the existing files-in-folder cursor pagination EP).
* Sharings and favorites are now only included on-demand. There are clients that do not need this extra data, so it does not make sense that we're making extra joins in the current EP when clients such as rclone, cli and windows do not care about sharings or favorites.
* Added index to support COLLATE custom_numeric queries, same as files.
* Added COLLATE to any query that searches by plain_name to use the index properly

## Benchmark

Using a folder with ~510K existing subfolders (on local so times are not as accurate as the files PR benchmark)

Offset 5000, limit 1000.

```sql
Limit (cost=109808.79..109925.26 rows=1000 width=1226) (actual time=338.793..345.600 rows=1000.00 loops=1)
Buffers: shared hit=5892 read=17325
-> Gather Merge (cost=109226.46..128172.18 rows=162671 width=1226) (actual time=314.769..324.616 rows=6000.00 loops=1)
Workers Planned: 2
Workers Launched: 2
Buffers: shared hit=5892 read=17325
-> Sort (cost=108226.44..108395.89 rows=67780 width=1226) (actual time=248.498..248.635 rows=2230.00 loops=3)
Sort Key: plain_name COLLATE custom_numeric
Sort Method: top-N heapsort Memory: 1890kB
Buffers: shared hit=5892 read=17325
-> Parallel Seq Scan on folders (cost=0.00..30036.58 rows=67780 width=1226) (actual time=18.652..126.712 rows=80787.67 loops=3)
Filter: ((NOT removed) AND (NOT deleted) AND (user_id = 1) AND (parent_uuid = '48204e02-0420-4a47-9a2a-6ab7df4793dd'::uuid))
Rows Removed by Filter: 289216
Buffers: shared hit=5774 read=17325
Planning Time: 0.942 ms
Execution Time: 347.557 ms
```


Cursor pagination (equivalent to offset 5000)

```sql
Limit (cost=1.21..816.32 rows=1000 width=1226) (actual time=0.673..2.873 rows=1000.00 loops=1)
Output: id, parent_id, name, bucket, user_id, created_at, updated_at, encrypt_version, deleted, deleted_at, plain_name, uuid, parent_uuid, removed, removed_at, creation_time, modification_time, ((plain_name)::character varying(650))
Buffers: shared hit=34
-> Incremental Sort (cost=1.21..108965.89 rows=133680 width=1226) (actual time=0.672..2.758 rows=1000.00 loops=1)
Sort Key: folders.plain_name COLLATE custom_numeric, folders.uuid
Presorted Key: folders.plain_name
Full-sort Groups: 32 Sort Method: quicksort Average Memory: 33kB Peak Memory: 33kB
Buffers: shared hit=34
-> Index Scan using folders_parentuuid_plainname_numeric_unique on public.folders (cost=0.42..102950.29 rows=133680 width=1226) (actual time=0.276..1.591 rows=1001.00 loops=1)
Index Cond: ((folders.parent_uuid = '48204e02-0420-4a47-9a2a-6ab7df4793dd'::uuid) AND ((folders.plain_name)::text >= 'load_test_folder_7fa72940_6435'::text COLLATE custom_numeric))
Filter: ((folders.user_id = 1) AND (ROW((folders.plain_name)::text, folders.uuid) > ROW('load_test_folder_7fa72940_6435'::text COLLATE custom_numeric, '4ecf1c68-fd0b-4b55-a6bc-60565580495c'::uuid)))
Rows Removed by Filter: 1
Index Searches: 1
Buffers: shared hit=34
Planning Time: 4.862 ms
Execution Time: 3.165 ms
```
