### PR TITLE
[_] feat(cursor-pagination): add folder cursor pagination for sync

### DIFF
--- a/src/common/dto/get-sync.dto.ts
+++ b/src/common/dto/get-sync.dto.ts
@@ -1,0 +1,46 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import {
+  IsInt,
+  IsISO8601,
+  IsOptional,
+  IsString,
+  Max,
+  MaxLength,
+  Min,
+  ValidateIf,
+} from 'class-validator';
+
+export abstract class GetSyncDto {
+  @ApiProperty({
+    description:
+      'Filter items updated after this date. Required if cursor is not provided',
+    required: false,
+  })
+  @ValidateIf((dto) => !dto.cursor)
+  @IsISO8601(
+    { strict: true },
+    { message: 'updatedAt must be a valid ISO8601 date' },
+  )
+  updatedAt?: string;
+
+  @ApiProperty({
+    description: 'Cursor token to fetch the next page of results',
+    required: false,
+  })
+  @IsOptional()
+  @IsString()
+  @MaxLength(256)
+  cursor?: string;
+
+  @ApiProperty({
+    description: 'Page size, max 1000',
+    required: false,
+  })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(1000)
+  limit?: number;
+}

--- a/src/modules/file/dto/get-files-sync.dto.ts
+++ b/src/modules/file/dto/get-files-sync.dto.ts
@@ -1,19 +1,9 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { Type } from 'class-transformer';
-import {
-  IsEnum,
-  IsISO8601,
-  IsInt,
-  IsOptional,
-  IsString,
-  Max,
-  MaxLength,
-  Min,
-  ValidateIf,
-} from 'class-validator';
+import { IsEnum, IsOptional } from 'class-validator';
 import { FileStatus } from '../file.domain';
+import { GetSyncDto } from '../../../common/dto/get-sync.dto';
 
-export class GetFilesSyncDto {
+export class GetFilesSyncDto extends GetSyncDto {
   @ApiProperty({
     description: 'File status filter',
     enum: FileStatus,
@@ -22,36 +12,4 @@ export class GetFilesSyncDto {
   @IsOptional()
   @IsEnum(FileStatus)
   status?: FileStatus;
-
-  @ApiProperty({
-    description:
-      'Filter files updated after this date. Required if cursor is not provided',
-    required: false,
-  })
-  @ValidateIf((dto) => !dto.cursor)
-  @IsISO8601(
-    { strict: true },
-    { message: 'updatedAt must be a valid ISO8601 date' },
-  )
-  updatedAt?: string;
-
-  @ApiProperty({
-    description: 'Cursor token to fetch the next page of results',
-    required: false,
-  })
-  @IsOptional()
-  @IsString()
-  @MaxLength(256)
-  cursor?: string;
-
-  @ApiProperty({
-    description: 'Page size, max 1000',
-    required: false,
-  })
-  @IsOptional()
-  @Type(() => Number)
-  @IsInt()
-  @Min(1)
-  @Max(1000)
-  limit?: number;
 }

--- a/src/modules/folder/dto/get-folders-sync.dto.ts
+++ b/src/modules/folder/dto/get-folders-sync.dto.ts
@@ -1,0 +1,57 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import {
+  IsEnum,
+  IsISO8601,
+  IsInt,
+  IsOptional,
+  IsString,
+  Max,
+  MaxLength,
+  Min,
+  ValidateIf,
+} from 'class-validator';
+import { FolderStatus } from '../folder.domain';
+
+export class GetFoldersSyncDto {
+  @ApiProperty({
+    description: 'Folder status filter',
+    enum: FolderStatus,
+    required: false,
+  })
+  @IsOptional()
+  @IsEnum(FolderStatus)
+  status?: FolderStatus;
+
+  @ApiProperty({
+    description:
+      'Filter folders updated after this date. Required if cursor is not provided',
+    required: false,
+  })
+  @ValidateIf((dto) => !dto.cursor)
+  @IsISO8601(
+    { strict: true },
+    { message: 'updatedAt must be a valid ISO8601 date' },
+  )
+  updatedAt?: string;
+
+  @ApiProperty({
+    description: 'Cursor token to fetch the next page of results',
+    required: false,
+  })
+  @IsOptional()
+  @IsString()
+  @MaxLength(256)
+  cursor?: string;
+
+  @ApiProperty({
+    description: 'Page size, max 1000',
+    required: false,
+  })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(1000)
+  limit?: number;
+}

--- a/src/modules/folder/dto/get-folders-sync.dto.ts
+++ b/src/modules/folder/dto/get-folders-sync.dto.ts
@@ -1,19 +1,9 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { Type } from 'class-transformer';
-import {
-  IsEnum,
-  IsISO8601,
-  IsInt,
-  IsOptional,
-  IsString,
-  Max,
-  MaxLength,
-  Min,
-  ValidateIf,
-} from 'class-validator';
+import { IsEnum, IsOptional } from 'class-validator';
 import { FolderStatus } from '../folder.domain';
+import { GetSyncDto } from '../../../common/dto/get-sync.dto';
 
-export class GetFoldersSyncDto {
+export class GetFoldersSyncDto extends GetSyncDto {
   @ApiProperty({
     description: 'Folder status filter',
     enum: FolderStatus,
@@ -22,36 +12,4 @@ export class GetFoldersSyncDto {
   @IsOptional()
   @IsEnum(FolderStatus)
   status?: FolderStatus;
-
-  @ApiProperty({
-    description:
-      'Filter folders updated after this date. Required if cursor is not provided',
-    required: false,
-  })
-  @ValidateIf((dto) => !dto.cursor)
-  @IsISO8601(
-    { strict: true },
-    { message: 'updatedAt must be a valid ISO8601 date' },
-  )
-  updatedAt?: string;
-
-  @ApiProperty({
-    description: 'Cursor token to fetch the next page of results',
-    required: false,
-  })
-  @IsOptional()
-  @IsString()
-  @MaxLength(256)
-  cursor?: string;
-
-  @ApiProperty({
-    description: 'Page size, max 1000',
-    required: false,
-  })
-  @IsOptional()
-  @Type(() => Number)
-  @IsInt()
-  @Min(1)
-  @Max(1000)
-  limit?: number;
 }

--- a/src/modules/folder/dto/responses/get-folders-sync.dto.ts
+++ b/src/modules/folder/dto/responses/get-folders-sync.dto.ts
@@ -1,0 +1,12 @@
+import { ApiProperty, OmitType } from '@nestjs/swagger';
+import { FolderDto } from './folder.dto';
+
+export class FolderSyncDto extends OmitType(FolderDto, ['isFavorite']) {}
+
+export class GetFoldersSyncResponseDto {
+  @ApiProperty({ type: FolderSyncDto, isArray: true })
+  folders: FolderSyncDto[];
+
+  @ApiProperty({ type: String, nullable: true })
+  nextCursor: string | null;
+}

--- a/src/modules/folder/folder.controller.spec.ts
+++ b/src/modules/folder/folder.controller.spec.ts
@@ -1037,6 +1037,172 @@ describe('FolderController', () => {
     });
   });
 
+  describe('getFoldersSync', () => {
+    const buildQuery = (overrides = {}) => ({
+      status: FolderStatus.EXISTS,
+      updatedAt: new Date('2024-01-01T00:00:00.000Z').toISOString(),
+      cursor: undefined,
+      limit: undefined,
+      ...overrides,
+    });
+
+    it('When called, then it should call the usecase with parsed params', async () => {
+      const query = buildQuery();
+      jest
+        .spyOn(folderUseCases, 'getFoldersUpdatedAfterWithCursor')
+        .mockResolvedValueOnce({
+          folders: [],
+          hasMore: false,
+          nextCursor: null,
+        });
+
+      await folderController.getFoldersSync(userMocked, query as any);
+
+      expect(
+        folderUseCases.getFoldersUpdatedAfterWithCursor,
+      ).toHaveBeenCalledWith(
+        userMocked.id,
+        query.status,
+        new Date(query.updatedAt),
+        1000,
+        undefined,
+      );
+    });
+
+    it('When updatedAt is not provided, then it should default to the epoch', async () => {
+      const query = buildQuery({ updatedAt: undefined, cursor: 'abc' });
+      jest
+        .spyOn(folderUseCases, 'getFoldersUpdatedAfterWithCursor')
+        .mockResolvedValueOnce({
+          folders: [],
+          hasMore: false,
+          nextCursor: null,
+        });
+
+      await folderController.getFoldersSync(userMocked, query as any);
+
+      expect(
+        folderUseCases.getFoldersUpdatedAfterWithCursor,
+      ).toHaveBeenCalledWith(
+        userMocked.id,
+        query.status,
+        new Date(1),
+        1000,
+        'abc',
+      );
+    });
+
+    it('When a limit is provided, then it should forward it instead of the default', async () => {
+      const query = buildQuery({ limit: 50 });
+      jest
+        .spyOn(folderUseCases, 'getFoldersUpdatedAfterWithCursor')
+        .mockResolvedValueOnce({
+          folders: [],
+          hasMore: false,
+          nextCursor: null,
+        });
+
+      await folderController.getFoldersSync(userMocked, query as any);
+
+      expect(
+        folderUseCases.getFoldersUpdatedAfterWithCursor,
+      ).toHaveBeenCalledWith(
+        userMocked.id,
+        query.status,
+        expect.any(Date),
+        50,
+        undefined,
+      );
+    });
+
+    it('When folders are returned, then it should strip deletedAt/removedAt fields', async () => {
+      const rawFolder = {
+        ...newFolder(),
+        plainName: 'already-set',
+        deleted: true,
+        deletedAt: new Date(),
+        removed: true,
+        removedAt: new Date(),
+      };
+      jest
+        .spyOn(folderUseCases, 'getFoldersUpdatedAfterWithCursor')
+        .mockResolvedValueOnce({
+          folders: [rawFolder as any],
+          hasMore: false,
+          nextCursor: null,
+        });
+
+      const result = await folderController.getFoldersSync(
+        userMocked,
+        buildQuery() as any,
+      );
+
+      expect(result.folders[0]).not.toHaveProperty('deletedAt');
+      expect(result.folders[0]).not.toHaveProperty('removedAt');
+      expect(result.folders[0]).toHaveProperty('deleted');
+      expect(result.folders[0]).toHaveProperty('removed');
+    });
+
+    it('When a folder has no plainName, then it should decrypt it via decryptFolderName', async () => {
+      const rawFolder = { ...newFolder(), plainName: undefined };
+      jest
+        .spyOn(folderUseCases, 'getFoldersUpdatedAfterWithCursor')
+        .mockResolvedValueOnce({
+          folders: [rawFolder as any],
+          hasMore: false,
+          nextCursor: null,
+        });
+      jest
+        .spyOn(folderUseCases, 'decryptFolderName')
+        .mockReturnValue({ plainName: 'decrypted-name' } as any);
+
+      const result = await folderController.getFoldersSync(
+        userMocked,
+        buildQuery() as any,
+      );
+
+      expect(folderUseCases.decryptFolderName).toHaveBeenCalledWith(rawFolder);
+      expect(result.folders[0].plainName).toBe('decrypted-name');
+    });
+
+    it('When a folder already has a plainName, then it should not call decryptFolderName', async () => {
+      const rawFolder = { ...newFolder(), plainName: 'already-set' };
+      jest
+        .spyOn(folderUseCases, 'getFoldersUpdatedAfterWithCursor')
+        .mockResolvedValueOnce({
+          folders: [rawFolder as any],
+          hasMore: false,
+          nextCursor: null,
+        });
+      jest.spyOn(folderUseCases, 'decryptFolderName');
+
+      const result = await folderController.getFoldersSync(
+        userMocked,
+        buildQuery() as any,
+      );
+
+      expect(folderUseCases.decryptFolderName).not.toHaveBeenCalled();
+      expect(result.folders[0].plainName).toBe('already-set');
+    });
+
+    it('When the usecase returns a nextCursor, then it should be returned as-is', async () => {
+      jest
+        .spyOn(folderUseCases, 'getFoldersUpdatedAfterWithCursor')
+        .mockResolvedValueOnce({
+          folders: [],
+          hasMore: true,
+          nextCursor: 'encoded-cursor-token',
+        });
+
+      const result = await folderController.getFoldersSync(
+        userMocked,
+        buildQuery() as any,
+      );
+
+      expect(result.nextCursor).toBe('encoded-cursor-token');
+    });
+  });
+
   describe('getFolder', () => {
     const folderUuid = v4();
 

--- a/src/modules/folder/folder.controller.ts
+++ b/src/modules/folder/folder.controller.ts
@@ -50,6 +50,8 @@ import { Client } from '../../common/decorators/client.decorator';
 import { BasicPaginationDto } from '../../common/dto/basic-pagination.dto';
 import { Workspace } from '../workspaces/domains/workspaces.domain';
 import { CheckFoldersExistenceOldDto } from './dto/folder-existence-in-folder-old.dto';
+import { GetFoldersSyncDto } from './dto/get-folders-sync.dto';
+import { GetFoldersSyncResponseDto } from './dto/responses/get-folders-sync.dto';
 import { Requester } from '../auth/decorators/requester.decorator';
 import {
   type CreateBulkFoldersResponseDto,
@@ -582,6 +584,38 @@ export class FolderController {
 
       throw err;
     }
+  }
+
+  @Get('/sync')
+  @ApiOperation({
+    summary: 'Get delta of folders since a date',
+  })
+  @ApiOkResponse({ type: GetFoldersSyncResponseDto })
+  async getFoldersSync(
+    @UserDecorator() user: User,
+    @Query() queryParams: GetFoldersSyncDto,
+  ): Promise<GetFoldersSyncResponseDto> {
+    const { status, updatedAt, cursor, limit } = queryParams;
+
+    const { folders, nextCursor } =
+      await this.folderUseCases.getFoldersUpdatedAfterWithCursor(
+        user.id,
+        status,
+        new Date(updatedAt || 1),
+        limit ?? 1000,
+        cursor,
+      );
+
+    folders.forEach((f) => {
+      delete f.deletedAt;
+      delete f.removedAt;
+
+      if (!f.plainName) {
+        f.plainName = this.folderUseCases.decryptFolderName(f).plainName;
+      }
+    });
+
+    return { folders, nextCursor };
   }
 
   @Get('/:uuid/meta')

--- a/src/modules/folder/folder.repository.spec.ts
+++ b/src/modules/folder/folder.repository.spec.ts
@@ -6,7 +6,7 @@ import { Folder } from './folder.domain';
 import { type FolderAttributes } from './folder.attributes';
 import { newFolder, newUser } from '../../../test/fixtures';
 import { FileStatus } from '../file/file.domain';
-import { Op, QueryTypes } from 'sequelize';
+import { Op, QueryTypes, Sequelize } from 'sequelize';
 import { WorkspaceItemUserModel } from '../workspaces/models/workspace-items-users.model';
 import { WorkspaceItemType } from '../workspaces/attributes/workspace-items-users.attributes';
 import { UserModel } from '../user/user.model';
@@ -1615,6 +1615,95 @@ describe('SequelizeFolderRepository', () => {
           transaction: expect.any(Object),
         }),
       );
+    });
+  });
+
+  describe('findFoldersWithCursorWhereUpdatedAfter', () => {
+    const user = newUser();
+
+    it('When called without a cursor, then it should filter by updatedAfter and mark hasMore false when rows fit the page', async () => {
+      const where = { userId: user.id };
+      const updatedAfter = new Date();
+      const folder = newFolder();
+
+      jest.spyOn(folderModel, 'findAll').mockResolvedValueOnce([folder] as any);
+
+      const result = await repository.findFoldersWithCursorWhereUpdatedAfter({
+        where,
+        updatedAfter,
+        pageSize: 1000,
+      });
+
+      expect(folderModel.findAll).toHaveBeenCalledWith({
+        where: {
+          ...where,
+          parentUuid: { [Op.not]: null },
+          updatedAt: { [Op.gt]: updatedAfter },
+        },
+        replacements: undefined,
+        order: [
+          ['updatedAt', 'ASC'],
+          ['uuid', 'ASC'],
+        ],
+        limit: 1001,
+      });
+      expect(result).toEqual({ folders: expect.any(Array), hasMore: false });
+      expect(result.folders).toHaveLength(1);
+    });
+
+    it('When there is one more row than the page size, then hasMore is true and the extra row is dropped', async () => {
+      const where = { userId: user.id };
+      const updatedAfter = new Date();
+      const folders = [newFolder(), newFolder()];
+
+      jest.spyOn(folderModel, 'findAll').mockResolvedValueOnce(folders as any);
+
+      const result = await repository.findFoldersWithCursorWhereUpdatedAfter({
+        where,
+        updatedAfter,
+        pageSize: 1,
+      });
+
+      expect(result.hasMore).toBe(true);
+      expect(result.folders).toHaveLength(1);
+    });
+
+    it('When a cursor is provided, then it filters by the cursor tuple and ignores updatedAfter', async () => {
+      const where = { userId: user.id };
+      const updatedAfter = new Date();
+      const cursorUpdatedAt = new Date('2024-01-01T00:00:00.000Z');
+      const cursorId = v4();
+
+      jest.spyOn(folderModel, 'findAll').mockResolvedValueOnce([]);
+
+      await repository.findFoldersWithCursorWhereUpdatedAfter({
+        where,
+        updatedAfter,
+        pageSize: 1000,
+        cursor: {
+          updatedAt: cursorUpdatedAt.toISOString(),
+          uuid: cursorId,
+        },
+      });
+
+      expect(folderModel.findAll).toHaveBeenCalledWith({
+        where: {
+          ...where,
+          parentUuid: { [Op.not]: null },
+          [Op.and]: [
+            Sequelize.literal(
+              '("updated_at", "uuid") > (:cursorUpdatedAt, :cursorId)',
+            ),
+          ],
+        },
+        replacements: { cursorUpdatedAt, cursorId },
+        order: [
+          ['updatedAt', 'ASC'],
+          ['uuid', 'ASC'],
+        ],
+        limit: 1001,
+        logging: expect.any(Function),
+      });
     });
   });
 });

--- a/src/modules/folder/folder.repository.spec.ts
+++ b/src/modules/folder/folder.repository.spec.ts
@@ -1702,7 +1702,6 @@ describe('SequelizeFolderRepository', () => {
           ['uuid', 'ASC'],
         ],
         limit: 1001,
-        logging: expect.any(Function),
       });
     });
   });

--- a/src/modules/folder/folder.repository.ts
+++ b/src/modules/folder/folder.repository.ts
@@ -31,6 +31,8 @@ import {
   FavoriteItemType,
   type FavoriteAttributes,
 } from '../favorite/favorite.domain';
+import { Time } from '../../lib/time';
+import { type FolderUpdatedAtIdCursorDto } from './utils/folder-cursor.util';
 
 function mapSnakeCaseToCamelCase(data) {
   const camelCasedObject = {};
@@ -113,6 +115,12 @@ interface FolderRepository {
     offset: number,
     order: Array<[keyof FolderModel, 'ASC' | 'DESC']>,
   ): Promise<Array<Folder> | []>;
+  findFoldersWithCursorWhereUpdatedAfter(params: {
+    where: Partial<FolderAttributes>;
+    updatedAfter: Date;
+    pageSize: number;
+    cursor?: FolderUpdatedAtIdCursorDto;
+  }): Promise<{ folders: Folder[]; hasMore: boolean }>;
   updateByFolderId(
     folderId: FolderAttributes['id'],
     update: Partial<Folder>,
@@ -946,6 +954,51 @@ export class SequelizeFolderRepository implements FolderRepository {
     });
 
     return folders.map((folder) => this.toDomain(folder));
+  }
+
+  async findFoldersWithCursorWhereUpdatedAfter({
+    where,
+    updatedAfter,
+    pageSize,
+    cursor,
+  }: {
+    where: Partial<FolderAttributes>;
+    updatedAfter: Date;
+    pageSize: number;
+    cursor?: FolderUpdatedAtIdCursorDto;
+  }): Promise<{ folders: Folder[]; hasMore: boolean }> {
+    const cursorUpdatedAt = cursor ? Time.now(cursor.updatedAt) : null;
+
+    const whereCondition: WhereOptions<FolderAttributes> = {
+      ...where,
+      parentUuid: { [Op.not]: null },
+      ...(cursor
+        ? {
+            [Op.and]: [
+              Sequelize.literal(
+                '("updated_at", "uuid") > (:cursorUpdatedAt, :cursorId)',
+              ),
+            ],
+          }
+        : { updatedAt: { [Op.gt]: updatedAfter } }),
+    };
+
+    const rows = await this.folderModel.findAll({
+      where: whereCondition,
+      replacements: cursor
+        ? { cursorUpdatedAt, cursorId: cursor.uuid }
+        : undefined,
+      order: [
+        ['updatedAt', 'ASC'],
+        ['uuid', 'ASC'],
+      ],
+      limit: pageSize + 1,
+    });
+
+    const hasMore = rows.length > pageSize;
+    const page = hasMore ? rows.slice(0, pageSize) : rows;
+
+    return { folders: page.map((f) => this.toDomain(f)), hasMore };
   }
 
   async findAllCursorInWorkspaceWhereUpdatedAfter(

--- a/src/modules/folder/folder.usecase.spec.ts
+++ b/src/modules/folder/folder.usecase.spec.ts
@@ -28,6 +28,7 @@ import { CalculateFolderSizeTimeoutException } from './exception/calculate-folde
 import { SharingService } from '../sharing/sharing.service';
 import { type UpdateFolderMetaDto } from './dto/update-folder-meta.dto';
 import { FileStatus } from '../file/file.domain';
+import { FolderStatus } from './folder.domain';
 import { SequelizeFileRepository } from '../file/file.repository';
 import { FavoriteUseCases } from '../favorite/favorite.usecase';
 import { FavoriteItemType } from '../favorite/favorite.domain';
@@ -182,10 +183,9 @@ describe('FolderUseCases', () => {
         [mockBackupFolder.uuid, mockFolder.uuid],
         FavoriteItemType.Folder,
       );
-      expect(favoriteUseCases.removeFavoritesInsideFolders).toHaveBeenCalledWith(
-        user,
-        [mockBackupFolder.uuid, mockFolder.uuid],
-      );
+      expect(
+        favoriteUseCases.removeFavoritesInsideFolders,
+      ).toHaveBeenCalledWith(user, [mockBackupFolder.uuid, mockFolder.uuid]);
     });
 
     it('When only ids are passed, then only folders by id should be searched', async () => {
@@ -2411,6 +2411,199 @@ describe('FolderUseCases', () => {
         uuidSort,
       );
       expect(result).toEqual(folders);
+    });
+  });
+
+  describe('getFoldersUpdatedAfterWithCursor', () => {
+    const userIdForSync = 1;
+    const updatedAfter = new Date();
+    const mockFolders = [newFolder(), newFolder()];
+
+    it('When status is provided, then it should filter the repository query by its deleted/removed mapping', async () => {
+      jest
+        .spyOn(folderRepository, 'findFoldersWithCursorWhereUpdatedAfter')
+        .mockResolvedValueOnce({ folders: mockFolders, hasMore: false });
+
+      await service.getFoldersUpdatedAfterWithCursor(
+        userIdForSync,
+        FolderStatus.EXISTS,
+        updatedAfter,
+        1000,
+        undefined,
+      );
+
+      expect(
+        folderRepository.findFoldersWithCursorWhereUpdatedAfter,
+      ).toHaveBeenCalledWith({
+        where: { userId: userIdForSync, deleted: false, removed: false },
+        updatedAfter,
+        pageSize: 1000,
+        cursor: undefined,
+      });
+    });
+
+    it('When status is not provided, then it should not filter the repository query by status', async () => {
+      jest
+        .spyOn(folderRepository, 'findFoldersWithCursorWhereUpdatedAfter')
+        .mockResolvedValueOnce({ folders: mockFolders, hasMore: false });
+
+      await service.getFoldersUpdatedAfterWithCursor(
+        userIdForSync,
+        undefined,
+        updatedAfter,
+        1000,
+        undefined,
+      );
+
+      expect(
+        folderRepository.findFoldersWithCursorWhereUpdatedAfter,
+      ).toHaveBeenCalledWith({
+        where: { userId: userIdForSync },
+        updatedAfter,
+        pageSize: 1000,
+        cursor: undefined,
+      });
+    });
+
+    it('When a valid cursorToken is provided, then it should decode it and pass it to the repository', async () => {
+      const cursorData = {
+        updatedAt: updatedAfter.toISOString(),
+        uuid: v4(),
+      };
+      const cursorToken = Buffer.from(JSON.stringify(cursorData)).toString(
+        'base64',
+      );
+
+      jest
+        .spyOn(folderRepository, 'findFoldersWithCursorWhereUpdatedAfter')
+        .mockResolvedValueOnce({ folders: mockFolders, hasMore: false });
+
+      await service.getFoldersUpdatedAfterWithCursor(
+        userIdForSync,
+        undefined,
+        updatedAfter,
+        1000,
+        cursorToken,
+      );
+
+      expect(
+        folderRepository.findFoldersWithCursorWhereUpdatedAfter,
+      ).toHaveBeenCalledWith(expect.objectContaining({ cursor: cursorData }));
+    });
+
+    it('When the cursor status does not match the requested status, then it should throw', async () => {
+      const cursorData = {
+        updatedAt: updatedAfter.toISOString(),
+        uuid: v4(),
+        status: FolderStatus.EXISTS,
+      };
+      const cursorToken = Buffer.from(JSON.stringify(cursorData)).toString(
+        'base64',
+      );
+
+      jest.spyOn(folderRepository, 'findFoldersWithCursorWhereUpdatedAfter');
+
+      await expect(
+        service.getFoldersUpdatedAfterWithCursor(
+          userIdForSync,
+          FolderStatus.TRASHED,
+          updatedAfter,
+          1000,
+          cursorToken,
+        ),
+      ).rejects.toThrow(BadRequestException);
+      expect(
+        folderRepository.findFoldersWithCursorWhereUpdatedAfter,
+      ).not.toHaveBeenCalled();
+    });
+
+    it('When an invalid cursorToken is provided, then it should throw', async () => {
+      jest.spyOn(folderRepository, 'findFoldersWithCursorWhereUpdatedAfter');
+
+      await expect(
+        service.getFoldersUpdatedAfterWithCursor(
+          userIdForSync,
+          undefined,
+          updatedAfter,
+          1000,
+          'not-a-valid-cursor',
+        ),
+      ).rejects.toThrow(BadRequestException);
+      expect(
+        folderRepository.findFoldersWithCursorWhereUpdatedAfter,
+      ).not.toHaveBeenCalled();
+    });
+
+    it('When hasMore is true, then it should return an encoded nextCursor built from the last folder', async () => {
+      const lastFolder = mockFolders[mockFolders.length - 1];
+      jest
+        .spyOn(folderRepository, 'findFoldersWithCursorWhereUpdatedAfter')
+        .mockResolvedValueOnce({ folders: mockFolders, hasMore: true });
+
+      const result = await service.getFoldersUpdatedAfterWithCursor(
+        userIdForSync,
+        undefined,
+        updatedAfter,
+        1000,
+        undefined,
+      );
+
+      expect(result.nextCursor).not.toBeNull();
+      const decoded = JSON.parse(
+        Buffer.from(result.nextCursor, 'base64').toString('utf-8'),
+      );
+      expect(decoded).toEqual({
+        updatedAt: lastFolder.updatedAt.toISOString(),
+        uuid: lastFolder.uuid,
+      });
+    });
+
+    it('When hasMore is false, then nextCursor should be null', async () => {
+      jest
+        .spyOn(folderRepository, 'findFoldersWithCursorWhereUpdatedAfter')
+        .mockResolvedValueOnce({ folders: mockFolders, hasMore: false });
+
+      const result = await service.getFoldersUpdatedAfterWithCursor(
+        userIdForSync,
+        undefined,
+        updatedAfter,
+        1000,
+        undefined,
+      );
+
+      expect(result.nextCursor).toBeNull();
+    });
+
+    it('When hasMore is true but there are no folders, then nextCursor should be null', async () => {
+      jest
+        .spyOn(folderRepository, 'findFoldersWithCursorWhereUpdatedAfter')
+        .mockResolvedValueOnce({ folders: [], hasMore: true });
+
+      const result = await service.getFoldersUpdatedAfterWithCursor(
+        userIdForSync,
+        undefined,
+        updatedAfter,
+        1000,
+        undefined,
+      );
+
+      expect(result.nextCursor).toBeNull();
+    });
+
+    it('When folders are returned, then it should return them as-is', async () => {
+      jest
+        .spyOn(folderRepository, 'findFoldersWithCursorWhereUpdatedAfter')
+        .mockResolvedValueOnce({ folders: mockFolders, hasMore: false });
+
+      const result = await service.getFoldersUpdatedAfterWithCursor(
+        userIdForSync,
+        undefined,
+        updatedAfter,
+        1000,
+        undefined,
+      );
+
+      expect(result.folders).toEqual(mockFolders);
     });
   });
 });

--- a/src/modules/folder/folder.usecase.ts
+++ b/src/modules/folder/folder.usecase.ts
@@ -17,6 +17,7 @@ import { type UserAttributes } from '../user/user.attributes';
 import { SequelizeUserRepository } from '../user/user.repository';
 import {
   Folder,
+  FolderStatus,
   type FolderOptions,
   type SortableFolderAttributes,
 } from './folder.domain';
@@ -36,6 +37,8 @@ import { type MoveFolderDto } from './dto/move-folder.dto';
 import { SequelizeFileRepository } from '../file/file.repository';
 import { FavoriteUseCases } from '../favorite/favorite.usecase';
 import { FavoriteItemType } from '../favorite/favorite.domain';
+import { encodeCursor, decodeCursor } from '../../common/utils/cursor.util';
+import { FolderSyncCursorDto } from './utils/folder-cursor.util';
 
 const invalidName = /[\\/]|^\s*$/;
 
@@ -691,6 +694,55 @@ export class FolderUseCases {
       options.offset,
       additionalOrders,
     );
+  }
+
+  async getFoldersUpdatedAfterWithCursor(
+    userId: UserAttributes['id'],
+    status: FolderStatus | undefined,
+    updatedAfter: Date,
+    pageSize: number,
+    cursorToken: string | undefined,
+  ): Promise<{
+    folders: Folder[];
+    hasMore: boolean;
+    nextCursor: string | null;
+  }> {
+    const cursor = cursorToken
+      ? decodeCursor(FolderSyncCursorDto, cursorToken)
+      : undefined;
+
+    if (cursorToken && !cursor) {
+      throw new BadRequestException('Invalid cursor');
+    }
+
+    if (cursor && cursor.status !== status) {
+      throw new BadRequestException('Cursor does not match status filter');
+    }
+
+    const filter: Partial<FolderAttributes> = {
+      userId,
+      ...(status ? Folder.getFilterByStatus(status) : {}),
+    };
+
+    const { folders, hasMore } =
+      await this.folderRepository.findFoldersWithCursorWhereUpdatedAfter({
+        where: filter,
+        updatedAfter,
+        pageSize,
+        cursor,
+      });
+
+    const lastFolder = folders.at(-1);
+    const nextCursor =
+      hasMore && lastFolder
+        ? encodeCursor({
+            updatedAt: lastFolder.updatedAt.toISOString(),
+            uuid: lastFolder.uuid,
+            status,
+          })
+        : null;
+
+    return { folders, hasMore, nextCursor };
   }
 
   getWorkspacesFoldersUpdatedAfter(

--- a/src/modules/folder/utils/folder-cursor.util.spec.ts
+++ b/src/modules/folder/utils/folder-cursor.util.spec.ts
@@ -1,0 +1,74 @@
+import { v4 } from 'uuid';
+import { decodeCursor, encodeCursor } from '../../../common/utils/cursor.util';
+import {
+  FolderUpdatedAtIdCursorDto,
+  FolderSyncCursorDto,
+} from './folder-cursor.util';
+import { FolderStatus } from '../folder.domain';
+
+describe('folder-cursor.util', () => {
+  describe('FolderUpdatedAtIdCursorDto', () => {
+    it('When a valid cursor is encoded and decoded, then it should return the original data', () => {
+      const cursor: FolderUpdatedAtIdCursorDto = {
+        updatedAt: new Date().toISOString(),
+        uuid: v4(),
+      };
+
+      const token = encodeCursor(cursor);
+      const decoded = decodeCursor(FolderUpdatedAtIdCursorDto, token);
+
+      expect(decoded).toEqual(cursor);
+    });
+
+    it('When the decoded JSON has an invalid uuid, then it should return null', () => {
+      const token = Buffer.from(
+        JSON.stringify({ updatedAt: new Date().toISOString(), uuid: 'nope' }),
+      ).toString('base64');
+
+      expect(decodeCursor(FolderUpdatedAtIdCursorDto, token)).toBeNull();
+    });
+
+    it('When the decoded JSON has an invalid updatedAt, then it should return null', () => {
+      const token = Buffer.from(
+        JSON.stringify({ updatedAt: 'not-a-date', uuid: v4() }),
+      ).toString('base64');
+
+      expect(decodeCursor(FolderUpdatedAtIdCursorDto, token)).toBeNull();
+    });
+  });
+
+  describe('FolderSyncCursorDto', () => {
+    it('When a valid sync cursor (with status) is encoded and decoded, then it should return the original data', () => {
+      const cursor: FolderSyncCursorDto = {
+        updatedAt: new Date().toISOString(),
+        uuid: v4(),
+        status: FolderStatus.EXISTS,
+      };
+
+      const token = encodeCursor(cursor);
+      const decoded = decodeCursor(FolderSyncCursorDto, token);
+
+      expect(decoded).toEqual(cursor);
+    });
+
+    it('When status is present but not a valid FolderStatus, then it should return null', () => {
+      const token = Buffer.from(
+        JSON.stringify({
+          updatedAt: new Date().toISOString(),
+          uuid: v4(),
+          status: 'not-a-status',
+        }),
+      ).toString('base64');
+
+      expect(decodeCursor(FolderSyncCursorDto, token)).toBeNull();
+    });
+
+    it('When status is omitted, then it should still decode successfully', () => {
+      const token = Buffer.from(
+        JSON.stringify({ updatedAt: new Date().toISOString(), uuid: v4() }),
+      ).toString('base64');
+
+      expect(decodeCursor(FolderSyncCursorDto, token)).not.toBeNull();
+    });
+  });
+});

--- a/src/modules/folder/utils/folder-cursor.util.ts
+++ b/src/modules/folder/utils/folder-cursor.util.ts
@@ -1,0 +1,16 @@
+import { IsISO8601, IsUUID, IsIn, IsOptional } from 'class-validator';
+import { FolderStatus } from '../folder.domain';
+
+export class FolderUpdatedAtIdCursorDto {
+  @IsISO8601()
+  updatedAt: string;
+
+  @IsUUID()
+  uuid: string;
+}
+
+export class FolderSyncCursorDto extends FolderUpdatedAtIdCursorDto {
+  @IsOptional()
+  @IsIn(Object.values(FolderStatus))
+  status?: FolderStatus;
+}


### PR DESCRIPTION
Adds cursor pagination ordering by updated_at for folders updated after a given date.

## Changes

* Added new EP to use keyset pagination for folders modified after a given date (used for sync flows), replacing the offset-based version.

## Benchmark

Using an user with 300K folders on prod.

Offset 5000, limit 1000.

```sql
Limit (cost=4091.85..4910.11 rows=1000 width=289) (actual time=338.322..453.542 rows=1000.00 loops=1)
Buffers: shared hit=160 read=1199
-> Index Scan using idx_folders_user_id_updated_at_parent_uuid_not_null on folders "FolderModel" (cost=0.57..196032.59 rows=239573 width=289) (actual time=2.306..453.095 rows=6000.00 loops=1)
Index Cond: ((user_id = 193541) AND (updated_at > '2025-05-01 00:00:00'::timestamp without time zone))
Index Searches: 1
Buffers: shared hit=160 read=1199
Planning Time: 0.212 ms
Execution Time: 453.639 ms
```

Cursor pagination (equivalent to offset 5000)

```sql
Limit (cost=1.98..1200.40 rows=1000 width=289) (actual time=36.614..114.920 rows=1000.00 loops=1)
Buffers: shared hit=31 read=343
-> Incremental Sort (cost=1.98..97950.13 rows=81731 width=289) (actual time=36.613..114.797 rows=1000.00 loops=1)
Sort Key: updated_at, uuid
Presorted Key: updated_at
Full-sort Groups: 10 Sort Method: quicksort Average Memory: 58kB Peak Memory: 58kB
Pre-sorted Groups: 11 Sort Method: quicksort Average Memory: 49kB Peak Memory: 51kB
Buffers: shared hit=31 read=343
-> Index Scan using idx_folders_user_id_updated_at_parent_uuid_not_null on folders "FolderModel" (cost=0.57..94769.87 rows=81731 width=289) (actual time=3.602..113.328 rows=1023.00 loops=1)
Index Cond: ((user_id = 193541) AND (updated_at > '2025-05-01 00:00:00'::timestamp without time zone) AND (updated_at >= '2026-03-14 18:16:38'::timestamp without time zone))
Filter: (ROW(updated_at, uuid) > ROW('2026-03-14 18:16:38'::timestamp without time zone, 'bc043e53-f456-4d20-b68c-a21f35fa35c6'::uuid))
Rows Removed by Filter: 78
Index Searches: 1
Buffers: shared hit=31 read=343
Planning Time: 0.237 ms
Execution Time: 115.021 ms
```